### PR TITLE
REST URLS and client signatures

### DIFF
--- a/tck/transport/rest_client.py
+++ b/tck/transport/rest_client.py
@@ -114,7 +114,7 @@ class RESTClient(BaseTransportClient):
 
     # A2A Protocol Method Implementations - Real HTTP Calls
 
-    def send_message(self, message: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+    def send_message(self, message: Dict[str, Any], extra_headers: Optional[Dict[str, str]] = None, **kwargs) -> Dict[str, Any]:
         """
         Send message via HTTP POST and wait for completion.
 
@@ -138,8 +138,8 @@ class RESTClient(BaseTransportClient):
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
-            if "extra_headers" in kwargs:
-                headers.update(kwargs["extra_headers"])
+            if extra_headers:
+                headers.update(extra_headers)
 
             # Prepare payload according to A2A REST specification
             payload = {"message": message}
@@ -179,6 +179,9 @@ class RESTClient(BaseTransportClient):
             error_msg = f"Unexpected error in REST send_message: {str(e)}"
             logger.error(error_msg)
             raise TransportError(error_msg, TransportType.REST)
+
+    def __repr__(self) -> str:
+        return super().__repr__()
 
     async def send_streaming_message(self, message: Dict[str, Any], **kwargs) -> AsyncIterator[Dict[str, Any]]:
         """

--- a/tck/transport/rest_client.py
+++ b/tck/transport/rest_client.py
@@ -118,7 +118,7 @@ class RESTClient(BaseTransportClient):
         """
         Send message via HTTP POST and wait for completion.
 
-        Maps to: POST /messages HTTP request
+        Maps to: POST v1/message:send HTTP request
 
         Args:
             message: A2A message in JSON format
@@ -134,7 +134,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Sending message via REST: {message.get('message_id', 'unknown')}")
 
             # Prepare request
-            url = urljoin(self.base_url, "messages")
+            url = urljoin(self.base_url, "v1/message:send")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -184,7 +184,7 @@ class RESTClient(BaseTransportClient):
         """
         Send message via HTTP POST and stream responses using Server-Sent Events.
 
-        Maps to: POST /messages/stream HTTP request with SSE response
+        Maps to: POST v1/messages:stream HTTP request with SSE response
 
         Args:
             message: A2A message in JSON format
@@ -200,7 +200,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Starting REST streaming for message: {message.get('message_id', 'unknown')}")
 
             # Prepare request
-            url = urljoin(self.base_url, "messages/stream")
+            url = urljoin(self.base_url, "v1/message:stream")
             headers = self.default_headers.copy()
             headers["Accept"] = "text/event-stream"  # SSE format
 
@@ -269,7 +269,7 @@ class RESTClient(BaseTransportClient):
         """
         Get task status via HTTP GET.
 
-        Maps to: GET /tasks/{task_id} HTTP request
+        Maps to: GET v1/tasks/{task_id} HTTP request
 
         Args:
             task_id: ID of the task to retrieve
@@ -285,7 +285,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Getting task via REST: {task_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"tasks/{task_id}")
+            url = urljoin(self.base_url, f"v1/tasks/{task_id}")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -325,7 +325,7 @@ class RESTClient(BaseTransportClient):
         """
         Cancel task via HTTP POST.
 
-        Maps to: POST /tasks/{task_id}/cancel HTTP request
+        Maps to: POST v1/tasks/{task_id}:cancel HTTP request
 
         Args:
             task_id: ID of the task to cancel
@@ -341,7 +341,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Cancelling task via REST: {task_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"tasks/{task_id}/cancel")
+            url = urljoin(self.base_url, f"v1/tasks/{task_id}:cancel")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -376,7 +376,7 @@ class RESTClient(BaseTransportClient):
         """
         Resubscribe to task updates via HTTP SSE streaming.
 
-        Maps to: GET /tasks/{task_id}/events HTTP request with SSE response
+        Maps to: GET v1/tasks/{task_id}:subscribe HTTP request with SSE response
         This is an alias for subscribe_to_task for interface compatibility.
 
         Args:
@@ -395,7 +395,7 @@ class RESTClient(BaseTransportClient):
         """
         Subscribe to task updates via HTTP SSE streaming.
 
-        Maps to: GET /tasks/{task_id}/events HTTP request with SSE response
+        Maps to: GET v1/tasks/{task_id}:subscribeevents HTTP request with SSE response
 
         Args:
             task_id: ID of the task to subscribe to
@@ -411,7 +411,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Subscribing to task via REST: {task_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"tasks/{task_id}/events")
+            url = urljoin(self.base_url, f"v1/tasks/{task_id}:subscribe")
             headers = self.default_headers.copy()
             headers["Accept"] = "text/event-stream"  # SSE format
 
@@ -471,7 +471,7 @@ class RESTClient(BaseTransportClient):
         """
         Get agent card via HTTP GET.
 
-        Maps to: GET /agent-card HTTP request
+        Maps to: GET /v1/card HTTP request
 
         Args:
             **kwargs: Additional configuration options (extra_headers)
@@ -486,7 +486,7 @@ class RESTClient(BaseTransportClient):
             logger.info("Getting agent card via REST")
 
             # Prepare request
-            url = urljoin(self.base_url, "agent-card")
+            url = urljoin(self.base_url, "/v1/card")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -521,7 +521,7 @@ class RESTClient(BaseTransportClient):
         """
         Get authenticated extended agent card via HTTP GET.
 
-        Maps to: GET /agent-card HTTP request with authentication headers
+        Maps to: GET /v1/card HTTP request with authentication headers
 
         Args:
             **kwargs: Additional configuration options (extra_headers with auth)
@@ -536,7 +536,7 @@ class RESTClient(BaseTransportClient):
             logger.info("Getting authenticated extended agent card via REST")
 
             # Prepare request
-            url = urljoin(self.base_url, "agent-card")
+            url = urljoin(self.base_url, "/v1/card")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided (should include authentication)
@@ -573,7 +573,7 @@ class RESTClient(BaseTransportClient):
         """
         Set push notification config for a task via HTTP POST.
 
-        Maps to: POST /tasks/{task_id}/push-notification-configs HTTP request
+        Maps to: POST v1/tasks/{task_id}/pushNotificationConfigs HTTP request
 
         Args:
             task_id: ID of the task to configure
@@ -590,7 +590,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Setting push notification config for task via REST: {task_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"tasks/{task_id}/push-notification-configs")
+            url = urljoin(self.base_url, f"v1/tasks/{task_id}/pushNotificationConfigs")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -625,7 +625,7 @@ class RESTClient(BaseTransportClient):
         """
         Get push notification config via HTTP GET.
 
-        Maps to: GET /tasks/{task_id}/push-notification-configs/{config_id} HTTP request
+        Maps to: GET v1/tasks/{task_id}/pushNotificationConfigs/{config_id} HTTP request
 
         Args:
             task_id: ID of the task
@@ -642,7 +642,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Getting push notification config via REST: {task_id}/{config_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"tasks/{task_id}/push-notification-configs/{config_id}")
+            url = urljoin(self.base_url, f"v1/tasks/{task_id}/pushNotificationConfigs/{config_id}")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -677,7 +677,7 @@ class RESTClient(BaseTransportClient):
         """
         List push notification configs for a task via HTTP GET.
 
-        Maps to: GET /tasks/{task_id}/push-notification-configs HTTP request
+        Maps to: GET v1/tasks/{task_id}/pushNotificationConfigs HTTP request
 
         Args:
             task_id: ID of the task
@@ -693,7 +693,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Listing push notification configs via REST: {task_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"tasks/{task_id}/push-notification-configs")
+            url = urljoin(self.base_url, f"v1/tasks/{task_id}/pushNotificationConfigs")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -728,7 +728,7 @@ class RESTClient(BaseTransportClient):
         """
         Delete push notification config via HTTP DELETE.
 
-        Maps to: DELETE /tasks/{task_id}/push-notification-configs/{config_id} HTTP request
+        Maps to: DELETE v1/tasks/{task_id}/pushNotificationConfigs/{config_id} HTTP request
 
         Args:
             task_id: ID of the task
@@ -745,7 +745,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Deleting push notification config via REST: {task_id}/{config_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"tasks/{task_id}/push-notification-configs/{config_id}")
+            url = urljoin(self.base_url, f"v1/tasks/{task_id}/pushNotificationConfigs/{config_id}")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided

--- a/tests/unit/transport/test_rest_client.py
+++ b/tests/unit/transport/test_rest_client.py
@@ -221,7 +221,7 @@ class TestRESTClientSendMessage:
 
             # Verify correct URL and payload were used
             mock_post.assert_called_once_with(
-                "https://example.com:8080/messages", json={"message": message}, headers=client.default_headers
+                "https://example.com:8080/v1/message:send", json={"message": message}, headers=client.default_headers
             )
 
             # Verify result
@@ -253,7 +253,7 @@ class TestRESTClientSendMessage:
             expected_headers.update(extra_headers)
 
             mock_post.assert_called_once_with(
-                "https://example.com:8080/messages", json={"message": message}, headers=expected_headers
+                "https://example.com:8080/v1/message:send", json={"message": message}, headers=expected_headers
             )
 
     @patch("httpx.Client.post")
@@ -284,7 +284,7 @@ class TestRESTClientSendMessage:
             }
 
             mock_post.assert_called_once_with(
-                "https://example.com:8080/messages", json=expected_payload, headers=client.default_headers
+                "https://example.com:8080/v1/message:send", json=expected_payload, headers=client.default_headers
             )
 
     @patch("httpx.Client.post")
@@ -398,7 +398,7 @@ class TestRESTClientStreamingMessage:
         # Verify correct URL and headers were used
         mock_async_client.stream.assert_called_once_with(
             "POST",
-            "https://example.com:8080/messages/stream",
+            "https://example.com:8080/v1/message:stream",
             json={"message": message},
             headers={**client.default_headers, "Accept": "text/event-stream"},
         )
@@ -508,7 +508,7 @@ class TestRESTClientTaskOperations:
 
             result = client.get_task("task-123")
 
-            mock_get.assert_called_once_with("https://example.com:8080/tasks/task-123", params={}, headers=client.default_headers)
+            mock_get.assert_called_once_with("https://example.com:8080/v1/tasks/task-123", params={}, headers=client.default_headers)
 
             assert result["id"] == "task-123"
             assert result["context_id"] == "default-context"
@@ -532,7 +532,7 @@ class TestRESTClientTaskOperations:
             client.get_task("task-123", history_length=10)
 
             mock_get.assert_called_once_with(
-                "https://example.com:8080/tasks/task-123", params={"history_length": 10}, headers=client.default_headers
+                "https://example.com:8080/v1/tasks/task-123", params={"history_length": 10}, headers=client.default_headers
             )
 
     @patch("httpx.Client.post")
@@ -562,7 +562,7 @@ class TestRESTClientTaskOperations:
 
             result = client.cancel_task("task-456")
 
-            mock_post.assert_called_once_with("https://example.com:8080/tasks/task-456/cancel", headers=client.default_headers)
+            mock_post.assert_called_once_with("https://example.com:8080/v1/tasks/task-456:cancel", headers=client.default_headers)
 
             assert result["id"] == "task-456"
             assert result["status"]["state"] == "TASK_STATE_CANCELLED"
@@ -618,7 +618,7 @@ class TestRESTClientTaskOperations:
         # Verify correct URL and headers were used
         mock_async_client.stream.assert_called_once_with(
             "GET",
-            "https://example.com:8080/tasks/task-789/events",
+            "https://example.com:8080/v1/tasks/task-789:subscribe",
             headers={**client.default_headers, "Accept": "text/event-stream"},
         )
 
@@ -652,7 +652,7 @@ class TestRESTClientAgentCard:
 
             result = client.get_agent_card()
 
-            mock_get.assert_called_once_with("https://example.com:8080/agent-card", headers=client.default_headers)
+            mock_get.assert_called_once_with("https://example.com:8080/v1/card", headers=client.default_headers)
 
             assert result["protocol_version"] == "0.3.0"
             assert result["name"] == "A2A REST Test Agent"
@@ -689,7 +689,7 @@ class TestRESTClientAgentCard:
             expected_headers = client.default_headers.copy()
             expected_headers.update(auth_headers)
 
-            mock_get.assert_called_once_with("https://example.com:8080/agent-card", headers=expected_headers)
+            mock_get.assert_called_once_with("https://example.com:8080/v1/card", headers=expected_headers)
 
             assert result["name"] == "A2A REST Test Agent (Extended)"
             assert result["capabilities"]["authenticated_features"] is True
@@ -728,7 +728,7 @@ class TestRESTClientPushNotifications:
             result = client.set_push_notification_config("task-123", config)
 
             mock_post.assert_called_once_with(
-                "https://example.com:8080/tasks/task-123/push-notification-configs", json=config, headers=client.default_headers
+                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs", json=config, headers=client.default_headers
             )
 
             assert result["push_notification_config"]["id"] == "config1"
@@ -740,7 +740,7 @@ class TestRESTClientPushNotifications:
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {
-            "name": "tasks/task-123/push-notification-configs/config1",
+            "name": "tasks/task-123/pushNotificationConfigs/config1",
             "push_notification_config": {
                 "id": "config1",
                 "url": "https://webhook.example.com/notify",
@@ -759,7 +759,7 @@ class TestRESTClientPushNotifications:
             result = client.get_push_notification_config("task-123", "config1")
 
             mock_get.assert_called_once_with(
-                "https://example.com:8080/tasks/task-123/push-notification-configs/config1", headers=client.default_headers
+                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs/config1", headers=client.default_headers
             )
 
             assert result["push_notification_config"]["id"] == "config1"
@@ -772,11 +772,11 @@ class TestRESTClientPushNotifications:
         mock_response.json.return_value = {
             "configs": [
                 {
-                    "name": "tasks/task-123/push-notification-configs/config1",
+                    "name": "tasks/task-123/pushNotificationConfigs/config1",
                     "push_notification_config": {"id": "config1", "url": "https://webhook1.example.com/notify"},
                 },
                 {
-                    "name": "tasks/task-123/push-notification-configs/config2",
+                    "name": "tasks/task-123/pushNotificationConfigs/config2",
                     "push_notification_config": {"id": "config2", "url": "https://webhook2.example.com/notify"},
                 },
             ],
@@ -794,7 +794,7 @@ class TestRESTClientPushNotifications:
             result = client.list_push_notification_configs("task-123")
 
             mock_get.assert_called_once_with(
-                "https://example.com:8080/tasks/task-123/push-notification-configs", headers=client.default_headers
+                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs", headers=client.default_headers
             )
 
             assert len(result["configs"]) == 2
@@ -819,7 +819,7 @@ class TestRESTClientPushNotifications:
             result = client.delete_push_notification_config("task-123", "config1")
 
             mock_delete.assert_called_once_with(
-                "https://example.com:8080/tasks/task-123/push-notification-configs/config1", headers=client.default_headers
+                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs/config1", headers=client.default_headers
             )
 
             assert result == {}  # Empty response for successful deletion


### PR DESCRIPTION
REST URLs are not the one defined in the specs
rest_client methods are not using the same parameters as the base client