### PR TITLE
feat: remove v1 from REST endpoints

### DIFF
--- a/tests/mandatory/protocol/test_a2a_v030_new_methods.py
+++ b/tests/mandatory/protocol/test_a2a_v030_new_methods.py
@@ -95,7 +95,7 @@ class TestAuthenticatedExtendedCard:
                 assert "authentication" in str(e).lower() or "unauthorized" in str(e).lower()
 
         elif transport_type == "rest":
-            # REST: GET /v1/card
+            # REST: GET /card
             try:
                 response = sut_client.get_extended_agent_card()
                 assert response is not None
@@ -285,9 +285,9 @@ class TestMethodMappingCompliance:
         A2A v0.3.0 Specification Reference: §3.5.6 Method Mapping Reference Table
 
         Validates mapping for:
-        - SendMessage → SendMessage → POST /v1/message:send
-        - tasks/get → GetTask → GET /v1/tasks/{id}
-        - tasks/cancel → CancelTask → POST /v1/tasks/{id}:cancel
+        - SendMessage → SendMessage → POST /message:send
+        - tasks/get → GetTask → GET /tasks/{id}
+        - tasks/cancel → CancelTask → POST /tasks/{id}:cancel
         """
         transport_type = get_client_transport_type(sut_client)
 
@@ -335,7 +335,7 @@ class TestMethodMappingCompliance:
         Validates:
         - JSON-RPC: PascalCase compound words
         - gRPC: PascalCase compound words
-        - REST: /v1/{resource}[/{id}][:{action}] pattern
+        - REST: /{resource}[/{id}][:{action}] pattern
         """
         transport_type = get_client_transport_type(sut_client)
 
@@ -353,8 +353,8 @@ class TestMethodMappingCompliance:
             if hasattr(sut_client, "_get_url_patterns"):
                 url_patterns = sut_client._get_url_patterns()
                 for pattern in url_patterns.values():
-                    # Should start with /v1/
-                    assert pattern.startswith("/v1/"), f"REST URL {pattern} should start with /v1/"
+                    # Should start with /
+                    assert pattern.startswith("/"), f"REST URL {pattern} should start with /"
 
                     # Should follow resource-based pattern
                     if ":send" in pattern:
@@ -436,7 +436,7 @@ class TestTransportSpecificFeatures:
         # Test HTTP caching headers
         if hasattr(sut_client, "get_with_caching"):
             try:
-                response = sut_client.get_with_caching("/v1/card")
+                response = sut_client.get_with_caching("/card")
 
                 # Should include caching headers
                 headers = getattr(response, "headers", {})

--- a/tests/mandatory/protocol/test_extended_agent_card.py
+++ b/tests/mandatory/protocol/test_extended_agent_card.py
@@ -3,7 +3,7 @@ A2A v0.3.0 Protocol: Mandatory Extended Agent Card Tests
 
 SPECIFICATION REQUIREMENTS (Section 7.10):
 - agent/getAuthenticatedExtendedCard JSON-RPC method, or GetAgentCard gRPC
-  method or v1/card JSON+HTTP endpoint MUST be available when declared
+  method or /card JSON+HTTP endpoint MUST be available when declared
 - Client MUST authenticate using declared security schemes
 - Server SHOULD include WWW-Authenticate header on 401 responses
 - Clients SHOULD replace cached Agent Card with extended card content
@@ -60,11 +60,11 @@ def get_extended_card_url(base_url: str) -> str:
     """
     Construct the extended Agent Card URL according to A2A v0.3.0 specification.
 
-    Per Section 7.10: The endpoint URL is {AgentCard.url}/v1/card
+    Per Section 7.10: The endpoint URL is {AgentCard.url}/card
     relative to the base URL specified in the public Agent Card.
     """
     parsed = urllib.parse.urlparse(base_url)
-    extended_path = f"{parsed.path}/v1/card"
+    extended_path = f"{parsed.path}/card"
 
     # Reconstruct the URL
     extended_url = urllib.parse.urlunparse(

--- a/tests/optional/capabilities/test_transport_specific_features.py
+++ b/tests/optional/capabilities/test_transport_specific_features.py
@@ -298,10 +298,10 @@ class TestRESTSpecificFeatures:
 
         # REST HTTP verb mapping tests
         verb_mappings = {
-            "POST": ["/v1/messages", "/v1/tasks/{id}/cancel"],
-            "GET": ["/v1/tasks/{id}", "/v1/agent/card"],
-            "PUT": ["/v1/tasks/{id}/pushNotificationConfig"],
-            "DELETE": ["/v1/tasks/{id}/pushNotificationConfig"],
+            "POST": ["/messages", "/tasks/{id}/cancel"],
+            "GET": ["/tasks/{id}", "/agent/card"],
+            "PUT": ["/tasks/{id}/pushNotificationConfig"],
+            "DELETE": ["/tasks/{id}/pushNotificationConfig"],
         }
 
         logger.info("⚪ REST HTTP verb mapping test requires REST client implementation")

--- a/tests/unit/transport/test_rest_client.py
+++ b/tests/unit/transport/test_rest_client.py
@@ -221,7 +221,7 @@ class TestRESTClientSendMessage:
 
             # Verify correct URL and payload were used
             mock_post.assert_called_once_with(
-                "https://example.com:8080/v1/message:send", json={"message": message}, headers=client.default_headers
+                "https://example.com:8080/message:send", json={"message": message}, headers=client.default_headers
             )
 
             # Verify result
@@ -253,7 +253,7 @@ class TestRESTClientSendMessage:
             expected_headers.update(extra_headers)
 
             mock_post.assert_called_once_with(
-                "https://example.com:8080/v1/message:send", json={"message": message}, headers=expected_headers
+                "https://example.com:8080/message:send", json={"message": message}, headers=expected_headers
             )
 
     @patch("httpx.Client.post")
@@ -284,7 +284,7 @@ class TestRESTClientSendMessage:
             }
 
             mock_post.assert_called_once_with(
-                "https://example.com:8080/v1/message:send", json=expected_payload, headers=client.default_headers
+                "https://example.com:8080/message:send", json=expected_payload, headers=client.default_headers
             )
 
     @patch("httpx.Client.post")
@@ -398,7 +398,7 @@ class TestRESTClientStreamingMessage:
         # Verify correct URL and headers were used
         mock_async_client.stream.assert_called_once_with(
             "POST",
-            "https://example.com:8080/v1/message:stream",
+            "https://example.com:8080/message:stream",
             json={"message": message},
             headers={**client.default_headers, "Accept": "text/event-stream"},
         )
@@ -508,7 +508,7 @@ class TestRESTClientTaskOperations:
 
             result = client.get_task("task-123")
 
-            mock_get.assert_called_once_with("https://example.com:8080/v1/tasks/task-123", params={}, headers=client.default_headers)
+            mock_get.assert_called_once_with("https://example.com:8080/tasks/task-123", params={}, headers=client.default_headers)
 
             assert result["id"] == "task-123"
             assert result["context_id"] == "default-context"
@@ -532,7 +532,7 @@ class TestRESTClientTaskOperations:
             client.get_task("task-123", history_length=10)
 
             mock_get.assert_called_once_with(
-                "https://example.com:8080/v1/tasks/task-123", params={"history_length": 10}, headers=client.default_headers
+                "https://example.com:8080/tasks/task-123", params={"history_length": 10}, headers=client.default_headers
             )
 
     @patch("httpx.Client.post")
@@ -562,7 +562,7 @@ class TestRESTClientTaskOperations:
 
             result = client.cancel_task("task-456")
 
-            mock_post.assert_called_once_with("https://example.com:8080/v1/tasks/task-456:cancel", headers=client.default_headers)
+            mock_post.assert_called_once_with("https://example.com:8080/tasks/task-456:cancel", headers=client.default_headers)
 
             assert result["id"] == "task-456"
             assert result["status"]["state"] == "TASK_STATE_CANCELLED"
@@ -618,7 +618,7 @@ class TestRESTClientTaskOperations:
         # Verify correct URL and headers were used
         mock_async_client.stream.assert_called_once_with(
             "GET",
-            "https://example.com:8080/v1/tasks/task-789:subscribe",
+            "https://example.com:8080/tasks/task-789:subscribe",
             headers={**client.default_headers, "Accept": "text/event-stream"},
         )
 
@@ -657,7 +657,7 @@ class TestRESTClientAgentCard:
             expected_headers = client.default_headers.copy()
             expected_headers.update(auth_headers)
 
-            mock_get.assert_called_once_with("https://example.com:8080/v1/card", headers=expected_headers)
+            mock_get.assert_called_once_with("https://example.com:8080/card", headers=expected_headers)
 
             assert result["name"] == "A2A REST Test Agent (Extended)"
             assert result["capabilities"]["authenticated_features"] is True
@@ -696,7 +696,7 @@ class TestRESTClientPushNotifications:
             result = client.set_push_notification_config("task-123", config)
 
             mock_post.assert_called_once_with(
-                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs", json=config, headers=client.default_headers
+                "https://example.com:8080/tasks/task-123/pushNotificationConfigs", json=config, headers=client.default_headers
             )
 
             assert result["push_notification_config"]["id"] == "config1"
@@ -727,7 +727,7 @@ class TestRESTClientPushNotifications:
             result = client.get_push_notification_config("task-123", "config1")
 
             mock_get.assert_called_once_with(
-                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs/config1", headers=client.default_headers
+                "https://example.com:8080/tasks/task-123/pushNotificationConfigs/config1", headers=client.default_headers
             )
 
             assert result["push_notification_config"]["id"] == "config1"
@@ -762,7 +762,7 @@ class TestRESTClientPushNotifications:
             result = client.list_push_notification_configs("task-123")
 
             mock_get.assert_called_once_with(
-                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs", headers=client.default_headers
+                "https://example.com:8080/tasks/task-123/pushNotificationConfigs", headers=client.default_headers
             )
 
             assert len(result["configs"]) == 2
@@ -787,7 +787,7 @@ class TestRESTClientPushNotifications:
             result = client.delete_push_notification_config("task-123", "config1")
 
             mock_delete.assert_called_once_with(
-                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs/config1", headers=client.default_headers
+                "https://example.com:8080/tasks/task-123/pushNotificationConfigs/config1", headers=client.default_headers
             )
 
             assert result == {}  # Empty response for successful deletion

--- a/tests/validators/a2a_v030_compliance.py
+++ b/tests/validators/a2a_v030_compliance.py
@@ -168,15 +168,15 @@ class TransportComplianceValidator:
         """
         result = {
             "required_methods": [
-                "send_message",  # POST /v1/message:send
-                "get_task",  # GET /v1/tasks/{id}
-                "cancel_task",  # POST /v1/tasks/{id}:cancel
-                "get_extended_agent_card",  # GET /v1/card
-                "list_tasks",  # GET /v1/tasks (gRPC/REST specific)
+                "send_message",  # POST /message:send
+                "get_task",  # GET /tasks/{id}
+                "cancel_task",  # POST /tasks/{id}:cancel
+                "get_extended_agent_card",  # GET /extendedAgentCard
+                "list_tasks",  # GET /tasks (gRPC/REST specific)
             ],
             "optional_methods": [
-                "send_streaming_message",  # POST /v1/message:stream
-                "subscribe_to_task",  # POST /v1/tasks/{id}:subscribe
+                "send_streaming_message",  # POST /message:stream
+                "subscribe_to_task",  # POST /tasks/{id}:subscribe
             ],
             "transport_specific_features": [
                 "http_status_codes",  # Proper HTTP status codes
@@ -211,38 +211,38 @@ class MethodMappingValidator:
         "send_message": {
             "jsonrpc": "SendMessage",
             "grpc": "SendMessage",
-            "rest": "POST /v1/message:send",
+            "rest": "POST /message:send",
             "description": "Send message to agent",
         },
         "send_streaming_message": {
             "jsonrpc": "message/stream",
             "grpc": "SendStreamingMessage",
-            "rest": "POST /v1/message:stream",
+            "rest": "POST /message:stream",
             "description": "Send message with streaming",
         },
-        "get_task": {"jsonrpc": "tasks/get", "grpc": "GetTask", "rest": "GET /v1/tasks/{id}", "description": "Get task status"},
+        "get_task": {"jsonrpc": "tasks/get", "grpc": "GetTask", "rest": "GET /tasks/{id}", "description": "Get task status"},
         "list_tasks": {
             "jsonrpc": None,  # Not available in JSON-RPC
             "grpc": "ListTask",
-            "rest": "GET /v1/tasks",
+            "rest": "GET /tasks",
             "description": "List tasks (gRPC/REST only)",
         },
         "cancel_task": {
             "jsonrpc": "tasks/cancel",
             "grpc": "CancelTask",
-            "rest": "POST /v1/tasks/{id}:cancel",
+            "rest": "POST /tasks/{id}:cancel",
             "description": "Cancel task",
         },
         "subscribe_to_task": {
             "jsonrpc": "SubscribeToTask",
             "grpc": "TaskSubscription",
-            "rest": "POST /v1/tasks/{id}:subscribe",
+            "rest": "POST /tasks/{id}:subscribe",
             "description": "Resume task streaming",
         },
         "get_extended_agent_card": {
             "jsonrpc": "getExtendedCard",
             "grpc": "GetExtendedAgentCard",
-            "rest": "GET /v1/extendedAgentCard",
+            "rest": "GET /extendedAgentCard",
             "description": "Get extended agent card",
         },
     }

--- a/tests/validators/method_mapping_validator.py
+++ b/tests/validators/method_mapping_validator.py
@@ -303,12 +303,12 @@ class MethodMappingValidator:
         """
         Validate REST endpoint naming conventions (§3.5.3).
 
-        REST endpoints MUST follow /v1/{resource}[/{id}][:{action}] pattern.
+        REST endpoints MUST follow /{resource}[/{id}][:{action}] pattern.
         """
         results = {
             "transport": "rest",
             "compliant": True,
-            "naming_convention": "/v1/{resource}[/{id}][:{action}]",
+            "naming_convention": "/{resource}[/{id}][:{action}]",
             "violations": [],
             "valid_endpoints": [],
         }
@@ -336,13 +336,13 @@ class MethodMappingValidator:
         return bool(re.match(pattern, method))
 
     def _validate_rest_endpoint_pattern(self, endpoint: str) -> bool:
-        """Validate REST endpoint follows /v1/{resource} pattern."""
-        # Must start with /v1/
-        if not endpoint.startswith("/v1/"):
+        """Validate REST endpoint follows /{resource} pattern."""
+        # Must start with /
+        if not endpoint.startswith("/"):
             return False
 
         # Should follow resource-based pattern
-        pattern = r"^/v1/[a-z]+(/\{[a-zA-Z]+\}|:[a-z]+)?$"
+        pattern = r"^/[a-z]+(/\{[a-zA-Z]+\}|:[a-z]+)?$"
         return bool(re.match(pattern, endpoint))
 
     def _get_available_jsonrpc_methods(self, client: JSONRPCClient) -> List[str]:


### PR DESCRIPTION
The `v1` prefix has been removed from the spec in https://github.com/a2aproject/A2A/pull/1383
