### PR TITLE
fix: Fix tests failing on missing `send_json_rpc` method

### DIFF
--- a/tests/unit/adapters/test_jsonrpc_adapter.py
+++ b/tests/unit/adapters/test_jsonrpc_adapter.py
@@ -92,10 +92,6 @@ class MockJSONRPCClient(JSONRPCClient):
         response = self._make_jsonrpc_request("agent/card", {}, extra_headers=extra_headers)
         return response["result"]
 
-    def send_json_rpc(self, method=None, params=None, id=None, extra_headers=None, **kwargs):
-        self.call_log.append(("send_json_rpc", method, params, id, extra_headers, kwargs))
-        return self._make_jsonrpc_request(method, params, id, extra_headers)
-
     # Implement remaining abstract methods with minimal functionality
     def resubscribe_task(self, task_id: str, extra_headers=None):
         return iter([{"taskId": task_id, "state": "in-progress"}])
@@ -266,21 +262,6 @@ class TestJSONRPCTestAdapter:
         assert call[0] == "_make_jsonrpc_request"
         assert call[1] == "custom/method"
         assert call[2] == {"param1": "value1"}
-
-    def test_legacy_send_json_rpc(self, adapter, test_context):
-        """Test legacy send_json_rpc method."""
-        result = adapter.test_legacy_send_json_rpc(
-            test_context, "message/send", {"message": {"content": "Legacy test"}}, "legacy-id-123"
-        )
-
-        assert result.outcome == TestOutcome.PASS
-        assert result.duration_ms is not None
-
-        # Verify legacy method was called
-        call = adapter.jsonrpc_client.call_log[0]
-        assert call[0] == "send_json_rpc"
-        assert call[1] == "message/send"
-        assert call[3] == "legacy-id-123"  # request ID
 
     def test_jsonrpc_task_response_validation(self, adapter, test_context):
         """Test JSON-RPC specific task response validation."""

--- a/tests/unit/transport/test_jsonrpc_client.py
+++ b/tests/unit/transport/test_jsonrpc_client.py
@@ -194,26 +194,6 @@ class TestJSONRPCClient:
         # Verify result extraction
         assert result == {"taskId": "task-123", "status": "cancelled"}
 
-    @patch("requests.Session.post")
-    def test_legacy_send_json_rpc_compatibility(self, mock_post):
-        """Test backward compatibility with legacy send_json_rpc method."""
-        # Mock successful response
-        mock_response = Mock()
-        mock_response.status_code = 200
-        mock_response.text = '{"jsonrpc": "2.0", "result": {"success": true}, "id": "test-id"}'
-        mock_response.json.return_value = {"jsonrpc": "2.0", "result": {"success": True}, "id": "test-id"}
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
-
-        # Test legacy interface
-        result = self.client.send_json_rpc(method="test/method", params={"param": "value"}, id="test-id")
-
-        # Verify request structure matches legacy expectations
-        call_args = mock_post.call_args
-        assert call_args[1]["json"]["method"] == "test/method"
-        assert call_args[1]["json"]["params"] == {"param": "value"}
-        assert call_args[1]["json"]["id"] == "test-id"
-
     def test_context_manager(self):
         """Test using client as context manager."""
         with JSONRPCClient("https://example.com/jsonrpc") as client:

--- a/tests/unit/transport/test_transport_integration.py
+++ b/tests/unit/transport/test_transport_integration.py
@@ -203,7 +203,7 @@ class TestTransportIntegration:
 
         # Test JSON-RPC client specific features
         jsonrpc_client = all_clients[TransportType.JSON_RPC]
-        assert hasattr(jsonrpc_client, "send_json_rpc")  # Legacy method
+        assert not hasattr(jsonrpc_client, "send_json_rpc")  # Legacy method was removed
         assert not jsonrpc_client.supports_method("list_tasks")  # Not supported in JSON-RPC
 
         # Test gRPC client specific features

--- a/tests/utils/transport_helpers.py
+++ b/tests/utils/transport_helpers.py
@@ -55,12 +55,6 @@ def transport_send_message(
                 return {"error": e.json_rpc_error}
             return {"error": {"code": -32603, "message": str(e)}}
 
-    # Fallback to legacy JSON-RPC pattern for backward compatibility
-    elif hasattr(client, "send_json_rpc"):
-        logger.debug("Using legacy send_json_rpc for backward compatibility")
-        req = message_utils.make_json_rpc_request("message/send", params=message_params)
-        return client.send_json_rpc(method=req["method"], params=req["params"], id=req["id"])
-
     else:
         raise ValueError(f"Client {type(client)} does not support message sending")
 
@@ -103,16 +97,6 @@ def transport_get_task(
                 return {"error": e.json_rpc_error}
             return {"error": {"code": -32603, "message": str(e)}}
 
-    # Fallback to legacy JSON-RPC pattern
-    elif hasattr(client, "send_json_rpc"):
-        logger.debug("Using legacy send_json_rpc for tasks/get")
-        params = {"id": task_id}
-        if history_length is not None:
-            params["historyLength"] = history_length
-
-        req = message_utils.make_json_rpc_request("tasks/get", params=params)
-        return client.send_json_rpc(method=req["method"], params=req["params"], id=req["id"])
-
     else:
         raise ValueError(f"Client {type(client)} does not support task retrieval")
 
@@ -151,13 +135,6 @@ def transport_cancel_task(
                 return {"error": e.json_rpc_error}
             return {"error": {"code": -32603, "message": str(e)}}
 
-    # Fallback to legacy JSON-RPC pattern
-    elif hasattr(client, "send_json_rpc"):
-        logger.debug("Using legacy send_json_rpc for tasks/cancel")
-        params = {"id": task_id}
-        req = message_utils.make_json_rpc_request("tasks/cancel", params=params)
-        return client.send_json_rpc(method=req["method"], params=req["params"], id=req["id"])
-
     else:
         raise ValueError(f"Client {type(client)} does not support task cancellation")
 
@@ -192,12 +169,6 @@ def transport_get_agent_card(client: BaseTransportClient, extra_headers: Optiona
             elif hasattr(e, "json_rpc_error") and e.json_rpc_error:
                 return {"error": e.json_rpc_error}
             return {"error": {"code": -32603, "message": str(e)}}
-
-    # Fallback to legacy JSON-RPC pattern
-    elif hasattr(client, "send_json_rpc"):
-        logger.debug("Using legacy send_json_rpc for agent/authenticatedExtendedCard")
-        req = message_utils.make_json_rpc_request("agent/authenticatedExtendedCard", params={})
-        return client.send_json_rpc(method=req["method"], params=req["params"], id=req["id"])
 
     else:
         raise ValueError(f"Client {type(client)} does not support agent card retrieval")
@@ -441,11 +412,6 @@ def transport_send_json_rpc_request(
                 return {"error": e.json_rpc_error, "id": req.get("id")}
             raise
 
-    # Fallback to legacy JSON-RPC pattern for backward compatibility
-    elif hasattr(client, "send_json_rpc"):
-        logger.debug(f"Using legacy send_json_rpc for method {method}")
-        return client.send_json_rpc(method=req["method"], params=req.get("params"), id=req.get("id"))
-
     # Fallback for other transport implementations
     else:
         raise ValueError(f"Client {type(client)} does not support arbitrary JSON-RPC requests")
@@ -486,12 +452,6 @@ def transport_set_push_notification_config(
                 return {"error": e.json_rpc_error}
             return {"error": {"code": -32603, "message": str(e)}}
 
-    # Fallback to JSON-RPC pattern for backward compatibility
-    elif hasattr(client, "send_json_rpc"):
-        logger.debug("Using legacy send_json_rpc for push notification config")
-        params = {"taskId": task_id, "pushNotificationConfig": config}
-        return transport_send_json_rpc_request(client, "tasks/pushNotificationConfig/set", params)
-
     else:
         raise ValueError(f"Client {type(client)} does not support push notification configuration")
 
@@ -531,12 +491,6 @@ def transport_get_push_notification_config(
                 return {"error": e.json_rpc_error}
             return {"error": {"code": -32603, "message": str(e)}}
 
-    # Fallback to JSON-RPC pattern for backward compatibility
-    elif hasattr(client, "send_json_rpc"):
-        logger.debug("Using legacy send_json_rpc for push notification config")
-        params = {"id": task_id, "configId": config_id}
-        return transport_send_json_rpc_request(client, "tasks/pushNotificationConfig/get", params)
-
     else:
         raise ValueError(f"Client {type(client)} does not support push notification configuration")
 
@@ -574,12 +528,6 @@ def transport_list_push_notification_configs(
             elif hasattr(e, "json_rpc_error") and e.json_rpc_error:
                 return {"error": e.json_rpc_error}
             return {"error": {"code": -32603, "message": str(e)}}
-
-    # Fallback to JSON-RPC pattern for backward compatibility
-    elif hasattr(client, "send_json_rpc"):
-        logger.debug("Using legacy send_json_rpc for push notification config list")
-        params = {"id": task_id}
-        return transport_send_json_rpc_request(client, "tasks/pushNotificationConfig/list", params)
 
     else:
         raise ValueError(f"Client {type(client)} does not support push notification configuration")
@@ -619,12 +567,6 @@ def transport_delete_push_notification_config(
             elif hasattr(e, "json_rpc_error") and e.json_rpc_error:
                 return {"error": e.json_rpc_error}
             return {"error": {"code": -32603, "message": str(e)}}
-
-    # Fallback to JSON-RPC pattern for backward compatibility
-    elif hasattr(client, "send_json_rpc"):
-        logger.debug("Using legacy send_json_rpc for push notification config")
-        params = {"taskId": task_id, "configId": config_id}
-        return transport_send_json_rpc_request(client, "tasks/pushNotificationConfig/delete", params)
 
     else:
         raise ValueError(f"Client {type(client)} does not support push notification configuration")


### PR DESCRIPTION
As I understood, `send_json_rpc` method was removed from `SUTClient` and `JSONRPCClient` but some tests that method were omitted and others are failing because. This PR removes and fixes those tests.