### PR TITLE
fix: Fix test failing on `TransportError` constructor signature change

### DIFF
--- a/tck/transport/jsonrpc_client.py
+++ b/tck/transport/jsonrpc_client.py
@@ -33,7 +33,7 @@ class JSONRPCError(TransportError):
     """
 
     def __init__(self, message: str, original_error: Optional[Exception] = None, json_rpc_error: Optional[Dict[str, Any]] = None):
-        super().__init__(message, TransportType.JSON_RPC, original_error)
+        super().__init__(message, TransportType.JSON_RPC, json_rpc_error, original_error)
         self.json_rpc_error = json_rpc_error
 
 

--- a/tests/unit/transport/test_base_client.py
+++ b/tests/unit/transport/test_base_client.py
@@ -99,7 +99,7 @@ class TestTransportError:
     def test_transport_error_with_original(self):
         """Test TransportError with original exception."""
         original = ValueError("Original error")
-        error = TransportError("Test error", TransportType.GRPC, original)
+        error = TransportError("Test error", TransportType.GRPC, original_error=original)
         assert "[GRPC] Test error (caused by: Original error)" in str(error)
         assert error.original_error == original
 


### PR DESCRIPTION
`test_transport_error_with_original` test is failing on inner error being empty. This seems as a regression because `TransportError` constructor signature has changed.