### PR TITLE
fix: Update clients and tests for A2A Protocol v1.0.0

### DIFF
--- a/tck/transport/jsonrpc_client.py
+++ b/tck/transport/jsonrpc_client.py
@@ -465,7 +465,7 @@ class JSONRPCClient(BaseTransportClient):
 
     def get_agent_card(self, extra_headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
         """
-        Get agent card using agent/getAuthenticatedExtendedCard method.
+        Get agent card using GetExtendedAgentCard method.
 
         Makes a real JSON-RPC call to get the agent card information.
 
@@ -481,7 +481,7 @@ class JSONRPCClient(BaseTransportClient):
         Specification Reference: A2A Protocol v0.3.0 §5.5 - Agent Card Retrieval
         """
         try:
-            response = self._make_jsonrpc_request(method="agent/getAuthenticatedExtendedCard", params={}, extra_headers=extra_headers)
+            response = self._make_jsonrpc_request(method="GetExtendedAgentCard", params={}, extra_headers=extra_headers)
             return response.get("result", {})
 
         except Exception as e:
@@ -623,7 +623,7 @@ class JSONRPCClient(BaseTransportClient):
 
     def get_authenticated_extended_card(self, extra_headers: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
         """
-        Get the authenticated extended agent card.
+        Get the extended agent card.
 
         Makes a real JSON-RPC call to retrieve extended agent information.
 
@@ -631,16 +631,16 @@ class JSONRPCClient(BaseTransportClient):
             extra_headers: Optional HTTP headers (typically auth headers)
 
         Returns:
-            The extended agent card with additional authenticated information
+            The extended agent card with additional information
 
         Raises:
-            JSONRPCError: If authenticated card retrieval fails
+            JSONRPCError: If card retrieval fails
 
-        Specification Reference: A2A Protocol v0.3.0 §5.6 - Authenticated Extended Card
+        Specification Reference: A2A Protocol v0.3.0 §5.6 - Extended Card
         """
         try:
             response = self._make_jsonrpc_request(
-                method="agent/getAuthenticatedExtendedCard", params={}, extra_headers=extra_headers
+                method="GetExtendedAgentCard", params={}, extra_headers=extra_headers
             )
             return response.get("result", {})
 

--- a/tck/transport/rest_client.py
+++ b/tck/transport/rest_client.py
@@ -68,7 +68,7 @@ class RESTClient(BaseTransportClient):
         self.default_headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "User-Agent": "A2A-TCK-REST-Client/0.3.0",
+            "User-Agent": "A2A-TCK-REST-Client/1.0.0",
         }
 
         logger.info(f"Initialized REST client for endpoint: {self.base_url}")
@@ -164,7 +164,7 @@ class RESTClient(BaseTransportClient):
         """
         Send message via HTTP POST and wait for completion.
 
-        Maps to: POST v1/message:send HTTP request
+        Maps to: POST message:send HTTP request
 
         Args:
             message: A2A message in JSON format
@@ -181,7 +181,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Sending message via REST: {message.get('message_id', 'unknown')}")
 
             # Prepare request
-            url = urljoin(self.base_url, "v1/message:send")
+            url = urljoin(self.base_url, "message:send")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -252,7 +252,7 @@ class RESTClient(BaseTransportClient):
         """
         Send message via HTTP POST and stream responses using Server-Sent Events.
 
-        Maps to: POST v1/messages:stream HTTP request with SSE response
+        Maps to: POST messages:stream HTTP request with SSE response
 
         Args:
             message: A2A message in JSON format
@@ -269,7 +269,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Starting REST streaming for message: {message.get('message_id', 'unknown')}")
 
             # Prepare request
-            url = urljoin(self.base_url, "v1/message:stream")
+            url = urljoin(self.base_url, "message:stream")
             headers = self.default_headers.copy()
             headers["Accept"] = "text/event-stream"  # SSE format
             # Add extra headers if provided
@@ -338,7 +338,7 @@ class RESTClient(BaseTransportClient):
         """
         Get task status via HTTP GET.
 
-        Maps to: GET v1/tasks/{task_id} HTTP request
+        Maps to: GET tasks/{task_id} HTTP request
 
         Args:
             task_id: ID of the task to retrieve
@@ -354,7 +354,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Getting task via REST: {task_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"v1/tasks/{task_id}")
+            url = urljoin(self.base_url, f"tasks/{task_id}")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -397,7 +397,7 @@ class RESTClient(BaseTransportClient):
         """
         Cancel task via HTTP POST.
 
-        Maps to: POST v1/tasks/{task_id}:cancel HTTP request
+        Maps to: POST tasks/{task_id}:cancel HTTP request
 
         Args:
             task_id: ID of the task to cancel
@@ -413,7 +413,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Cancelling task via REST: {task_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"v1/tasks/{task_id}:cancel")
+            url = urljoin(self.base_url, f"tasks/{task_id}:cancel")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -450,7 +450,7 @@ class RESTClient(BaseTransportClient):
         """
         Subscribe to task updates via HTTP SSE streaming.
 
-        Maps to: GET v1/tasks/{task_id}:subscribe HTTP request with SSE response
+        Maps to: GET tasks/{task_id}:subscribe HTTP request with SSE response
         This is an alias for subscribe_to_task for interface compatibility.
 
         Args:
@@ -469,7 +469,7 @@ class RESTClient(BaseTransportClient):
         """
         Subscribe to task updates via HTTP SSE streaming.
 
-        Maps to: GET v1/tasks/{task_id}:subscribeevents HTTP request with SSE response
+        Maps to: GET tasks/{task_id}:subscribeevents HTTP request with SSE response
 
         Args:
             task_id: ID of the task to subscribe to
@@ -485,7 +485,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Subscribing to task via REST: {task_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"v1/tasks/{task_id}:subscribe")
+            url = urljoin(self.base_url, f"tasks/{task_id}:subscribe")
             headers = self.default_headers.copy()
             headers["Accept"] = "text/event-stream"  # SSE format
             # Add extra headers if provided
@@ -544,7 +544,7 @@ class RESTClient(BaseTransportClient):
         """
         Get agent card via HTTP GET.
 
-        Maps to: GET /v1/card HTTP request
+        Maps to: GET /card HTTP request
 
         Args:
             **kwargs: Additional configuration options (extra_headers)
@@ -559,7 +559,7 @@ class RESTClient(BaseTransportClient):
             logger.info("Getting agent card via REST")
 
             # Prepare request
-            url = urljoin(self.base_url, "/v1/card")
+            url = urljoin(self.base_url, "card")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -594,7 +594,7 @@ class RESTClient(BaseTransportClient):
         """
         Get authenticated extended agent card via HTTP GET.
 
-        Maps to: GET /v1/card HTTP request with authentication headers
+        Maps to: GET /card HTTP request with authentication headers
 
         Args:
             **kwargs: Additional configuration options (extra_headers with auth)
@@ -609,7 +609,7 @@ class RESTClient(BaseTransportClient):
             logger.info("Getting authenticated extended agent card via REST")
 
             # Prepare request
-            url = urljoin(self.base_url, "/v1/card")
+            url = urljoin(self.base_url, "card")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided (should include authentication)
@@ -646,7 +646,7 @@ class RESTClient(BaseTransportClient):
         """
         Set push notification config for a task via HTTP POST.
 
-        Maps to: POST v1/tasks/{task_id}/pushNotificationConfigs HTTP request
+        Maps to: POST tasks/{task_id}/pushNotificationConfigs HTTP request
 
         Args:
             task_id: ID of the task to configure
@@ -663,7 +663,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Setting push notification config for task via REST: {task_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"v1/tasks/{task_id}/pushNotificationConfigs")
+            url = urljoin(self.base_url, f"tasks/{task_id}/pushNotificationConfigs")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -717,7 +717,7 @@ class RESTClient(BaseTransportClient):
         """
         Get push notification config via HTTP GET.
 
-        Maps to: GET v1/tasks/{task_id}/pushNotificationConfigs/{config_id} HTTP request
+        Maps to: GET tasks/{task_id}/pushNotificationConfigs/{config_id} HTTP request
 
         Args:
             task_id: ID of the task
@@ -734,7 +734,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Getting push notification config via REST: {task_id}/{config_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"v1/tasks/{task_id}/pushNotificationConfigs/{config_id}")
+            url = urljoin(self.base_url, f"tasks/{task_id}/pushNotificationConfigs/{config_id}")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -769,7 +769,7 @@ class RESTClient(BaseTransportClient):
         """
         List push notification configs for a task via HTTP GET.
 
-        Maps to: GET v1/tasks/{task_id}/pushNotificationConfigs HTTP request
+        Maps to: GET tasks/{task_id}/pushNotificationConfigs HTTP request
 
         Args:
             task_id: ID of the task
@@ -785,7 +785,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Listing push notification configs via REST: {task_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"v1/tasks/{task_id}/pushNotificationConfigs")
+            url = urljoin(self.base_url, f"tasks/{task_id}/pushNotificationConfigs")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -833,7 +833,7 @@ class RESTClient(BaseTransportClient):
         """
         Delete push notification config via HTTP DELETE.
 
-        Maps to: DELETE v1/tasks/{task_id}/pushNotificationConfigs/{config_id} HTTP request
+        Maps to: DELETE tasks/{task_id}/pushNotificationConfigs/{config_id} HTTP request
 
         Args:
             task_id: ID of the task
@@ -850,7 +850,7 @@ class RESTClient(BaseTransportClient):
             logger.info(f"Deleting push notification config via REST: {task_id}/{config_id}")
 
             # Prepare request
-            url = urljoin(self.base_url, f"v1/tasks/{task_id}/pushNotificationConfigs/{config_id}")
+            url = urljoin(self.base_url, f"tasks/{task_id}/pushNotificationConfigs/{config_id}")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided
@@ -893,7 +893,7 @@ class RESTClient(BaseTransportClient):
         """
         List tasks via HTTP GET (REST transport supports this method).
 
-        Maps to: GET v1/tasks HTTP request
+        Maps to: GET tasks HTTP request
 
         Args:
             **kwargs: Additional configuration options (extra_headers, pagination)
@@ -908,7 +908,7 @@ class RESTClient(BaseTransportClient):
             logger.info("Listing tasks via REST")
 
             # Prepare request
-            url = urljoin(self.base_url, "v1/tasks")
+            url = urljoin(self.base_url, "tasks")
             headers = self.default_headers.copy()
 
             # Add extra headers if provided

--- a/tests/mandatory/jsonrpc/test_a2a_error_codes_enhanced.py
+++ b/tests/mandatory/jsonrpc/test_a2a_error_codes_enhanced.py
@@ -62,11 +62,12 @@ def create_test_task(sut_client) -> Optional[str]:
         }
 
         message_response = transport_helpers.transport_send_message(sut_client, {"message": test_message})
-
         if "result" in message_response and isinstance(message_response["result"], dict):
-            task = message_response["result"]
-            if "id" in task:
-                return task["id"]
+            result = message_response["result"]
+            if "task" in result and isinstance(result["task"], dict):
+                task = result["task"]
+                if "id" in task:
+                    return task["id"]
     except Exception as e:
         logger.warning(f"Failed to create test task: {e}")
 
@@ -89,7 +90,11 @@ def test_push_notification_not_supported_error_32003_enhanced(sut_client):
     push_notifications_supported = False
 
     try:
-        agent_card = transport_helpers.transport_get_agent_card(sut_client)
+        result = transport_helpers.transport_get_agent_card(sut_client)
+        if "result" in result and isinstance(result["result"], dict):
+            agent_card = result["result"]
+        else:
+            agent_card = result
         capabilities = agent_card.get("capabilities", {})
         push_notifications_supported = capabilities.get("pushNotifications", False)
     except Exception as e:
@@ -98,12 +103,13 @@ def test_push_notification_not_supported_error_32003_enhanced(sut_client):
     if not push_notifications_supported:
         # Test direct rejection for unsupported feature
         task_id = create_test_task(sut_client) or f"test-task-{message_utils.generate_request_id()}"
-
+        config_id = str(uuid.uuid4())
         # Try to set push notification config on agent that doesn't support it
-        config = {"url": "https://test.example.com/webhook", "token": "test-token"}
+        name= f"tasks/{task_id}/pushNotificationConfigs/{config_id}"
+        config = {"name": name, "pushNotificationConfig":{"url": "https://test.example.com/webhook", "token": "test-token"}}
 
         try:
-            response = transport_helpers.transport_set_push_notification_config(sut_client, task_id, config)
+            response = transport_helpers.transport_set_push_notification_config(sut_client, task_id, config_id, config)
 
             if "error" in response:
                 error_code = response["error"]["code"]

--- a/tests/mandatory/protocol/test_a2a_v030_new_methods.py
+++ b/tests/mandatory/protocol/test_a2a_v030_new_methods.py
@@ -260,8 +260,6 @@ class TestTasksList:
             our_task = next(t for t in tasks if t["id"] == created_task_id)
             assert "status" in our_task
             assert "contextId" in our_task
-            assert "kind" in our_task
-            assert our_task["kind"] == "task"
 
         except Exception as e:
             pytest.fail(f"Failed to test tasks/list with existing tasks: {e}")
@@ -519,14 +517,14 @@ class TestTransportSpecificFeatures:
                 }
             }
             response = transport_send_message(sut_client, message_params)
-            task = response.get("result", {})
+            task = response.get("result", {}).get("task", {})
 
             # Task may have additional fields beyond spec
-            spec_fields = {"id", "contextId", "status", "history", "artifacts", "metadata", "kind"}
+            spec_fields = {"id", "contextId", "status", "history", "artifacts", "metadata"}
             task_fields = set(task.keys())
 
             # Additional fields are allowed as long as spec fields are present
-            missing_required = {"id", "status", "kind"} - task_fields
+            missing_required = {"id", "status"} - task_fields
             assert not missing_required, f"Missing required fields: {missing_required}"
 
         except Exception as e:

--- a/tests/mandatory/protocol/test_agent_card_mandatory.py
+++ b/tests/mandatory/protocol/test_agent_card_mandatory.py
@@ -67,7 +67,6 @@ def test_agent_card_mandatory_fields(fetched_agent_card):
         "name",
         "protocolVersion",
         "skills",
-        "url",
         "version",
     ]
 
@@ -180,9 +179,8 @@ def test_agent_card_basic_info_mandatory(fetched_agent_card):
     Fix Suggestion: Include all required basic information fields
 
     Asserts:
-        - name, description, url, version are present
+        - name, description, version are present
         - fields are non-empty strings
-        - url appears to be a valid URL format
     """
     # Check name
     assert "name" in fetched_agent_card, "Agent Card must include name field"
@@ -195,14 +193,6 @@ def test_agent_card_basic_info_mandatory(fetched_agent_card):
     description = fetched_agent_card["description"]
     assert isinstance(description, str), "description must be a string"
     assert description.strip(), "description cannot be empty"
-
-    # Check url
-    assert "url" in fetched_agent_card, "Agent Card must include url field"
-    url = fetched_agent_card["url"]
-    assert isinstance(url, str), "url must be a string"
-    assert url.strip(), "url cannot be empty"
-    # Basic URL format validation
-    assert url.startswith(("http://", "https://")), "url must be a valid HTTP/HTTPS URL"
 
     # Check version
     assert "version" in fetched_agent_card, "Agent Card must include version field"

--- a/tests/mandatory/quality/test_error_validation_enhanced.py
+++ b/tests/mandatory/quality/test_error_validation_enhanced.py
@@ -135,7 +135,7 @@ def test_invalid_method_error_validation(sut_client):
     req_id = message_utils.generate_request_id()
     invalid_request = message_utils.make_json_rpc_request("invalid/nonexistent/method", params={}, id=req_id)
 
-    response = transport_helpers.transport_send_json_rpc_request(sut_client, invalid_request)
+    response = transport_helpers.transport_send_raw_json_rpc_request(sut_client, invalid_request)
 
     # Should be an error response
     assert "error" in response, "Invalid method should return JSON-RPC error response"
@@ -225,7 +225,7 @@ def test_invalid_params_error_validation(sut_client):
         req_id = message_utils.generate_request_id()
         invalid_request = message_utils.make_json_rpc_request(test_case["method"], params=test_case["params"], id=req_id)
 
-        response = transport_helpers.transport_send_json_rpc_request(sut_client, invalid_request)
+        response = transport_helpers.transport_send_raw_json_rpc_request(sut_client, invalid_request)
 
         # Should be an error response
         if "error" not in response:
@@ -296,7 +296,7 @@ def test_nonexistent_resource_error_validation(sut_client):
         req_id = message_utils.generate_request_id()
         request = message_utils.make_json_rpc_request(test_case["method"], params=test_case["params"], id=req_id)
 
-        response = transport_helpers.transport_send_json_rpc_request(sut_client, request)
+        response = transport_helpers.transport_send_raw_json_rpc_request(sut_client, request)
 
         # Should be an error response
         if "error" not in response:
@@ -388,7 +388,7 @@ def test_error_consistency_across_methods(sut_client):
             request = message_utils.make_json_rpc_request(test["method"], params=test["params"], id=req_id)
 
             try:
-                response = transport_helpers.transport_send_json_rpc_request(sut_client, request)
+                response = transport_helpers.transport_send_raw_json_rpc_request(sut_client, request)
 
                 if "error" in response:
                     error_analysis = validate_json_rpc_error_structure(response)
@@ -483,7 +483,7 @@ def test_error_response_completeness(sut_client):
         req_id = message_utils.generate_request_id()
         request = message_utils.make_json_rpc_request(test_case["method"], params=test_case["params"], id=req_id)
 
-        response = transport_helpers.transport_send_json_rpc_request(sut_client, request)
+        response = transport_helpers.transport_send_raw_json_rpc_request(sut_client, request)
 
         if "error" not in response:
             logger.warning(f"⚠️ {test_case['name']}: No error returned")

--- a/tests/utils/transport_helpers.py
+++ b/tests/utils/transport_helpers.py
@@ -394,6 +394,39 @@ def get_client_transport_type(client: Any) -> str:
         return "unknown"
 
 
+def transport_send_raw_json_rpc_request(
+    client: BaseTransportClient, req: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Send a raw JSON-RPC request dict using any transport client.
+
+    Internal helper function.
+
+    Args:
+        client: Transport client
+        req: JSON-RPC request dict
+
+    Returns:
+        JSON-RPC response from the server
+
+    Specification Reference: A2A v0.3.0 §3.2.1 - JSON-RPC 2.0 Transport
+    """
+    # Check if client has raw JSON-RPC support (preferred for arbitrary methods)
+    if hasattr(client, "send_raw_json_rpc"):
+        logger.debug(f"Using send_raw_json_rpc for method {req.get('method')}")
+        try:
+            return client.send_raw_json_rpc(req)
+        except Exception as e:
+            # Handle transport-specific JSON-RPC error exceptions
+            if hasattr(e, "json_rpc_error") and e.json_rpc_error:
+                # Return error in JSON-RPC format for consistency
+                return {"error": e.json_rpc_error, "id": req.get("id")}
+            raise
+
+    # Fallback for other transport implementations
+    else:
+        raise ValueError(f"Client {type(client)} does not support arbitrary JSON-RPC requests")
+
+
 def transport_send_json_rpc_request(
     client: BaseTransportClient, method: str, params: Optional[Dict[str, Any]] = None, id: Optional[str] = None
 ) -> Dict[str, Any]:
@@ -417,21 +450,8 @@ def transport_send_json_rpc_request(
     # Create JSON-RPC request
     req = message_utils.make_json_rpc_request(method, params=params, id=id)
 
-    # Check if client has raw JSON-RPC support (preferred for arbitrary methods)
-    if hasattr(client, "send_raw_json_rpc"):
-        logger.debug(f"Using send_raw_json_rpc for method {method}")
-        try:
-            return client.send_raw_json_rpc(req)
-        except Exception as e:
-            # Handle transport-specific JSON-RPC error exceptions
-            if hasattr(e, "json_rpc_error") and e.json_rpc_error:
-                # Return error in JSON-RPC format for consistency
-                return {"error": e.json_rpc_error, "id": req.get("id")}
-            raise
-
-    # Fallback for other transport implementations
-    else:
-        raise ValueError(f"Client {type(client)} does not support arbitrary JSON-RPC requests")
+    # Delegate to the internal helper
+    return transport_send_raw_json_rpc_request(client, req)
 
 
 def transport_set_push_notification_config(


### PR DESCRIPTION
  Update REST and JSON-RPC clients to align with A2A Protocol specification v1.0.0:
  - Remove v1/ prefix from REST endpoint URLs
  - Update JSON-RPC method name to GetExtendedAgentCard
  - Update User-Agent version to 1.0.0
  - Fix tests to handle nested task structure in responses
  - Remove deprecated 'kind' field from task assertions
  - Remove deprecated 'url' field from agent card validation
