### PR TITLE
fix: Remove usage of non-existent agent/card method

### DIFF
--- a/tck/transport/jsonrpc_client.py
+++ b/tck/transport/jsonrpc_client.py
@@ -503,7 +503,7 @@ class JSONRPCClient(BaseTransportClient):
         """
         try:
             response = self._make_jsonrpc_request(
-                method="agent/authenticatedExtendedCard", params={}, extra_headers=extra_headers
+                method="agent/getAuthenticatedExtendedCard", params={}, extra_headers=extra_headers
             )
             return response.get("result", {})
 

--- a/tck/transport/jsonrpc_client.py
+++ b/tck/transport/jsonrpc_client.py
@@ -329,7 +329,7 @@ class JSONRPCClient(BaseTransportClient):
 
     def get_agent_card(self, extra_headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
         """
-        Get agent card using agent/card method.
+        Get agent card using agent/getAuthenticatedExtendedCard method.
 
         Makes a real JSON-RPC call to get the agent card information.
 
@@ -345,7 +345,7 @@ class JSONRPCClient(BaseTransportClient):
         Specification Reference: A2A Protocol v0.3.0 §5.5 - Agent Card Retrieval
         """
         try:
-            response = self._make_jsonrpc_request(method="agent/card", params={}, extra_headers=extra_headers)
+            response = self._make_jsonrpc_request(method="agent/getAuthenticatedExtendedCard", params={}, extra_headers=extra_headers)
             return response.get("result", {})
 
         except Exception as e:

--- a/tests/mandatory/protocol/test_a2a_v030_new_methods.py
+++ b/tests/mandatory/protocol/test_a2a_v030_new_methods.py
@@ -2,7 +2,7 @@
 A2A v0.3.0 New Methods Testing
 
 Tests for new methods introduced in A2A v0.3.0 specification:
-- agent/authenticatedExtendedCard (§7.10)
+- agent/getAuthenticatedExtendedCard (§7.10)
 - tasks/list (§7.3.1 - gRPC/REST only)
 - Method mapping compliance across transports (§3.5.6)
 - Transport-specific features validation
@@ -11,7 +11,7 @@ These tests validate that SUTs correctly implement the new v0.3.0 methods
 with proper authentication, transport mapping, and functional compliance.
 
 References:
-- A2A v0.3.0 Specification §7.10: agent/authenticatedExtendedCard
+- A2A v0.3.0 Specification §7.10: agent/getAuthenticatedExtendedCard
 - A2A v0.3.0 Specification §7.3.1: tasks/list
 - A2A v0.3.0 Specification §3.5.6: Method Mapping Reference Table
 - A2A v0.3.0 Specification §3.2: Transport Protocol Requirements
@@ -38,7 +38,7 @@ from tests.utils.transport_helpers import (
 
 class TestAuthenticatedExtendedCard:
     """
-    Test suite for agent/authenticatedExtendedCard method (§7.10)
+    Test suite for agent/getAuthenticatedExtendedCard method (§7.10)
 
     Validates that SUTs correctly implement authenticated agent card retrieval
     with proper authentication requirements and extended card functionality.
@@ -49,7 +49,7 @@ class TestAuthenticatedExtendedCard:
     @pytest.mark.a2a_v030
     def test_authenticated_extended_card_method_exists(self, sut_client: BaseTransportClient, agent_card_data):
         """
-        Test that agent/authenticatedExtendedCard method exists and is callable.
+        Test that agent/getAuthenticatedExtendedCard method exists and is callable.
 
         A2A v0.3.0 Specification Reference: §7.10
         Transport Support: All transports (JSON-RPC, gRPC, REST)
@@ -107,7 +107,7 @@ class TestAuthenticatedExtendedCard:
     @pytest.mark.a2a_v030
     def test_authenticated_extended_card_without_auth(self, sut_client: BaseTransportClient, agent_card_data):
         """
-        Test that agent/authenticatedExtendedCard properly rejects unauthenticated requests.
+        Test that agent/getAuthenticatedExtendedCard properly rejects unauthenticated requests.
 
         A2A v0.3.0 Specification Reference: §7.10
 
@@ -163,7 +163,7 @@ class TestAuthenticatedExtendedCard:
     @a2a_v030
     def test_authenticated_extended_card_with_auth(self, sut_client: BaseTransportClient, agent_card_data):
         """
-        Test that agent/authenticatedExtendedCard returns extended card with valid auth.
+        Test that agent/getAuthenticatedExtendedCard returns extended card with valid auth.
 
         A2A v0.3.0 Specification Reference: §7.10 & §11.1.3
 

--- a/tests/mandatory/protocol/test_a2a_v030_new_methods.py
+++ b/tests/mandatory/protocol/test_a2a_v030_new_methods.py
@@ -47,7 +47,7 @@ class TestAuthenticatedExtendedCard:
     @pytest.mark.mandatory
     @pytest.mark.mandatory_protocol
     @pytest.mark.a2a_v030
-    def test_authenticated_extended_card_method_exists(self, sut_client: BaseTransportClient):
+    def test_authenticated_extended_card_method_exists(self, sut_client: BaseTransportClient, agent_card_data):
         """
         Test that agent/authenticatedExtendedCard method exists and is callable.
 
@@ -60,12 +60,8 @@ class TestAuthenticatedExtendedCard:
         - Authentication is properly enforced
         """
         # Check if agent card supports authenticated extended card
-        try:
-            agent_card = sut_client.get_agent_card()
-            if not agent_card.get("supportsAuthenticatedExtendedCard", False):
-                pytest.skip("SUT does not support authenticated extended card")
-        except Exception as e:
-            pytest.skip(f"Could not retrieve agent card: {e}")
+        if not agent_card_data.get("supportsAuthenticatedExtendedCard", False):
+            pytest.skip("SUT does not support authenticated extended card")
 
         # Test method existence based on transport type
         transport_type = get_client_transport_type(sut_client)
@@ -109,7 +105,7 @@ class TestAuthenticatedExtendedCard:
     @pytest.mark.mandatory
     @pytest.mark.mandatory_protocol
     @pytest.mark.a2a_v030
-    def test_authenticated_extended_card_without_auth(self, sut_client: BaseTransportClient):
+    def test_authenticated_extended_card_without_auth(self, sut_client: BaseTransportClient, agent_card_data):
         """
         Test that agent/authenticatedExtendedCard properly rejects unauthenticated requests.
 
@@ -121,12 +117,8 @@ class TestAuthenticatedExtendedCard:
         - Error response follows A2A error format
         """
         # Check if SUT supports authenticated extended card
-        try:
-            agent_card = sut_client.get_agent_card()
-            if not agent_card.get("supportsAuthenticatedExtendedCard", False):
-                pytest.skip("SUT does not support authenticated extended card")
-        except Exception:
-            pytest.skip("Could not retrieve agent card")
+        if not agent_card_data.get("supportsAuthenticatedExtendedCard", False):
+            pytest.skip("SUT does not support authenticated extended card")
 
         # Test without authentication credentials
         transport_type = get_client_transport_type(sut_client)
@@ -169,7 +161,7 @@ class TestAuthenticatedExtendedCard:
 
     @optional_capability
     @a2a_v030
-    def test_authenticated_extended_card_with_auth(self, sut_client: BaseTransportClient):
+    def test_authenticated_extended_card_with_auth(self, sut_client: BaseTransportClient, agent_card_data):
         """
         Test that agent/authenticatedExtendedCard returns extended card with valid auth.
 
@@ -185,12 +177,8 @@ class TestAuthenticatedExtendedCard:
         where agents claim to support authenticated extended cards but don't implement them properly.
         """
         # Check if SUT supports authenticated extended card
-        try:
-            agent_card = sut_client.get_agent_card()
-            if not agent_card.get("supportsAuthenticatedExtendedCard", False):
-                pytest.skip("SUT does not support authenticated extended card")
-        except Exception:
-            pytest.skip("Could not retrieve agent card")
+        if not agent_card_data.get("supportsAuthenticatedExtendedCard", False):
+            pytest.skip("SUT does not support authenticated extended card")
 
         # Skip if no authentication is configured
         if not hasattr(sut_client, "headers") or not any(

--- a/tests/mandatory/protocol/test_extended_agent_card.py
+++ b/tests/mandatory/protocol/test_extended_agent_card.py
@@ -2,15 +2,16 @@
 A2A v0.3.0 Protocol: Mandatory Extended Agent Card Tests
 
 SPECIFICATION REQUIREMENTS (Section 7.10):
-- agent/authenticatedExtendedCard endpoint MUST be available when declared
+- agent/getAuthenticatedExtendedCard JSON-RPC method, or GetAgentCard gRPC
+  method or v1/card JSON+HTTP endpoint MUST be available when declared
 - Client MUST authenticate using declared security schemes
 - Server SHOULD include WWW-Authenticate header on 401 responses
 - Clients SHOULD replace cached Agent Card with extended card content
 
-These tests verify the mandatory agent/authenticatedExtendedCard method
+These tests verify the mandatory agent/getAuthenticatedExtendedCard method
 when supportsAuthenticatedExtendedCard is declared in the Agent Card.
 
-Reference: A2A v0.3.0 Specification Section 7.10 (agent/authenticatedExtendedCard)
+Reference: A2A v0.3.0 Specification Section 7.10 (agent/getAuthenticatedExtendedCard)
 """
 
 import logging
@@ -59,19 +60,11 @@ def get_extended_card_url(base_url: str) -> str:
     """
     Construct the extended Agent Card URL according to A2A v0.3.0 specification.
 
-    Per Section 7.10: The endpoint URL is {AgentCard.url}/../agent/authenticatedExtendedCard
+    Per Section 7.10: The endpoint URL is {AgentCard.url}/v1/card
     relative to the base URL specified in the public Agent Card.
     """
     parsed = urllib.parse.urlparse(base_url)
-
-    # Remove the path and add the extended card path
-    base_path = parsed.path.rstrip("/")
-    if base_path:
-        # Go up one directory from the base path, then add the extended card path
-        parent_path = "/".join(base_path.split("/")[:-1])
-        extended_path = f"{parent_path}/agent/authenticatedExtendedCard"
-    else:
-        extended_path = "/agent/authenticatedExtendedCard"
+    extended_path = f"{parsed.path}/v1/card"
 
     # Reconstruct the URL
     extended_url = urllib.parse.urlunparse(
@@ -94,7 +87,7 @@ def test_extended_agent_card_endpoint_exists(extended_card_agent_card):
     MANDATORY: A2A v0.3.0 Section 7.10 - Extended Agent Card Endpoint Availability
 
     When supportsAuthenticatedExtendedCard is declared as true, the agent MUST
-    implement the agent/authenticatedExtendedCard endpoint.
+    implement the agent/getAuthenticatedExtendedCard endpoint.
 
     This endpoint is an HTTP GET endpoint (not JSON-RPC) that returns a more
     detailed Agent Card after authentication.

--- a/tests/mandatory/security/test_agent_card_security.py
+++ b/tests/mandatory/security/test_agent_card_security.py
@@ -65,19 +65,11 @@ def get_extended_card_url(base_url: str) -> str:
     """
     Construct the extended Agent Card URL according to A2A v0.3.0 specification.
 
-    Per Section 9.1: The endpoint URL is {AgentCard.url}/../agent/authenticatedExtendedCard
+    Per Section 9.1: The endpoint URL is {AgentCard.url}/v1/card
     relative to the base URL specified in the public Agent Card.
     """
     parsed = urllib.parse.urlparse(base_url)
-
-    # Remove the path and add the extended card path
-    base_path = parsed.path.rstrip("/")
-    if base_path:
-        # Go up one directory from the base path, then add the extended card path
-        parent_path = "/".join(base_path.split("/")[:-1])
-        extended_path = f"{parent_path}/agent/authenticatedExtendedCard"
-    else:
-        extended_path = "/agent/authenticatedExtendedCard"
+    extended_path = f"{parsed.path}/v1/card"
 
     # Reconstruct the URL
     extended_url = urllib.parse.urlunparse(

--- a/tests/unit/adapters/test_jsonrpc_adapter.py
+++ b/tests/unit/adapters/test_jsonrpc_adapter.py
@@ -55,7 +55,7 @@ class MockJSONRPCClient(JSONRPCClient):
         elif method == "tasks/cancel":
             task_id = params.get("taskId", "unknown-task")
             return {"jsonrpc": "2.0", "result": {"taskId": task_id, "state": "cancelled"}, "id": request_id or "test-id"}
-        elif method == "agent/card":
+        elif method == "agent/getAuthenticatedExtendedCard":
             return {
                 "jsonrpc": "2.0",
                 "result": {"protocol_version": "0.3.0", "name": "Test JSON-RPC Agent", "endpoint": "https://example.com/jsonrpc"},
@@ -89,7 +89,7 @@ class MockJSONRPCClient(JSONRPCClient):
 
     def get_agent_card(self, extra_headers=None):
         self.call_log.append(("get_agent_card", extra_headers))
-        response = self._make_jsonrpc_request("agent/card", {}, extra_headers=extra_headers)
+        response = self._make_jsonrpc_request("agent/getAuthenticatedExtendedCard", {}, extra_headers=extra_headers)
         return response["result"]
 
     def send_json_rpc(self, method=None, params=None, id=None, extra_headers=None, **kwargs):

--- a/tests/utils/transport_helpers.py
+++ b/tests/utils/transport_helpers.py
@@ -195,8 +195,8 @@ def transport_get_agent_card(client: BaseTransportClient, extra_headers: Optiona
 
     # Fallback to legacy JSON-RPC pattern
     elif hasattr(client, "send_json_rpc"):
-        logger.debug("Using legacy send_json_rpc for agent/authenticatedExtendedCard")
-        req = message_utils.make_json_rpc_request("agent/authenticatedExtendedCard", params={})
+        logger.debug("Using legacy send_json_rpc for agent/getAuthenticatedExtendedCard")
+        req = message_utils.make_json_rpc_request("agent/getAuthenticatedExtendedCard", params={})
         return client.send_json_rpc(method=req["method"], params=req["params"], id=req["id"])
 
     else:

--- a/tests/validators/a2a_v030_compliance.py
+++ b/tests/validators/a2a_v030_compliance.py
@@ -98,7 +98,7 @@ class TransportComplianceValidator:
                 "send_message",  # message/send
                 "get_task",  # tasks/get
                 "cancel_task",  # tasks/cancel
-                "get_agent_card",  # agent/authenticatedExtendedCard
+                "get_agent_card",  # agent/getAuthenticatedExtendedCard
             ],
             "optional_methods": [
                 "send_streaming_message",  # message/stream
@@ -240,7 +240,7 @@ class MethodMappingValidator:
             "description": "Resume task streaming",
         },
         "get_agent_card": {
-            "jsonrpc": "agent/authenticatedExtendedCard",
+            "jsonrpc": "agent/getAuthenticatedExtendedCard",
             "grpc": "GetAgentCard",
             "rest": "GET /v1/card",
             "description": "Get authenticated agent card",


### PR DESCRIPTION
This PR replaces occurrences of `agent/card` method invocation which does not exist in the specification with `agent/getAuthenticatedExtendedCard` that does. Furthermore for tests in `tests/mandatory/protocol/test_a2a_v030_new_methods.py` it replaces call to `sut_client.get_agent_card()` with usage of `agent_card_data` fixture. The result of this call was used to detect if agent supports the authenticated card which is incorrect.

Fixes #61