### PR TITLE
fix: REST calls are failing with different errors

### DIFF
--- a/tck/transport/rest_client.py
+++ b/tck/transport/rest_client.py
@@ -138,7 +138,7 @@ class RESTClient(BaseTransportClient):
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
+            if "extra_headers" in kwargs and kwargs["extra_headers"]:
                 headers.update(kwargs["extra_headers"])
 
             # Prepare payload according to A2A REST specification
@@ -205,7 +205,7 @@ class RESTClient(BaseTransportClient):
             headers["Accept"] = "text/event-stream"  # SSE format
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
+            if "extra_headers" in kwargs and kwargs["extra_headers"]:
                 headers.update(kwargs["extra_headers"])
 
             # Prepare payload
@@ -289,7 +289,7 @@ class RESTClient(BaseTransportClient):
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
+            if "extra_headers" in kwargs and kwargs["extra_headers"]:
                 headers.update(kwargs["extra_headers"])
 
             # Add query parameters
@@ -345,7 +345,7 @@ class RESTClient(BaseTransportClient):
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
+            if "extra_headers" in kwargs and kwargs["extra_headers"]:
                 headers.update(kwargs["extra_headers"])
 
             # Make real HTTP request to live SUT
@@ -416,7 +416,7 @@ class RESTClient(BaseTransportClient):
             headers["Accept"] = "text/event-stream"  # SSE format
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
+            if "extra_headers" in kwargs and kwargs["extra_headers"]:
                 headers.update(kwargs["extra_headers"])
 
             # Make real HTTP streaming request to live SUT
@@ -490,7 +490,7 @@ class RESTClient(BaseTransportClient):
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
+            if "extra_headers" in kwargs and kwargs["extra_headers"]:
                 headers.update(kwargs["extra_headers"])
 
             # Make real HTTP request to live SUT
@@ -594,7 +594,7 @@ class RESTClient(BaseTransportClient):
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
+            if "extra_headers" in kwargs and kwargs["extra_headers"]:
                 headers.update(kwargs["extra_headers"])
 
             # Make real HTTP request to live SUT
@@ -646,7 +646,7 @@ class RESTClient(BaseTransportClient):
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
+            if "extra_headers" in kwargs and kwargs["extra_headers"]:
                 headers.update(kwargs["extra_headers"])
 
             # Make real HTTP request to live SUT
@@ -697,7 +697,7 @@ class RESTClient(BaseTransportClient):
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
+            if "extra_headers" in kwargs and kwargs["extra_headers"]:
                 headers.update(kwargs["extra_headers"])
 
             # Make real HTTP request to live SUT
@@ -749,7 +749,7 @@ class RESTClient(BaseTransportClient):
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
+            if "extra_headers" in kwargs and kwargs["extra_headers"]:
                 headers.update(kwargs["extra_headers"])
 
             # Make real HTTP request to live SUT
@@ -804,7 +804,7 @@ class RESTClient(BaseTransportClient):
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
+            if "extra_headers" in kwargs and kwargs["extra_headers"]:
                 headers.update(kwargs["extra_headers"])
 
             # Add query parameters for pagination, filtering, etc.

--- a/tests/utils/transport_helpers.py
+++ b/tests/utils/transport_helpers.py
@@ -41,7 +41,7 @@ def transport_send_message(
         logger.debug(f"Using transport-aware send_message for {client.transport_type.value}")
         message = message_params.get("message", message_params)
         try:
-            result = client.send_message(message, extra_headers)
+            result = client.send_message(message, extra_headers=extra_headers)
             # Wrap result in JSON-RPC format for compatibility with existing tests
             return {"result": result}
         except Exception as e:
@@ -221,7 +221,7 @@ def is_json_rpc_success_response(response: Dict[str, Any], expected_id: Optional
         return False
 
     # For full JSON-RPC responses, use the existing validation
-    if "jsonrpc" in response and "id" in response:
+    if response and "jsonrpc" in response and "id" in response:
         return message_utils.is_json_rpc_success_response(response, expected_id)
 
     # For transport-aware responses in JSON-RPC format ({"result": {...}} or {"error": {...}})


### PR DESCRIPTION
 * transport_helpers.is_json_rpc_success_response(resp) error messageAssertionError: assert 'id' in {'error': {'code': -32603, 'message': 'RESTClient.send_message() takes 2 positional arguments but 3 were given'}}
 * function is_json_rpc_success_response at 0x7f2bc3fc8040>({'error': {'code': -32603, 'message': "[REST] Unexpected error in REST send_message: 'NoneType' object is not iterable"}})
 * rest_client.py:180 Unexpected error in REST send_message: 'NoneType' object is not iterable