### PR TITLE
fix: Add the mandatory marker to the mandatory category

### DIFF
--- a/run_tck.py
+++ b/run_tck.py
@@ -154,7 +154,7 @@ def run_test_category(
     category_configs = {
         "mandatory": {
             "path": "tests/mandatory/",
-            "markers": "mandatory_jsonrpc or mandatory_protocol",
+            "markers": "mandatory or mandatory_jsonrpc or mandatory_protocol",
             "description": "Mandatory A2A compliance tests",
         },
         "capabilities": {
@@ -214,7 +214,7 @@ def run_test_category(
         # If jsonrpc is not requested, exclude JSON-RPC compliance tests
         if "jsonrpc" not in norm:
             effective_path = "tests/mandatory/protocol/"
-            effective_markers = "mandatory_protocol"
+            effective_markers = "mandatory or mandatory_protocol"
 
     # Build pytest command
     cmd = [


### PR DESCRIPTION
Only the tests marked with `mandatory_jsonrpc` or `mandatory_protocol` were run when the `mandatory` category is selected.
However there are a bunch of tests that are marked with the `mandatory` marker that were deselected.

* Before: `30 passed, 3 skipped, 67 deselected `
* After:  `5 failed, 41 passed, 44 skipped, 10 deselected`