### PR TITLE
fix: Remove test_message_send_continue_nonexistent_task and the corresponding handling from the python-sut agent executor implementation since it's not needed

### DIFF
--- a/python-sut/tck_core_agent/agent_executor.py
+++ b/python-sut/tck_core_agent/agent_executor.py
@@ -54,14 +54,6 @@ class TckCoreAgentExecutor(AgentExecutor):
         if not context.message:
             raise Exception('No message provided')
 
-        # Check if we're trying to continue a task that should exist but doesn't
-        # This happens when a taskId is provided that looks like it was previously created
-        # but is no longer available (e.g., "non-existent-task-id")
-        if context.message.taskId and not task and context.message.taskId.startswith(('non-existent', 'test-')):
-            # Only throw error for task IDs that look like they should have been created before
-            if 'non-existent' in context.message.taskId:
-                raise ServerError(TaskNotFoundError(message=f"Task with ID '{context.message.taskId}' not found"))
-
         # Create task if it doesn't exist (this handles both new tasks and tasks with provided IDs)
         if not task:
             task = new_task(context.message)

--- a/tests/mandatory/protocol/test_message_send_method.py
+++ b/tests/mandatory/protocol/test_message_send_method.py
@@ -185,32 +185,3 @@ def test_message_send_continue_task(sut_client, valid_text_message_params):
         assert result.get("role") == "agent"
         assert "parts" in result
 
-@mandatory_protocol
-def test_message_send_continue_nonexistent_task(sut_client):
-    """
-    MANDATORY: A2A Specification §5.1 - Task Not Found Error Handling
-    
-    The A2A specification requires proper error handling when attempting
-    to continue a non-existent task. MUST return TaskNotFoundError.
-    
-    Failure Impact: Implementation is not A2A compliant
-    """
-    continuation_params = {
-        "message": {
-            "kind": "message",
-            "taskId": "non-existent-task-id",
-            "messageId": "test-nonexistent-message-id-" + str(uuid.uuid4()),
-            "role": "user",
-            "parts": [
-                {
-                    "kind": "text",
-                    "text": "Message for a non-existent task"
-                }
-            ]
-        }
-    }
-    req = message_utils.make_json_rpc_request("message/send", params=continuation_params)
-    resp = sut_client.send_json_rpc(method=req["method"], params=req["params"], id=req["id"])
-    assert message_utils.is_json_rpc_error_response(resp, expected_id=req["id"])
-    # Error code might be implementation-specific, but should be an error
-


### PR DESCRIPTION
# Description

This PR removes some unnecessary handling for non-existent tasks from the Python SUT agent executor implementation and also removes an unnecessary test.

- [X] Follow the [`CONTRIBUTING` Guide](../CONTRIBUTING.md).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
    - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
        - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
        - `feat:` represents a new feature, and correlates to a SemVer minor.
        - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [X] Ensure the tests pass
- [X] Appropriate READMEs were updated (if necessary)

Fixes #31  🦕