### PR TITLE
fix: Message inside MessageSendParams should contain kind attribute

### DIFF
--- a/tck/transport/grpc_client.py
+++ b/tck/transport/grpc_client.py
@@ -723,6 +723,7 @@ class GRPCClient(BaseTransportClient):
                             "status": {
                                 "state": "TASK_STATE_WORKING",
                                 "message": {
+                                    "kind": "message",
                                     "message_id": f"sub-{task_id}-1",
                                     "role": "ROLE_AGENT",
                                     "content": [{"text": f"Subscribed to task {task_id} via gRPC"}],
@@ -737,6 +738,7 @@ class GRPCClient(BaseTransportClient):
                             "status": {
                                 "state": "TASK_STATE_COMPLETED",
                                 "message": {
+                                    "kind": "message",
                                     "message_id": f"sub-{task_id}-2",
                                     "role": "ROLE_AGENT",
                                     "content": [{"text": f"Task {task_id} completed via gRPC subscription"}],

--- a/tests/mandatory/protocol/test_a2a_v030_new_methods.py
+++ b/tests/mandatory/protocol/test_a2a_v030_new_methods.py
@@ -571,7 +571,7 @@ class TestTransportSpecificFeatures:
                     {
                         "method": "message/send",
                         "params": {
-                            "message": {"role": "user", "parts": [{"kind": "text", "text": "test"}], "messageId": "test-batch-1"}
+                            "message": {"kind": "message", "role": "user", "parts": [{"kind": "text", "text": "test"}], "messageId": "test-batch-1"}
                         },
                         "id": 2,
                     },

--- a/tests/optional/features/test_invalid_business_logic.py
+++ b/tests/optional/features/test_invalid_business_logic.py
@@ -35,6 +35,7 @@ def test_unsupported_part_kind(sut_client):
     # Create a message with an unsupported part type
     params = {
         "message": {
+            "kind": "message",
             "messageId": "test-unsupported-part-message-id-" + str(uuid.uuid4()),
             "role": "user",
             "parts": [
@@ -83,6 +84,7 @@ def test_invalid_file_part(sut_client):
     # Create a message with a file part containing an invalid URL
     params = {
         "message": {
+            "kind": "message",
             "messageId": "test-invalid-file-message-id-" + str(uuid.uuid4()),
             "role": "user",
             "parts": [
@@ -131,7 +133,7 @@ def test_empty_message_parts(sut_client):
         - Implementation correctly validates required message structure
     """
     # Create a message with empty parts array (violates A2A MUST requirement)
-    params = {"message": {"messageId": "test-empty-parts-message-id-" + str(uuid.uuid4()), "role": "user", "parts": []}}
+    params = {"message": {"kind": "message", "messageId": "test-empty-parts-message-id-" + str(uuid.uuid4()), "role": "user", "parts": []}}
 
     # Replace with transport helper
     resp = transport_helpers.transport_send_message(sut_client, params)
@@ -173,6 +175,7 @@ def test_very_large_message(sut_client):
     large_text = "A" * 100000  # 100KB of text
     params = {
         "message": {
+            "kind": "message",
             "messageId": "test-large-message-id-" + str(uuid.uuid4()),
             "role": "user",
             "parts": [{"kind": "text", "text": large_text}],
@@ -214,6 +217,7 @@ def test_missing_required_message_fields(sut_client):
     # Test 1: Missing messageId (MUST requirement violation)
     params_no_message_id = {
         "message": {
+            "kind": "message",
             # messageId is missing - violates A2A MUST requirement
             "role": "user",
             "parts": [{"kind": "text", "text": "Message without messageId"}],
@@ -233,6 +237,7 @@ def test_missing_required_message_fields(sut_client):
     # Test 2: Missing role (MUST requirement violation)
     params_no_role = {
         "message": {
+            "kind": "message",
             "messageId": "test-no-role-message-id-" + str(uuid.uuid4()),
             # role is missing - violates A2A MUST requirement
             "parts": [{"kind": "text", "text": "Message without role"}],
@@ -252,6 +257,7 @@ def test_missing_required_message_fields(sut_client):
     # Test 3: Missing parts (MUST requirement violation)
     params_no_parts = {
         "message": {
+            "kind": "message",
             "messageId": "test-no-parts-message-id-" + str(uuid.uuid4()),
             "role": "user",
             # parts is missing - violates A2A MUST requirement
@@ -289,6 +295,7 @@ def test_file_part_without_mimetype(sut_client):
     # Create a message with a file part missing the RECOMMENDED mimeType field
     params = {
         "message": {
+            "kind": "message",
             "messageId": "test-no-mimetype-message-id-" + str(uuid.uuid4()),
             "role": "user",
             "parts": [

--- a/tests/optional/features/test_reference_task_ids.py
+++ b/tests/optional/features/test_reference_task_ids.py
@@ -11,7 +11,7 @@ from tests.utils import transport_helpers
 @pytest.fixture
 def text_message_params():
     """Create a basic text message params object"""
-    return {"message": {"parts": [{"kind": "text", "text": "Hello from reference task ID test!"}]}}
+    return {"message": {"kind": "message", "parts": [{"kind": "text", "text": "Hello from reference task ID test!"}]}}
 
 
 @optional_feature
@@ -44,6 +44,7 @@ def test_reference_task_ids_valid(sut_client, text_message_params):
     # Step 2: Create a new task with reference to the first task
     params_with_reference = {
         "message": {
+            "kind": "message",
             "parts": [{"kind": "text", "text": "This message references another task"}],
             "referenceTaskIds": [reference_task_id],
         }
@@ -82,6 +83,7 @@ def test_reference_task_ids_invalid(sut_client):
     # Create a message with an invalid/non-existent reference task ID
     params = {
         "message": {
+            "kind": "message",
             "parts": [{"kind": "text", "text": "This message references a non-existent task"}],
             "referenceTaskIds": ["non-existent-task-id"],
         }

--- a/tests/optional/features/test_sdk_limitations.py
+++ b/tests/optional/features/test_sdk_limitations.py
@@ -22,6 +22,7 @@ def text_message_params():
     """Create a basic text message params object"""
     return {
         "message": {
+            "kind": "message",
             "messageId": "test-sdk-message-id-" + str(uuid.uuid4()),
             "role": "user",
             "parts": [{"kind": "text", "text": "Test message for SDK limitation tests"}],
@@ -60,6 +61,7 @@ def test_history_length_parameter_compliance(sut_client, text_message_params):
     for i in range(5):
         follow_up_params = {
             "message": {
+                "kind": "message",
                 "taskId": task_id,
                 "messageId": f"sdk-test-msg-{i + 1}-" + str(uuid.uuid4()),
                 "role": "user",

--- a/tests/optional/quality/test_resilience.py
+++ b/tests/optional/quality/test_resilience.py
@@ -24,6 +24,7 @@ def text_message_params():
     """Create a basic text message params object"""
     return {
         "message": {
+            "kind": "message",
             "messageId": "test-resilience-message-id-" + str(uuid.uuid4()),
             "role": "user",
             "parts": [{"kind": "text", "text": "Hello from resilience test!"}],
@@ -216,6 +217,7 @@ def test_partial_update_recovery(sut_client, text_message_params):
     for i, text in enumerate(update_texts):
         params = {
             "message": {
+                "kind": "message",
                 "messageId": "test-update-message-id-" + str(uuid.uuid4()),
                 "role": "user",
                 "taskId": task_id,

--- a/tests/unit/adapters/test_base_adapter.py
+++ b/tests/unit/adapters/test_base_adapter.py
@@ -411,7 +411,7 @@ class TestBaseTransportAdapter:
             {
                 "name": "basic_message",
                 "type": "send_message",
-                "message": {"content": "Test message", "type": "text"},
+                "message": {"kind": "message", "content": "Test message", "type": "text"},
                 "spec_reference": "A2A v0.3.0 §7.1",
             },
             {"name": "task_retrieval", "type": "get_task", "task_id": "test-task-789"},

--- a/tests/unit/adapters/test_jsonrpc_adapter.py
+++ b/tests/unit/adapters/test_jsonrpc_adapter.py
@@ -270,7 +270,7 @@ class TestJSONRPCTestAdapter:
     def test_legacy_send_json_rpc(self, adapter, test_context):
         """Test legacy send_json_rpc method."""
         result = adapter.test_legacy_send_json_rpc(
-            test_context, "message/send", {"message": {"content": "Legacy test"}}, "legacy-id-123"
+            test_context, "message/send", {"message": {"kind": "message", "content": "Legacy test"}}, "legacy-id-123"
         )
 
         assert result.outcome == TestOutcome.PASS

--- a/tests/unit/transport/test_rest_client.py
+++ b/tests/unit/transport/test_rest_client.py
@@ -194,6 +194,7 @@ class TestRESTClientSendMessage:
                 "status": {
                     "state": "TASK_STATE_SUBMITTED",
                     "message": {
+                        "kind": "message",
                         "message_id": "response-123",
                         "role": "ROLE_AGENT",
                         "content": [{"text": "Message received via REST"}],
@@ -491,6 +492,7 @@ class TestRESTClientTaskOperations:
             "status": {
                 "state": "TASK_STATE_COMPLETED",
                 "message": {
+                    "kind": "message",
                     "message_id": "status-123",
                     "role": "ROLE_AGENT",
                     "content": [{"text": "Task 123 retrieved via REST"}],
@@ -545,6 +547,7 @@ class TestRESTClientTaskOperations:
             "status": {
                 "state": "TASK_STATE_CANCELLED",
                 "message": {
+                    "kind": "message",
                     "message_id": "cancel-456",
                     "role": "ROLE_AGENT",
                     "content": [{"text": "Task 456 cancelled via REST"}],


### PR DESCRIPTION
My understanding [of the specification](https://a2a-protocol.org/dev/specification/#711-messagesendparams-object) is that `MessageSendParams` object should contain `kind` attribute in its `Message` object and implementations should return error response when `kind` is missing. `a2a-dotnet` currently behaves like that.

This PR fixes `a2a-tck` compatibility with `a2a-dotnet` by adding `kind` attributes to `Message` objects in `MessageSendParams`.