### PR TITLE
fix: Fix import of `compliance_levels` in `generate_compliance_report.py` when imported from `run_tck.py`

### DIFF
--- a/util_scripts/generate_compliance_report.py
+++ b/util_scripts/generate_compliance_report.py
@@ -129,7 +129,11 @@ class ComplianceReportGenerator:
 
     def _determine_compliance_level(self, mandatory, capability, quality, feature) -> Dict:
         """Determine the overall compliance level."""
-        from compliance_levels import COMPLIANCE_LEVELS
+        # Handle imports for both standalone execution and module import.
+        if __package__:
+            from .compliance_levels import COMPLIANCE_LEVELS
+        else:
+            from compliance_levels import COMPLIANCE_LEVELS
 
         # Must pass all mandatory tests for any compliance
         if mandatory["success_rate"] < 100:


### PR DESCRIPTION
Running:
```
python ./run_tck.py --sut-url http://localhost:<port> --category all --verbose --compliance-report report.json
```
from project root outputs:
```
...
⚠️  Warning: Could not generate compliance report: No module named 'compliance_levels'
...
```
in the terminal.

This is because `generate_compliance_report.py` cannot resolve import from `compliance_levels` .
