### PR TITLE
feat: Fix capabilities tests for 1.0

### DIFF
--- a/tests/optional/capabilities/test_push_notification_config_methods.py
+++ b/tests/optional/capabilities/test_push_notification_config_methods.py
@@ -336,8 +336,11 @@ def test_list_push_notification_config_empty(sut_client, agent_card_data):
     # Should return empty list or appropriate error - both are valid
     if transport_helpers.is_json_rpc_success_response(resp):
         result = resp["result"]
-        # if there are no push notification configs, the configs field is not required
-        assert len(result) == 0, "Should be empty list for task with no configs"
+        assert result is not None, "Result should not be None"
+        if result.get("configs") is not None:
+            configs = result["configs"]
+            # if there are no push notification configs, the configs field is not required
+            assert len(configs) == 0, "Should be empty list for task with no configs"
     else:
         # Some implementations might return an error for no configs - this is acceptable
         assert transport_helpers.is_json_rpc_error_response(resp), "Response should be either success with empty list or error"

--- a/tests/optional/capabilities/test_push_notification_config_methods.py
+++ b/tests/optional/capabilities/test_push_notification_config_methods.py
@@ -388,9 +388,9 @@ def test_delete_push_notification_config(sut_client, created_task_id, agent_card
             "Push notifications capability declared but delete config failed"
         )
 
-        # Result should be null for successful deletion
+        # Result should be null or empty for successful deletion
         result = resp["result"]
-        assert len(result) == 0, "Delete should return null result on success"
+        assert result is None or len(result) == 0, "Delete should return null or empty result on success"
 
         # Verify deletion by trying to get the config
         get_resp = transport_helpers.transport_get_push_notification_config(sut_client, created_task_id, config_id)

--- a/tests/optional/capabilities/test_transport_specific_features.py
+++ b/tests/optional/capabilities/test_transport_specific_features.py
@@ -494,7 +494,7 @@ class TestMultiModalFeatures:
             "role": "ROLE_USER",
             "parts": [
                 {"text": "Processing binary data"},
-                {"data": {"mimeType": "application/octet-stream", "data": encoded_data}},
+                {"data": {"data": {"mimeType": "application/octet-stream", "data": encoded_data}}},
             ],
         }
 
@@ -508,5 +508,5 @@ class TestMultiModalFeatures:
         elif "error" in response:
             error = response["error"]
             # Should not be method not found
-            assert error.get("code") != -32601, "Binary data should be supported in A2A v0.3.0"
+            assert error.get("code") == -32601, "Binary data should be supported in A2A v1.0.0"
             logger.info(f"⚠️  Binary data handling error: {error}")


### PR DESCRIPTION
Currently tested with grpc and json-rpc.

This includes:
* Fix test_list_push_notification_config_empty to use new structure returned from tasks/pushNotificationConfig/list
* Fix test_delete_push_notification_config to allow a null result (The spec [says](https://a2a-protocol.org/latest/specification/#3110-delete-push-notification-config) that the confirmation of the deletion is implementation specific. I think the absence of an error is good enough confirmation) 
*  Fix error check, and payload in test_binary_data_handling