### PR TITLE
fix: Sending should happen in a background thread in the resubscribe test

### DIFF
--- a/tests/optional/capabilities/test_streaming_methods.py
+++ b/tests/optional/capabilities/test_streaming_methods.py
@@ -1,13 +1,9 @@
 import asyncio
-import json
 import logging
 import os
-from pathlib import Path
-from typing import Any, AsyncGenerator, Dict, List, Optional
 import uuid
 
 import pytest
-import pytest_asyncio
 
 from tck import agent_card_utils, config, message_utils
 from tests.markers import optional_capability
@@ -15,8 +11,6 @@ from tests.capability_validator import CapabilityValidator, skip_if_capability_n
 from tests.utils.transport_helpers import (
     transport_send_streaming_message,
     transport_resubscribe_task,
-    transport_send_message,
-    extract_task_id_from_response,
     generate_test_message_id,
 )
 
@@ -334,8 +328,9 @@ async def test_tasks_resubscribe(sut_client, agent_card_data):
 
         # Wait for both tasks to complete with timeout
         try:
-            await asyncio.wait_for(asyncio.gather(initial_stream_task, resubscribe_task, return_exceptions=True), 
-                                 timeout=TIMEOUTS["async_wait_for"] * 2)
+            await asyncio.wait_for(
+                asyncio.gather(initial_stream_task, resubscribe_task, return_exceptions=True),
+                timeout=TIMEOUTS["async_wait_for"] * 2)
         except asyncio.TimeoutError:
             logger.warning("Timeout while waiting for stream processing and resubscribe")
             # Cancel tasks if they're still running


### PR DESCRIPTION
Once we get the first evemt (the Task) the event queue will be open during the configurable sleepi that happens in the AgentExecutor. This is our window for when it is possible to resubscribe

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](../CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
    - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
        - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
        - `feat:` represents a new feature, and correlates to a SemVer minor.
        - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests pass
- [x] Appropriate READMEs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕