### PR TITLE
fix: use kebab case for task states

### DIFF
--- a/tests/mandatory/protocol/test_message_send_method.py
+++ b/tests/mandatory/protocol/test_message_send_method.py
@@ -113,7 +113,7 @@ def test_message_send_valid_text(sut_client, valid_text_message_params, agent_ca
     # According to A2A spec, message/send can return either Task or Message
     if "status" in result:
         # This is a Task object
-        assert result.get("status", {}).get("state") in {"submitted", "working", "input_required", "completed"}
+        assert result.get("status", {}).get("state") in {"submitted", "working", "input-required", "completed"}
     else:
         # This is a Message object - verify it has the expected structure
         assert result.get("kind") == "message"
@@ -178,7 +178,7 @@ def test_message_send_continue_task(sut_client, valid_text_message_params):
     if "status" in result:
         # This is a Task object
         assert result["id"] == task_id  # Should be the same task ID
-        assert result.get("status", {}).get("state") in {"submitted", "working", "input_required", "completed"}
+        assert result.get("status", {}).get("state") in {"submitted", "working", "input-required", "completed"}
     else:
         # This is a Message object - verify it has the expected structure
         assert result.get("kind") == "message"

--- a/tests/optional/capabilities/test_message_send_capabilities.py
+++ b/tests/optional/capabilities/test_message_send_capabilities.py
@@ -49,7 +49,7 @@ def test_message_send_valid_file_part(sut_client, valid_file_message_params, age
     assert message_utils.is_json_rpc_success_response(resp, expected_id=req["id"])
     result = resp["result"]
 
-    assert result.get("status", {}).get("state") in {"submitted", "working", "input_required", "completed"}
+    assert result.get("status", {}).get("state") in {"submitted", "working", "input-required", "completed"}
 
 @optional_capability
 def test_message_send_valid_multiple_parts(sut_client, valid_text_message_params, valid_file_message_params, agent_card_data):
@@ -87,7 +87,7 @@ def test_message_send_valid_multiple_parts(sut_client, valid_text_message_params
     assert message_utils.is_json_rpc_success_response(resp, expected_id=req["id"])
     result = resp["result"]
 
-    assert result.get("status", {}).get("state") in {"submitted", "working", "input_required", "completed"}
+    assert result.get("status", {}).get("state") in {"submitted", "working", "input-required", "completed"}
 
 @optional_capability
 def test_message_send_continue_with_contextid(sut_client, valid_text_message_params):
@@ -143,7 +143,7 @@ def test_message_send_continue_with_contextid(sut_client, valid_text_message_par
     assert message_utils.is_json_rpc_success_response(second_resp, expected_id=second_req["id"])
     result = second_resp["result"]
     assert result["id"] == task_id  # Should be the same task ID
-    assert result.get("status", {}).get("state") in {"submitted", "working", "input_required", "completed"}
+    assert result.get("status", {}).get("state") in {"submitted", "working", "input-required", "completed"}
 
 @optional_capability
 def test_message_send_valid_data_part(sut_client, valid_data_message_params, agent_card_data):
@@ -173,7 +173,7 @@ def test_message_send_valid_data_part(sut_client, valid_data_message_params, age
     assert message_utils.is_json_rpc_success_response(resp, expected_id=req["id"])
     result = resp["result"]
 
-    assert result.get("status", {}).get("state") in {"submitted", "working", "input_required", "completed"}
+    assert result.get("status", {}).get("state") in {"submitted", "working", "input-required", "completed"}
 
 @optional_capability
 def test_message_send_data_part_array(sut_client, agent_card_data):
@@ -222,4 +222,4 @@ def test_message_send_data_part_array(sut_client, agent_card_data):
     assert message_utils.is_json_rpc_success_response(resp, expected_id=req["id"])
     result = resp["result"]
 
-    assert result.get("status", {}).get("state") in {"submitted", "working", "input_required", "completed"} 
+    assert result.get("status", {}).get("state") in {"submitted", "working", "input-required", "completed"} 

--- a/tests/optional/quality/test_task_state_quality.py
+++ b/tests/optional/quality/test_task_state_quality.py
@@ -126,7 +126,7 @@ def test_task_state_transitions(sut_client, text_message_params, follow_up_messa
     
     # Verify the state transitions - simple check that it's in an expected state
     current_state = get_resp2["result"]["status"]["state"]
-    assert current_state in {"working", "input_required", "completed"}, f"Unexpected state: {current_state}"
+    assert current_state in {"working", "input-required", "completed"}, f"Unexpected state: {current_state}"
 
 @quality_basic
 def test_tasks_cancel_already_canceled(sut_client):


### PR DESCRIPTION
specifically `input-required` instead of `input_required` per [the spec](https://github.com/a2aproject/A2A/blob/ec1c9def3e9bc78c5f9ec2abb2543d4fb651834b/specification/json/a2a.json#L2212)

Fixes #32 🦕