### PR TITLE
feat: add markers to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+unmarked_tests_report.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/tests/mandatory/protocol/test_agent_card_mandatory.py
+++ b/tests/mandatory/protocol/test_agent_card_mandatory.py
@@ -10,6 +10,7 @@ import pytest
 
 from tck import agent_card_utils
 from tck.sut_client import SUTClient
+from tests.markers import mandatory
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +41,7 @@ def fetched_agent_card(sut_client, agent_card_data):
 
     return agent_card
 
-
+@mandatory
 def test_agent_card_mandatory_fields(fetched_agent_card):
     """
     MANDATORY: A2A Specification §5.5 - AgentCard Required Fields
@@ -74,7 +75,7 @@ def test_agent_card_mandatory_fields(fetched_agent_card):
         assert field in fetched_agent_card, f"Required field '{field}' missing from Agent Card"
         assert fetched_agent_card[field] is not None, f"Required field '{field}' cannot be null"
 
-
+@mandatory
 def test_agent_card_capabilities_mandatory(fetched_agent_card):
     """
     MANDATORY: A2A Specification §5.5.2 - AgentCapabilities Field Required
@@ -97,7 +98,7 @@ def test_agent_card_capabilities_mandatory(fetched_agent_card):
     assert capabilities is not None, "capabilities field cannot be null"
     assert isinstance(capabilities, dict), "capabilities must be an object"
 
-
+@mandatory
 def test_agent_card_skills_mandatory(fetched_agent_card):
     """
     MANDATORY: A2A Specification §5.5.6 - Skills Array Required
@@ -131,7 +132,7 @@ def test_agent_card_skills_mandatory(fetched_agent_card):
             assert field in skill, f"skill at index {i} missing required field '{field}'"
             assert skill[field] is not None, f"skill at index {i} field '{field}' cannot be null"
 
-
+@mandatory
 def test_agent_card_input_output_modes_mandatory(fetched_agent_card):
     """
     MANDATORY: A2A Specification §5.5.3/5.5.4 - Input/Output Modes Required
@@ -167,7 +168,7 @@ def test_agent_card_input_output_modes_mandatory(fetched_agent_card):
         assert isinstance(mode, str), f"defaultOutputModes[{i}] must be a string"
         assert mode.strip(), f"defaultOutputModes[{i}] cannot be empty"
 
-
+@mandatory
 def test_agent_card_basic_info_mandatory(fetched_agent_card):
     """
     MANDATORY: A2A Specification §5.5.1 - Basic Agent Information Required

--- a/tests/optional/multi_transport/test_functional_equivalence.py
+++ b/tests/optional/multi_transport/test_functional_equivalence.py
@@ -41,7 +41,7 @@ def sample_message():
 
 
 @pytest.fixture
-def test_task_data(sut_client, sample_message):
+def task_data(sut_client, sample_message):
     """Create a task for cross-transport testing."""
     params = {"message": sample_message}
     resp = transport_send_message(sut_client, params)
@@ -102,7 +102,7 @@ def test_identical_functionality_message_send(all_transport_clients, sample_mess
 
 
 @transport_equivalence
-def test_identical_functionality_tasks_get(all_transport_clients, test_task_data):
+def test_identical_functionality_tasks_get(all_transport_clients, task_data):
     """
     TRANSPORT EQUIVALENCE: A2A v0.3.0 §3.4.1 - Identical Functionality for tasks/get
 
@@ -114,7 +114,7 @@ def test_identical_functionality_tasks_get(all_transport_clients, test_task_data
     if len(all_transport_clients) < 2:
         pytest.skip("Functional equivalence requires multiple transport implementations")
 
-    task_id = test_task_data["task_id"]
+    task_id = task_data["task_id"]
 
     # Test that all transports support tasks/get
     for transport_type, client in all_transport_clients.items():
@@ -213,7 +213,7 @@ def test_consistent_behavior_message_send(all_transport_clients, sample_message)
 
 
 @transport_equivalence
-def test_consistent_behavior_tasks_get(all_transport_clients, test_task_data):
+def test_consistent_behavior_tasks_get(all_transport_clients, task_data):
     """
     TRANSPORT EQUIVALENCE: A2A v0.3.0 §3.4.1 - Consistent Behavior for tasks/get
 
@@ -225,7 +225,7 @@ def test_consistent_behavior_tasks_get(all_transport_clients, test_task_data):
     if len(all_transport_clients) < 2:
         pytest.skip("Functional equivalence requires multiple transport implementations")
 
-    task_id = test_task_data["task_id"]
+    task_id = task_data["task_id"]
     results = []
     transport_types = []
 
@@ -279,7 +279,7 @@ def test_consistent_behavior_tasks_get(all_transport_clients, test_task_data):
 
 
 @transport_equivalence
-def test_identical_functionality_tasks_cancel(all_transport_clients, test_task_data):
+def test_identical_functionality_tasks_cancel(all_transport_clients, task_data):
     """
     TRANSPORT EQUIVALENCE: A2A v0.3.0 §3.4.1 - Identical Functionality for CancelTask
 
@@ -291,7 +291,7 @@ def test_identical_functionality_tasks_cancel(all_transport_clients, test_task_d
     if len(all_transport_clients) < 2:
         pytest.skip("Functional equivalence requires multiple transport implementations")
 
-    task_id = test_task_data["task_id"]
+    task_id = task_data["task_id"]
 
     # Test that all transports support tasks/cancel
     for transport_type, client in all_transport_clients.items():
@@ -323,7 +323,7 @@ def test_identical_functionality_tasks_cancel(all_transport_clients, test_task_d
 
 
 @transport_equivalence
-def test_consistent_behavior_tasks_cancel(all_transport_clients, test_task_data):
+def test_consistent_behavior_tasks_cancel(all_transport_clients, task_data):
     """
     TRANSPORT EQUIVALENCE: A2A v0.3.0 §3.4.1 - Consistent Behavior for tasks/cancel
 
@@ -335,7 +335,7 @@ def test_consistent_behavior_tasks_cancel(all_transport_clients, test_task_data)
     if len(all_transport_clients) < 2:
         pytest.skip("Functional equivalence requires multiple transport implementations")
 
-    task_id = test_task_data["task_id"]
+    task_id = task_data["task_id"]
     results = []
     transport_types = []
 
@@ -533,7 +533,7 @@ def test_same_error_handling_invalid_params(all_transport_clients):
 
 
 @transport_equivalence
-def test_same_error_handling_task_not_cancelable(all_transport_clients, test_task_data):
+def test_same_error_handling_task_not_cancelable(all_transport_clients, task_data):
     """
     TRANSPORT EQUIVALENCE: A2A v0.3.0 §3.4.1 - Same Error Handling for TaskNotCancelableError
 
@@ -545,7 +545,7 @@ def test_same_error_handling_task_not_cancelable(all_transport_clients, test_tas
     if len(all_transport_clients) < 2:
         pytest.skip("Functional equivalence requires multiple transport implementations")
 
-    task_id = test_task_data["task_id"]
+    task_id = task_data["task_id"]
     error_responses = []
     transport_types = []
 
@@ -866,7 +866,7 @@ def test_identical_functionality_message_stream(all_transport_clients, sample_me
 
 
 @transport_equivalence
-def test_identical_functionality_tasks_resubscribe(all_transport_clients, test_task_data):
+def test_identical_functionality_tasks_resubscribe(all_transport_clients, task_data):
     """
     TRANSPORT EQUIVALENCE: A2A v0.3.0 §3.4.1 - Identical Functionality for tasks/resubscribe
 
@@ -880,7 +880,7 @@ def test_identical_functionality_tasks_resubscribe(all_transport_clients, test_t
     if len(all_transport_clients) < 2:
         pytest.skip("Functional equivalence requires multiple transport implementations")
 
-    task_id = test_task_data["task_id"]
+    task_id = task_data["task_id"]
     resubscribe_transports = []
 
     # Test that streaming-capable transports support tasks/resubscribe

--- a/util_scripts/README.md
+++ b/util_scripts/README.md
@@ -20,6 +20,13 @@ Downloads and updates the local baseline specification files (`current_spec/`) t
 *   **Usage**: `util_scripts/update_current_spec.py [options]`
 *   **Detailed Documentation**: See the [Specification Update Workflow](../docs/SPEC_UPDATE_WORKFLOW.md).
 
+### `find_unmarked_tests.py`
+
+Check all tests that are without pytest markers and reports them in a `unmarked_tests_report.txt` file.
+This script is typically run after adding new tests to the TCK to verify they belong to the appropriate categories.
+
+*   **Usage**: `util_scripts/find_unmarked_tests.py`
+
 ## Internal Modules
 
 The following files are not intended to be executed directly. They are modules imported by other scripts (`run_tck.py`).

--- a/util_scripts/find_unmarked_tests.py
+++ b/util_scripts/find_unmarked_tests.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Find all test functions in the tests directory that don't have pytest markers.
+"""
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+import sys
+from typing import List, Tuple, Set
+
+def _is_pytest_mark_attribute(node: ast.AST) -> bool:
+    """Checks if an AST node represents a `pytest.mark.*` attribute."""
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Attribute)
+        and isinstance(node.value.value, ast.Name)
+        and node.value.value.id == "pytest"
+        and node.value.attr == "mark"
+    )
+
+
+def extract_marker_names(markers_file: Path) -> Set[str]:
+    """Extract all marker names defined in tests/markers.py."""
+    marker_names = set()
+
+    try:
+        with open(markers_file, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        tree = ast.parse(content)
+
+        for node in ast.walk(tree):
+            # Look for assignments like: mandatory = pytest.mark.mandatory
+            if not isinstance(node, ast.Assign):
+                continue
+
+            value_node = node.value
+            # Check if the value is of the form `pytest.mark.*`
+            if not _is_pytest_mark_attribute(value_node):
+                continue
+
+            # Get the variable name being assigned
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    marker_names.add(target.id)
+    except (OSError, SyntaxError) as e:
+        print(f"Warning: Could not parse markers file: {e}")
+
+    return marker_names
+
+
+def has_pytest_marker(node: ast.FunctionDef, known_markers: Set[str]) -> bool:
+    """Check if a function has any pytest.mark decorators or custom markers."""
+    for decorator in node.decorator_list:
+        # If the decorator is a call, e.g., @marker(), get the function part.
+        decorator_obj = decorator.func if isinstance(decorator, ast.Call) else decorator
+
+        # Check for custom markers like @mandatory or @mandatory()
+        if isinstance(decorator_obj, ast.Name) and decorator_obj.id in known_markers:
+            return True
+
+        # Check for standard pytest markers like @pytest.mark.foo
+        if _is_pytest_mark_attribute(decorator_obj):
+            return True
+
+    return False
+
+
+def find_unmarked_tests(file_path: Path, known_markers: Set[str]) -> List[Tuple[str, int]]:
+    """Find all test functions without markers in a file."""
+    unmarked_tests = []
+
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        tree = ast.parse(content, filename=str(file_path))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                # Check if it's a test function
+                if node.name.startswith('test_'):
+                    # Check if it has any pytest markers
+                    if not has_pytest_marker(node, known_markers):
+                        unmarked_tests.append((node.name, node.lineno))
+
+    except (OSError, SyntaxError) as e:
+        print(f"Error processing {file_path}: {e}")
+
+    return unmarked_tests
+
+
+def main():
+    """Main function to find all unmarked tests."""
+    tests_dir = Path("tests")
+    report_file = Path("unmarked_tests_report.txt")
+
+    if not tests_dir.exists():
+        print(f"Error: {tests_dir} directory not found")
+        sys.exit(1)
+
+    # Open the report file for writing
+    with open(report_file, 'w', encoding='utf-8') as f:
+        def write_line(line: str = ""):
+            """Helper to write to both console and file."""
+            print(line)
+            f.write(line + "\n")
+
+        # Extract known marker names from tests/markers.py
+        markers_file = tests_dir / "markers.py"
+        known_markers = set()
+
+        if markers_file.exists():
+            known_markers = extract_marker_names(markers_file)
+            write_line(f"Found {len(known_markers)} custom markers in tests/markers.py:")
+            write_line(f"  {', '.join(sorted(known_markers))}")
+            write_line()
+        else:
+            write_line(f"Warning: {markers_file} not found, will only detect @pytest.mark.* decorators")
+            write_line()
+
+        # Find all test files
+        test_files = list(tests_dir.glob("**/test_*.py"))
+
+        write_line(f"Scanning {len(test_files)} test files...")
+        write_line()
+
+        total_unmarked = 0
+        files_with_unmarked = []
+
+        for test_file in sorted(test_files):
+            unmarked = find_unmarked_tests(test_file, known_markers)
+
+            if unmarked:
+                total_unmarked += len(unmarked)
+                files_with_unmarked.append((test_file, unmarked))
+
+                # Print results for this file
+                rel_path = test_file.relative_to(tests_dir.parent)
+                write_line(f"📄 {rel_path}")
+                write_line(f"   Found {len(unmarked)} unmarked test(s):")
+                for test_name, lineno in unmarked:
+                    write_line(f"   - {test_name} (line {lineno})")
+                write_line()
+
+        # Summary
+        write_line("=" * 70)
+        write_line(f"Summary:")
+        write_line(f"  Total test files scanned: {len(test_files)}")
+        write_line(f"  Files with unmarked tests: {len(files_with_unmarked)}")
+        write_line(f"  Total unmarked tests: {total_unmarked}")
+        write_line("=" * 70)
+
+        # Group by directory
+        if files_with_unmarked:
+            write_line()
+            write_line("Unmarked tests by directory:")
+            by_dir = defaultdict(int)
+            for file_path, unmarked in files_with_unmarked:
+                dir_name = file_path.parent.relative_to(tests_dir.parent)
+                by_dir[dir_name] += len(unmarked)
+
+            for dir_name in sorted(by_dir.keys()):
+                write_line(f"  {dir_name}: {by_dir[dir_name]} unmarked test(s)")
+
+    print(f"\nReport saved to: {report_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Some TCK tests were missing markers and were not taken into account when it is running.

create util_scripts/find_unmarked_tests.py to identify tests with missing markers