### PR TITLE
refactor: update tests related to extendedAgentCard

### DIFF
--- a/tck/transport/base_client.py
+++ b/tck/transport/base_client.py
@@ -392,8 +392,8 @@ class BaseTransportClient(ABC):
             headers.update(extra_headers)
             if "A2A_TCK_DONT_USE_AUTH" in extra_headers:
                 # remove the auth headers
-                headers = {k: v for k, v in headers if k not in auth_headers}
-
+                headers = {k: v for k, v in headers.items() if k not in auth_headers}
+                del headers["A2A_TCK_DONT_USE_AUTH"]
         return headers
 
     def get_transport_info(self) -> Dict[str, Any]:

--- a/tests/mandatory/protocol/test_a2a_v030_new_methods.py
+++ b/tests/mandatory/protocol/test_a2a_v030_new_methods.py
@@ -95,7 +95,7 @@ class TestAuthenticatedExtendedCard:
                 assert "authentication" in str(e).lower() or "unauthorized" in str(e).lower()
 
         elif transport_type == "rest":
-            # REST: GET /v1/card
+            # REST: GET /card
             try:
                 response = sut_client.get_extended_agent_card()
                 assert response is not None
@@ -285,9 +285,9 @@ class TestMethodMappingCompliance:
         A2A v0.3.0 Specification Reference: §3.5.6 Method Mapping Reference Table
 
         Validates mapping for:
-        - SendMessage → SendMessage → POST /v1/message:send
-        - tasks/get → GetTask → GET /v1/tasks/{id}
-        - tasks/cancel → CancelTask → POST /v1/tasks/{id}:cancel
+        - SendMessage → SendMessage → POST /message:send
+        - tasks/get → GetTask → GET /tasks/{id}
+        - tasks/cancel → CancelTask → POST /tasks/{id}:cancel
         """
         transport_type = get_client_transport_type(sut_client)
 
@@ -335,7 +335,7 @@ class TestMethodMappingCompliance:
         Validates:
         - JSON-RPC: PascalCase compound words
         - gRPC: PascalCase compound words
-        - REST: /v1/{resource}[/{id}][:{action}] pattern
+        - REST: /{resource}[/{id}][:{action}] pattern
         """
         transport_type = get_client_transport_type(sut_client)
 
@@ -353,8 +353,8 @@ class TestMethodMappingCompliance:
             if hasattr(sut_client, "_get_url_patterns"):
                 url_patterns = sut_client._get_url_patterns()
                 for pattern in url_patterns.values():
-                    # Should start with /v1/
-                    assert pattern.startswith("/v1/"), f"REST URL {pattern} should start with /v1/"
+                    # Should start with /
+                    assert pattern.startswith("/"), f"REST URL {pattern} should start with /"
 
                     # Should follow resource-based pattern
                     if ":send" in pattern:
@@ -436,7 +436,7 @@ class TestTransportSpecificFeatures:
         # Test HTTP caching headers
         if hasattr(sut_client, "get_with_caching"):
             try:
-                response = sut_client.get_with_caching("/v1/card")
+                response = sut_client.get_with_caching("/card")
 
                 # Should include caching headers
                 headers = getattr(response, "headers", {})

--- a/tests/mandatory/protocol/test_a2a_v030_new_methods.py
+++ b/tests/mandatory/protocol/test_a2a_v030_new_methods.py
@@ -31,16 +31,15 @@ from tests.utils.transport_helpers import (
     transport_get_task,
     transport_cancel_task,
     transport_get_extended_agent_card,
-    is_transport_client,
     get_client_transport_type,
     generate_test_message_id,
 )
 
 logger = logging.getLogger(__name__)
 
-class TestAuthenticatedExtendedCard:
+class TestExtendedAgentCard:
     """
-    Test suite for agent/getAuthenticatedExtendedCard method (§7.10)
+    Test suite for GetExtendedAgentCard method (§7.10)
 
     Validates that SUTs correctly implement authenticated agent card retrieval
     with proper authentication requirements and extended card functionality.
@@ -49,9 +48,9 @@ class TestAuthenticatedExtendedCard:
     @pytest.mark.mandatory
     @pytest.mark.mandatory_protocol
     @pytest.mark.a2a_v030
-    def test_authenticated_extended_card_method_exists(self, sut_client: BaseTransportClient, agent_card_data):
+    def test_extended_agent_card_method_exists(self, sut_client: BaseTransportClient, agent_card_data):
         """
-        Test that agent/getAuthenticatedExtendedCard method exists and is callable.
+        Test that GetExtendedAgentCard method exists and is callable.
 
         A2A v0.3.0 Specification Reference: §7.10
         Transport Support: All transports (JSON-RPC, gRPC, REST)
@@ -61,9 +60,9 @@ class TestAuthenticatedExtendedCard:
         - Method follows correct naming conventions per transport
         - Authentication is properly enforced
         """
-        # Check if agent card supports authenticated extended card
-        if not agent_card_data.get("supportsAuthenticatedExtendedCard", False):
-            pytest.skip("SUT does not support authenticated extended card")
+        # Check if agent card supports extended agent card
+        if not agent_card_data.get("supportsExtendedAgentCard", False):
+            pytest.skip("SUT does not support extended card")
 
         # Test method existence based on transport type
         transport_type = get_client_transport_type(sut_client)
@@ -95,7 +94,7 @@ class TestAuthenticatedExtendedCard:
                 assert "authentication" in str(e).lower() or "unauthorized" in str(e).lower()
 
         elif transport_type == "rest":
-            # REST: GET /card
+            # REST: GET /extendedAgentCard
             try:
                 response = sut_client.get_extended_agent_card()
                 assert response is not None
@@ -103,113 +102,6 @@ class TestAuthenticatedExtendedCard:
             except Exception as e:
                 # Should get authentication error for unauthenticated request
                 assert "401" in str(e) or "403" in str(e) or "authentication" in str(e).lower()
-
-    @pytest.mark.mandatory
-    @pytest.mark.mandatory_protocol
-    @pytest.mark.a2a_v030
-    def test_authenticated_extended_card_without_auth(self, sut_client: BaseTransportClient, agent_card_data):
-        """
-        Test that agent/getAuthenticatedExtendedCard properly rejects unauthenticated requests.
-
-        A2A v0.3.0 Specification Reference: §7.10
-
-        Validates:
-        - Unauthenticated requests return 401 Unauthorized
-        - Proper WWW-Authenticate header is included (when applicable)
-        - Error response follows A2A error format
-        """
-        # Check if SUT supports authenticated extended card
-        if not agent_card_data.get("supportsAuthenticatedExtendedCard", False):
-            pytest.skip("SUT does not support authenticated extended card")
-
-        # Test without authentication credentials
-        transport_type = get_client_transport_type(sut_client)
-
-        if transport_type == "jsonrpc":
-            # Clear any existing authentication headers
-            original_headers = getattr(sut_client, "headers", {})
-            try:
-                if hasattr(sut_client, "headers"):
-                    # Remove auth headers temporarily
-                    auth_headers = ["authorization", "x-api-key", "authentication"]
-                    for header in auth_headers:
-                        sut_client.headers.pop(header, None)
-                        sut_client.headers.pop(header.title(), None)
-                        sut_client.headers.pop(header.upper(), None)
-
-                response = transport_get_extended_agent_card(sut_client)
-
-                # Should return error
-                assert "error" in response
-                error = response["error"]
-
-                # Should be authentication-related error
-                assert error["code"] in [-32007, -32603], f"Expected auth error, got: {error}"
-
-            finally:
-                # Restore original headers
-                if hasattr(sut_client, "headers"):
-                    sut_client.headers.update(original_headers)
-
-        else:
-            # For gRPC/REST, test without auth should fail
-            with pytest.raises(Exception) as exc_info:
-                sut_client.get_extended_agent_card()
-
-            error_msg = str(exc_info.value).lower()
-            assert any(keyword in error_msg for keyword in ["unauthorized", "authentication", "401", "403"]), (
-                f"Expected authentication error, got: {exc_info.value}"
-            )
-
-    @optional_capability
-    @a2a_v030
-    def test_authenticated_extended_card_with_auth(self, sut_client: BaseTransportClient, agent_card_data):
-        """
-        Test that agent/getAuthenticatedExtendedCard returns extended card with valid auth.
-
-        A2A v0.3.0 Specification Reference: §7.10 & §11.1.3
-
-        Validates:
-        - Authenticated requests return AgentCard object
-        - Extended card may contain additional details
-        - Response follows AgentCard schema
-
-        CAPABILITY-DEPENDENT: This test is MANDATORY if supportsAuthenticatedExtendedCard: true
-        is declared in the Agent Card, otherwise it's skipped. This prevents false advertising
-        where agents claim to support authenticated extended cards but don't implement them properly.
-        """
-        # Check if SUT supports authenticated extended card
-        if not agent_card_data.get("supportsAuthenticatedExtendedCard", False):
-            pytest.skip("SUT does not support authenticated extended card")
-
-        # Skip if no authentication is configured
-        if not hasattr(sut_client, "headers") or not any(
-            key.lower() in ["authorization", "x-api-key", "authentication"] for key in getattr(sut_client, "headers", {}).keys()
-        ):
-            pytest.skip("No authentication credentials configured for testing")
-
-        try:
-            extended_card = sut_client.get_extended_agent_card()
-
-            # Validate it's a proper AgentCard
-            assert isinstance(extended_card, dict)
-            assert "protocolVersion" in extended_card
-            assert "name" in extended_card
-            assert "description" in extended_card
-            assert "url" in extended_card
-            assert "skills" in extended_card
-            assert "capabilities" in extended_card
-
-            # Should be version 0.3.0 or compatible
-            protocol_version = extended_card["protocolVersion"]
-            assert protocol_version.startswith("0.3"), f"Expected v0.3.x, got: {protocol_version}"
-
-        except Exception as e:
-            if "authentication" in str(e).lower() or "401" in str(e) or "403" in str(e):
-                pytest.skip("Authentication credentials not accepted by SUT")
-            else:
-                pytest.fail(f"Failed to get authenticated extended card: {e}")
-
 
 class TestTasksList:
     """
@@ -436,7 +328,7 @@ class TestTransportSpecificFeatures:
         # Test HTTP caching headers
         if hasattr(sut_client, "get_with_caching"):
             try:
-                response = sut_client.get_with_caching("/card")
+                response = sut_client.get_with_caching("/extendedAgentCard")
 
                 # Should include caching headers
                 headers = getattr(response, "headers", {})

--- a/tests/mandatory/protocol/test_extended_agent_card.py
+++ b/tests/mandatory/protocol/test_extended_agent_card.py
@@ -9,7 +9,7 @@ SPECIFICATION REQUIREMENTS (Section 7.10):
 
 These tests verify the mandatory getExtendedAgentCard method
 when supportsAuthenticatedExtendedCard is declared in the Agent Card.
-
+when supportsExtendedAgentCard is declared in the Agent Card.
 Reference: A2A v0.3.0 Specification Section 7.10 (agent/getAuthenticatedExtendedCard)
 """
 

--- a/tests/mandatory/protocol/test_extended_agent_card.py
+++ b/tests/mandatory/protocol/test_extended_agent_card.py
@@ -2,155 +2,46 @@
 A2A v0.3.0 Protocol: Mandatory Extended Agent Card Tests
 
 SPECIFICATION REQUIREMENTS (Section 7.10):
-- agent/getAuthenticatedExtendedCard JSON-RPC method, or GetAgentCard gRPC
-  method or /card JSON+HTTP endpoint MUST be available when declared
+- GetExtendedAgentCard JSON-RPC method, or getExtendedAgentCard gRPC
+  method or /extendedAgentCard JSON+HTTP endpoint MUST be available when declared
 - Client MUST authenticate using declared security schemes
-- Server SHOULD include WWW-Authenticate header on 401 responses
 - Clients SHOULD replace cached Agent Card with extended card content
 
-These tests verify the mandatory agent/getAuthenticatedExtendedCard method
+These tests verify the mandatory getExtendedAgentCard method
 when supportsAuthenticatedExtendedCard is declared in the Agent Card.
 
 Reference: A2A v0.3.0 Specification Section 7.10 (agent/getAuthenticatedExtendedCard)
 """
 
 import logging
-import urllib.parse
-from typing import Dict, Any
 
 import pytest
 import requests
 
-from tck import agent_card_utils, config
-from tck.sut_client import SUTClient
-from tests.markers import mandatory
+from tck import agent_card_utils
+from tests.markers import optional_capability
+from tests.utils.transport_helpers import is_json_rpc_error_response, is_json_rpc_success_response, transport_get_extended_agent_card
 
 logger = logging.getLogger(__name__)
 
-
 @pytest.fixture(scope="module")
-def sut_client():
-    """Fixture to provide a SUTClient instance."""
-    return SUTClient()
-
-
-@pytest.fixture(scope="module")
-def extended_card_agent_card(agent_card_data):
-    """
-    Fixture that only returns Agent Card data if extended card is supported.
-    This ensures these tests only run when extended card is declared.
-    """
+def security_schemes(agent_card_data):
+    """Extract security schemes required for extended card access."""
     if agent_card_data is None:
         pytest.skip("Agent Card not available - cannot test extended card requirements")
 
-    supports_extended = agent_card_data.get("supportsAuthenticatedExtendedCard", False)
+    supports_extended = agent_card_data.get("supportsExtendedAgentCard", False)
     if not supports_extended:
-        pytest.skip("supportsAuthenticatedExtendedCard not declared - extended card tests not applicable")
+        pytest.skip("supportsExtendedAgentCard not declared - extended card tests not applicable")
 
-    return agent_card_data
-
-
-@pytest.fixture(scope="module")
-def extended_card_security_schemes(extended_card_agent_card):
-    """Extract security schemes required for extended card access."""
-    return agent_card_utils.get_authentication_schemes(extended_card_agent_card)
+    security_schemes = agent_card_utils.get_authentication_schemes(agent_card_data)
+    if not security_schemes:
+        pytest.fail("Agent card supports extended agent card but does provide security schemes for required authentication")
+    return security_schemes
 
 
-def get_extended_card_url(base_url: str) -> str:
-    """
-    Construct the extended Agent Card URL according to A2A v0.3.0 specification.
-
-    Per Section 7.10: The endpoint URL is {AgentCard.url}/card
-    relative to the base URL specified in the public Agent Card.
-    """
-    parsed = urllib.parse.urlparse(base_url)
-    extended_path = f"{parsed.path}/card"
-
-    # Reconstruct the URL
-    extended_url = urllib.parse.urlunparse(
-        (
-            parsed.scheme,
-            parsed.netloc,
-            extended_path,
-            "",  # params
-            "",  # query
-            "",  # fragment
-        )
-    )
-
-    return extended_url
-
-
-@mandatory
-def test_extended_agent_card_endpoint_exists(extended_card_agent_card):
-    """
-    MANDATORY: A2A v0.3.0 Section 7.10 - Extended Agent Card Endpoint Availability
-
-    When supportsAuthenticatedExtendedCard is declared as true, the agent MUST
-    implement the agent/getAuthenticatedExtendedCard endpoint.
-
-    This endpoint is an HTTP GET endpoint (not JSON-RPC) that returns a more
-    detailed Agent Card after authentication.
-
-    Test Procedure:
-    1. Construct extended card URL from base Agent Card URL
-    2. Send unauthenticated GET request
-    3. Verify endpoint exists (should return 401, not 404)
-
-    Asserts:
-        - Extended card endpoint exists and is accessible
-        - Returns 401/403 for unauthenticated requests (not 404)
-        - Endpoint responds to HTTP GET requests
-    """
-    base_url = extended_card_agent_card.get("url")
-    if not base_url:
-        pytest.fail("Agent Card missing required 'url' field")
-
-    extended_url = get_extended_card_url(base_url)
-    logger.info(f"Testing extended Agent Card endpoint: {extended_url}")
-
-    try:
-        # Send unauthenticated GET request
-        response = requests.get(extended_url, timeout=10)
-
-        # The endpoint should exist but require authentication
-        if response.status_code == 404:
-            pytest.fail(
-                f"SPECIFICATION VIOLATION: Extended Agent Card endpoint not found. "
-                f"A2A v0.3.0 Section 7.10 requires endpoint when supportsAuthenticatedExtendedCard=true. "
-                f"Got HTTP 404 for: {extended_url}"
-            )
-        elif response.status_code in (401, 403):
-            logger.info(f"✅ Extended card endpoint exists and requires authentication (HTTP {response.status_code})")
-
-            # Check for WWW-Authenticate header (SHOULD requirement)
-            if "WWW-Authenticate" in response.headers:
-                logger.info(f"✅ Server included WWW-Authenticate header: {response.headers['WWW-Authenticate']}")
-            else:
-                logger.warning("⚠️ Server missing WWW-Authenticate header (SHOULD requirement)")
-
-        elif response.status_code == 200:
-            # This might be valid if no authentication is required, check the response
-            try:
-                extended_card = response.json()
-                if isinstance(extended_card, dict) and "name" in extended_card:
-                    logger.info("✅ Extended card endpoint accessible without authentication")
-                    logger.warning("Note: Extended card accessible without auth (consider security implications)")
-                else:
-                    pytest.fail(f"Extended card endpoint returned invalid Agent Card format")
-            except ValueError:
-                pytest.fail(f"Extended card endpoint returned non-JSON response")
-        else:
-            logger.warning(f"Unexpected HTTP status for extended card endpoint: {response.status_code}")
-
-    except requests.exceptions.ConnectionError as e:
-        pytest.fail(f"Cannot connect to extended card endpoint: {e}")
-    except requests.exceptions.RequestException as e:
-        pytest.fail(f"Request to extended card endpoint failed: {e}")
-
-
-@mandatory
-def test_extended_agent_card_authentication_required(extended_card_agent_card, extended_card_security_schemes):
+@optional_capability
+def test_extended_agent_card_authentication_required(sut_client):
     """
     MANDATORY: A2A v0.3.0 Section 7.10 - Authentication Requirement
 
@@ -162,56 +53,22 @@ def test_extended_agent_card_authentication_required(extended_card_agent_card, e
 
     Test Procedure:
     1. Send request without authentication
-    2. Verify 401/403 response with proper headers
-    3. Check authentication scheme requirements
-
-    Asserts:
-        - Unauthenticated requests are rejected with 401/403
-        - Authentication schemes are properly enforced
-        - Error responses include proper authentication challenges
+    2. Verify response is an error
     """
-    if not extended_card_security_schemes:
-        pytest.skip("No authentication schemes declared - cannot test auth requirement")
 
-    base_url = extended_card_agent_card.get("url")
-    extended_url = get_extended_card_url(base_url)
-
-    logger.info(f"Testing authentication requirement for extended card: {extended_url}")
-    logger.info(f"Declared security schemes: {len(extended_card_security_schemes)}")
+    logger.info(f"Testing authentication requirement for extended card")
 
     try:
-        # Send request without authentication headers
-        response = requests.get(extended_url, timeout=10)
-
-        # MANDATORY: Must require authentication when schemes are declared
-        if response.status_code not in (401, 403):
-            if response.status_code == 200:
-                pytest.fail(
-                    f"SPECIFICATION VIOLATION: Extended card endpoint should require authentication. "
-                    f"A2A v0.3.0 Section 7.10 requires authentication using declared schemes. "
-                    f"Got HTTP 200 without authentication"
-                )
-            else:
-                pytest.fail(
-                    f"Unexpected response for unauthenticated extended card request. "
-                    f"Expected HTTP 401/403, got HTTP {response.status_code}"
-                )
-
-        logger.info(f"✅ Extended card properly requires authentication (HTTP {response.status_code})")
-
-        # Verify WWW-Authenticate header (SHOULD requirement)
-        auth_header = response.headers.get("WWW-Authenticate")
-        if auth_header:
-            logger.info(f"✅ WWW-Authenticate header present: {auth_header}")
-        else:
-            logger.warning("⚠️ Missing WWW-Authenticate header (recommended by specification)")
+        resp = transport_get_extended_agent_card(sut_client, {"A2A_TCK_DONT_USE_AUTH": "True"})
+        assert is_json_rpc_error_response(resp), f"Message GetExtendedAgentCard failed: {resp}"
+        logger.info(f"✅ Extended card properly requires authentication ({resp})")
 
     except requests.exceptions.RequestException as e:
         pytest.fail(f"Request to extended card endpoint failed: {e}")
 
 
-@mandatory
-def test_extended_agent_card_invalid_authentication(extended_card_agent_card, extended_card_security_schemes):
+@optional_capability
+def test_extended_agent_card_invalid_authentication(sut_client, security_schemes):
     """
     MANDATORY: A2A v0.3.0 Section 7.10 - Invalid Authentication Handling
 
@@ -220,7 +77,7 @@ def test_extended_agent_card_invalid_authentication(extended_card_agent_card, ex
 
     Test Procedure:
     1. Send requests with invalid credentials for each scheme type
-    2. Verify proper rejection with 401/403
+    2. Verify proper rejection
     3. Check error handling consistency
 
     Asserts:
@@ -228,20 +85,14 @@ def test_extended_agent_card_invalid_authentication(extended_card_agent_card, ex
         - Proper HTTP status codes are returned
         - Authentication validation is implemented correctly
     """
-    if not extended_card_security_schemes:
-        pytest.skip("No authentication schemes declared - cannot test invalid auth")
-
-    base_url = extended_card_agent_card.get("url")
-    extended_url = get_extended_card_url(base_url)
-
-    logger.info(f"Testing invalid authentication for extended card: {extended_url}")
+    logger.info(f"Testing invalid authentication for extended agent card")
 
     # Test invalid credentials for each declared scheme
-    for i, scheme in enumerate(extended_card_security_schemes):
-        scheme_type = scheme.get("type", "unknown").lower()
-        scheme_name = scheme.get("scheme", "unknown")
-
-        logger.info(f"Testing invalid credentials for scheme {i + 1}: {scheme_type}")
+    for scheme_name in security_schemes:
+        security_scheme = security_schemes[scheme_name]
+        assert len(security_scheme.keys()) == 1
+        scheme_type, scheme = next(iter(security_scheme.items()))
+        logger.info(f"Testing invalid credentials for scheme {scheme_name}/{scheme_type}")
 
         headers = {}
 
@@ -267,27 +118,16 @@ def test_extended_agent_card_invalid_authentication(extended_card_agent_card, ex
             headers["Authorization"] = f"Bearer invalid-extended-token-{scheme_type}"
 
         try:
-            response = requests.get(extended_url, headers=headers, timeout=10)
-
-            # MANDATORY: Invalid credentials must be rejected
-            if response.status_code not in (401, 403):
-                if response.status_code == 200:
-                    pytest.fail(
-                        f"SPECIFICATION VIOLATION: Extended card accepted invalid {scheme_type} credentials. "
-                        f"A2A v0.3.0 Section 7.10 requires proper credential validation. "
-                        f"Got HTTP 200 with invalid authentication"
-                    )
-                else:
-                    logger.warning(f"Unexpected status for invalid {scheme_type} credentials: {response.status_code}")
-            else:
-                logger.info(f"✅ Invalid {scheme_type} credentials properly rejected (HTTP {response.status_code})")
+            response = transport_get_extended_agent_card(sut_client, headers)
+            assert is_json_rpc_error_response(response), f"SPECIFICATION VIOLATION: Extended card accepted invalid {scheme_type} credentials for {scheme_type}"
+            logger.info(f"✅ Invalid {scheme_type} credentials properly rejected")
 
         except requests.exceptions.RequestException as e:
             logger.warning(f"Request failed for scheme {scheme_type}: {e}")
 
 
-@mandatory
-def test_extended_agent_card_response_format(extended_card_agent_card):
+@optional_capability
+def test_extended_agent_card_response_format(sut_client, agent_card_data):
     """
     MANDATORY: A2A v0.3.0 Section 7.10 - Response Format Validation
 
@@ -308,66 +148,46 @@ def test_extended_agent_card_response_format(extended_card_agent_card):
         - Contains all required Agent Card fields
         - Extended card provides additional details beyond public card
     """
-    base_url = extended_card_agent_card.get("url")
-    extended_url = get_extended_card_url(base_url)
-
-    logger.info(f"Testing extended Agent Card response format: {extended_url}")
+    logger.info(f"Testing extended Agent Card response format")
 
     # Note: In a real test environment, valid authentication credentials would be provided
     # For this mandatory test, we'll test the response format if accessible
 
     try:
-        # Attempt request without auth first to see response format
-        response = requests.get(extended_url, timeout=10)
+        response = transport_get_extended_agent_card(sut_client)
+        assert is_json_rpc_success_response(response)
+        assert "result" in response
+        extended_card = response["result"]
 
-        if response.status_code == 200:
-            # If accessible without auth, validate the response format
-            try:
-                extended_card = response.json()
+        # Validate basic Agent Card structure
+        required_fields = {
+            "name",
+            "description",
+            "supportedInterfaces",
+            "version",
+            "capabilities",
+            "defaultInputModes",
+            "defaultOutputModes",
+            "skills",
+        }
 
-                # Validate basic Agent Card structure
-                required_fields = [
-                    "name",
-                    "description",
-                    "url",
-                    "version",
-                    "capabilities",
-                    "defaultInputModes",
-                    "defaultOutputModes",
-                    "skills",
-                ]
+        for field in required_fields:
+            assert field in extended_card, f"Extended Agent Card missing required field: {field}"
 
-                for field in required_fields:
-                    assert field in extended_card, f"Extended Agent Card missing required field: {field}"
+            # Verify it's a properly formatted Agent Card
+            assert isinstance(extended_card.get("skills"), list), "Extended card 'skills' must be an array"
+            assert isinstance(extended_card.get("capabilities"), dict), "Extended card 'capabilities' must be an object"
 
-                # Verify it's a properly formatted Agent Card
-                assert isinstance(extended_card.get("skills"), list), "Extended card 'skills' must be an array"
-                assert isinstance(extended_card.get("capabilities"), dict), "Extended card 'capabilities' must be an object"
+            logger.info("✅ Extended Agent Card response format validation passed")
+            logger.info(f"Extended card has {len(extended_card.get('skills', []))} skills")
 
-                logger.info("✅ Extended Agent Card response format validation passed")
-                logger.info(f"Extended card has {len(extended_card.get('skills', []))} skills")
+            # Compare with public card to ensure it's extended
+            public_skill_count = len(agent_card_data.get("skills", []))
+            extended_skill_count = len(extended_card.get("skills", []))
 
-                # Compare with public card to ensure it's extended
-                public_skill_count = len(extended_card_agent_card.get("skills", []))
-                extended_skill_count = len(extended_card.get("skills", []))
-
-                if extended_skill_count > public_skill_count:
-                    logger.info(f"✅ Extended card provides additional skills ({extended_skill_count} vs {public_skill_count})")
-                else:
-                    logger.info(f"Extended card has same skill count as public card ({extended_skill_count})")
-
-            except ValueError:
-                pytest.fail("Extended Agent Card endpoint returned invalid JSON")
-            except AssertionError as e:
-                pytest.fail(f"Extended Agent Card format validation failed: {e}")
-
-        elif response.status_code in (401, 403):
-            logger.info("Extended card requires authentication - response format test skipped")
-            logger.info("To test response format, provide valid authentication credentials")
-            pytest.skip("Extended card requires authentication - cannot test response format without credentials")
-
-        else:
-            pytest.skip(f"Cannot test response format - HTTP {response.status_code}")
-
+            if extended_skill_count > public_skill_count:
+                logger.info(f"✅ Extended card provides additional skills ({extended_skill_count} vs {public_skill_count})")
+            else:
+                logger.info(f"Extended card has same skill count as public card ({extended_skill_count})")
     except requests.exceptions.RequestException as e:
         pytest.fail(f"Request to extended card endpoint failed: {e}")

--- a/tests/mandatory/protocol/test_extended_agent_card.py
+++ b/tests/mandatory/protocol/test_extended_agent_card.py
@@ -3,7 +3,7 @@ A2A v0.3.0 Protocol: Mandatory Extended Agent Card Tests
 
 SPECIFICATION REQUIREMENTS (Section 7.10):
 - agent/getAuthenticatedExtendedCard JSON-RPC method, or GetAgentCard gRPC
-  method or v1/card JSON+HTTP endpoint MUST be available when declared
+  method or /card JSON+HTTP endpoint MUST be available when declared
 - Client MUST authenticate using declared security schemes
 - Server SHOULD include WWW-Authenticate header on 401 responses
 - Clients SHOULD replace cached Agent Card with extended card content
@@ -60,11 +60,11 @@ def get_extended_card_url(base_url: str) -> str:
     """
     Construct the extended Agent Card URL according to A2A v0.3.0 specification.
 
-    Per Section 7.10: The endpoint URL is {AgentCard.url}/v1/card
+    Per Section 7.10: The endpoint URL is {AgentCard.url}/card
     relative to the base URL specified in the public Agent Card.
     """
     parsed = urllib.parse.urlparse(base_url)
-    extended_path = f"{parsed.path}/v1/card"
+    extended_path = f"{parsed.path}/card"
 
     # Reconstruct the URL
     extended_url = urllib.parse.urlunparse(

--- a/tests/mandatory/security/test_agent_card_security.py
+++ b/tests/mandatory/security/test_agent_card_security.py
@@ -159,7 +159,7 @@ def test_extended_card_access_controls(sut_client: BaseTransportClient, agent_ca
     logger.info(f"Security schemes required: {len(agent_card_security_info['security_schemes'])}")
 
 
-    response = transport_helpers.transport_get_extended_agent_card(sut_client, {"A2A_TCK_DONT_USE_AUTH": True})
+    response = transport_helpers.transport_get_extended_agent_card(sut_client, {"A2A_TCK_DONT_USE_AUTH": "True"})
 
     # Extended Agent Card MUST require authentication
     if "error" not in response:
@@ -211,7 +211,7 @@ def test_authentication_scheme_validation(sut_client, agent_card_security_info):
 
         # Test multiple invalid credential scenarios for each scheme
         test_scenarios = [
-            ("empty", {"A2A_TCK_DONT_USE_AUTH": True}),
+            ("empty", {"A2A_TCK_DONT_USE_AUTH": "True"}),
             ("malformed", {"Authorization": "Malformed auth header"}),
             ("invalid_type", {"Authorization": f"InvalidType invalid-token-{i}"}),
         ]

--- a/tests/optional/capabilities/test_transport_specific_features.py
+++ b/tests/optional/capabilities/test_transport_specific_features.py
@@ -298,10 +298,10 @@ class TestRESTSpecificFeatures:
 
         # REST HTTP verb mapping tests
         verb_mappings = {
-            "POST": ["/v1/messages", "/v1/tasks/{id}/cancel"],
-            "GET": ["/v1/tasks/{id}", "/v1/agent/card"],
-            "PUT": ["/v1/tasks/{id}/pushNotificationConfig"],
-            "DELETE": ["/v1/tasks/{id}/pushNotificationConfig"],
+            "POST": ["/messages", "/tasks/{id}/cancel"],
+            "GET": ["/tasks/{id}", "/agent/card"],
+            "PUT": ["/tasks/{id}/pushNotificationConfig"],
+            "DELETE": ["/tasks/{id}/pushNotificationConfig"],
         }
 
         logger.info("⚪ REST HTTP verb mapping test requires REST client implementation")

--- a/tests/unit/transport/test_rest_client.py
+++ b/tests/unit/transport/test_rest_client.py
@@ -221,7 +221,7 @@ class TestRESTClientSendMessage:
 
             # Verify correct URL and payload were used
             mock_post.assert_called_once_with(
-                "https://example.com:8080/v1/message:send", json={"message": message}, headers=client.default_headers
+                "https://example.com:8080/message:send", json={"message": message}, headers=client.default_headers
             )
 
             # Verify result
@@ -253,7 +253,7 @@ class TestRESTClientSendMessage:
             expected_headers.update(extra_headers)
 
             mock_post.assert_called_once_with(
-                "https://example.com:8080/v1/message:send", json={"message": message}, headers=expected_headers
+                "https://example.com:8080/message:send", json={"message": message}, headers=expected_headers
             )
 
     @patch("httpx.Client.post")
@@ -284,7 +284,7 @@ class TestRESTClientSendMessage:
             }
 
             mock_post.assert_called_once_with(
-                "https://example.com:8080/v1/message:send", json=expected_payload, headers=client.default_headers
+                "https://example.com:8080/message:send", json=expected_payload, headers=client.default_headers
             )
 
     @patch("httpx.Client.post")
@@ -398,7 +398,7 @@ class TestRESTClientStreamingMessage:
         # Verify correct URL and headers were used
         mock_async_client.stream.assert_called_once_with(
             "POST",
-            "https://example.com:8080/v1/message:stream",
+            "https://example.com:8080/message:stream",
             json={"message": message},
             headers={**client.default_headers, "Accept": "text/event-stream"},
         )
@@ -508,7 +508,7 @@ class TestRESTClientTaskOperations:
 
             result = client.get_task("task-123")
 
-            mock_get.assert_called_once_with("https://example.com:8080/v1/tasks/task-123", params={}, headers=client.default_headers)
+            mock_get.assert_called_once_with("https://example.com:8080/tasks/task-123", params={}, headers=client.default_headers)
 
             assert result["id"] == "task-123"
             assert result["context_id"] == "default-context"
@@ -532,7 +532,7 @@ class TestRESTClientTaskOperations:
             client.get_task("task-123", history_length=10)
 
             mock_get.assert_called_once_with(
-                "https://example.com:8080/v1/tasks/task-123", params={"history_length": 10}, headers=client.default_headers
+                "https://example.com:8080/tasks/task-123", params={"history_length": 10}, headers=client.default_headers
             )
 
     @patch("httpx.Client.post")
@@ -562,7 +562,7 @@ class TestRESTClientTaskOperations:
 
             result = client.cancel_task("task-456")
 
-            mock_post.assert_called_once_with("https://example.com:8080/v1/tasks/task-456:cancel", headers=client.default_headers)
+            mock_post.assert_called_once_with("https://example.com:8080/tasks/task-456:cancel", headers=client.default_headers)
 
             assert result["id"] == "task-456"
             assert result["status"]["state"] == "TASK_STATE_CANCELLED"
@@ -618,7 +618,7 @@ class TestRESTClientTaskOperations:
         # Verify correct URL and headers were used
         mock_async_client.stream.assert_called_once_with(
             "GET",
-            "https://example.com:8080/v1/tasks/task-789:subscribe",
+            "https://example.com:8080/tasks/task-789:subscribe",
             headers={**client.default_headers, "Accept": "text/event-stream"},
         )
 
@@ -657,7 +657,7 @@ class TestRESTClientAgentCard:
             expected_headers = client.default_headers.copy()
             expected_headers.update(auth_headers)
 
-            mock_get.assert_called_once_with("https://example.com:8080/v1/card", headers=expected_headers)
+            mock_get.assert_called_once_with("https://example.com:8080/card", headers=expected_headers)
 
             assert result["name"] == "A2A REST Test Agent (Extended)"
             assert result["capabilities"]["authenticated_features"] is True
@@ -696,7 +696,7 @@ class TestRESTClientPushNotifications:
             result = client.set_push_notification_config("task-123", config)
 
             mock_post.assert_called_once_with(
-                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs", json=config, headers=client.default_headers
+                "https://example.com:8080/tasks/task-123/pushNotificationConfigs", json=config, headers=client.default_headers
             )
 
             assert result["push_notification_config"]["id"] == "config1"
@@ -727,7 +727,7 @@ class TestRESTClientPushNotifications:
             result = client.get_push_notification_config("task-123", "config1")
 
             mock_get.assert_called_once_with(
-                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs/config1", headers=client.default_headers
+                "https://example.com:8080/tasks/task-123/pushNotificationConfigs/config1", headers=client.default_headers
             )
 
             assert result["push_notification_config"]["id"] == "config1"
@@ -762,7 +762,7 @@ class TestRESTClientPushNotifications:
             result = client.list_push_notification_configs("task-123")
 
             mock_get.assert_called_once_with(
-                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs", headers=client.default_headers
+                "https://example.com:8080/tasks/task-123/pushNotificationConfigs", headers=client.default_headers
             )
 
             assert len(result["configs"]) == 2
@@ -787,7 +787,7 @@ class TestRESTClientPushNotifications:
             result = client.delete_push_notification_config("task-123", "config1")
 
             mock_delete.assert_called_once_with(
-                "https://example.com:8080/v1/tasks/task-123/pushNotificationConfigs/config1", headers=client.default_headers
+                "https://example.com:8080/tasks/task-123/pushNotificationConfigs/config1", headers=client.default_headers
             )
 
             assert result == {}  # Empty response for successful deletion

--- a/tests/validators/a2a_v030_compliance.py
+++ b/tests/validators/a2a_v030_compliance.py
@@ -168,15 +168,15 @@ class TransportComplianceValidator:
         """
         result = {
             "required_methods": [
-                "send_message",  # POST /v1/message:send
-                "get_task",  # GET /v1/tasks/{id}
-                "cancel_task",  # POST /v1/tasks/{id}:cancel
-                "get_extended_agent_card",  # GET /v1/card
-                "list_tasks",  # GET /v1/tasks (gRPC/REST specific)
+                "send_message",  # POST /message:send
+                "get_task",  # GET /tasks/{id}
+                "cancel_task",  # POST /tasks/{id}:cancel
+                "get_extended_agent_card",  # GET /extendedAgentCard
+                "list_tasks",  # GET /tasks (gRPC/REST specific)
             ],
             "optional_methods": [
-                "send_streaming_message",  # POST /v1/message:stream
-                "subscribe_to_task",  # POST /v1/tasks/{id}:subscribe
+                "send_streaming_message",  # POST /message:stream
+                "subscribe_to_task",  # POST /tasks/{id}:subscribe
             ],
             "transport_specific_features": [
                 "http_status_codes",  # Proper HTTP status codes
@@ -211,38 +211,38 @@ class MethodMappingValidator:
         "send_message": {
             "jsonrpc": "SendMessage",
             "grpc": "SendMessage",
-            "rest": "POST /v1/message:send",
+            "rest": "POST /message:send",
             "description": "Send message to agent",
         },
         "send_streaming_message": {
             "jsonrpc": "message/stream",
             "grpc": "SendStreamingMessage",
-            "rest": "POST /v1/message:stream",
+            "rest": "POST /message:stream",
             "description": "Send message with streaming",
         },
-        "get_task": {"jsonrpc": "tasks/get", "grpc": "GetTask", "rest": "GET /v1/tasks/{id}", "description": "Get task status"},
+        "get_task": {"jsonrpc": "tasks/get", "grpc": "GetTask", "rest": "GET /tasks/{id}", "description": "Get task status"},
         "list_tasks": {
             "jsonrpc": None,  # Not available in JSON-RPC
             "grpc": "ListTask",
-            "rest": "GET /v1/tasks",
+            "rest": "GET /tasks",
             "description": "List tasks (gRPC/REST only)",
         },
         "cancel_task": {
             "jsonrpc": "tasks/cancel",
             "grpc": "CancelTask",
-            "rest": "POST /v1/tasks/{id}:cancel",
+            "rest": "POST /tasks/{id}:cancel",
             "description": "Cancel task",
         },
         "subscribe_to_task": {
             "jsonrpc": "SubscribeToTask",
             "grpc": "TaskSubscription",
-            "rest": "POST /v1/tasks/{id}:subscribe",
+            "rest": "POST /tasks/{id}:subscribe",
             "description": "Resume task streaming",
         },
         "get_extended_agent_card": {
             "jsonrpc": "getExtendedCard",
             "grpc": "GetExtendedAgentCard",
-            "rest": "GET /v1/extendedAgentCard",
+            "rest": "GET /extendedAgentCard",
             "description": "Get extended agent card",
         },
     }

--- a/tests/validators/method_mapping_validator.py
+++ b/tests/validators/method_mapping_validator.py
@@ -303,12 +303,12 @@ class MethodMappingValidator:
         """
         Validate REST endpoint naming conventions (§3.5.3).
 
-        REST endpoints MUST follow /v1/{resource}[/{id}][:{action}] pattern.
+        REST endpoints MUST follow /{resource}[/{id}][:{action}] pattern.
         """
         results = {
             "transport": "rest",
             "compliant": True,
-            "naming_convention": "/v1/{resource}[/{id}][:{action}]",
+            "naming_convention": "/{resource}[/{id}][:{action}]",
             "violations": [],
             "valid_endpoints": [],
         }
@@ -336,13 +336,13 @@ class MethodMappingValidator:
         return bool(re.match(pattern, method))
 
     def _validate_rest_endpoint_pattern(self, endpoint: str) -> bool:
-        """Validate REST endpoint follows /v1/{resource} pattern."""
-        # Must start with /v1/
-        if not endpoint.startswith("/v1/"):
+        """Validate REST endpoint follows /{resource} pattern."""
+        # Must start with /
+        if not endpoint.startswith("/"):
             return False
 
         # Should follow resource-based pattern
-        pattern = r"^/v1/[a-z]+(/\{[a-zA-Z]+\}|:[a-z]+)?$"
+        pattern = r"^/[a-z]+(/\{[a-zA-Z]+\}|:[a-z]+)?$"
         return bool(re.match(pattern, endpoint))
 
     def _get_available_jsonrpc_methods(self, client: JSONRPCClient) -> List[str]:


### PR DESCRIPTION
The implementation of the method is mandatory but it is only available when supportsExtendedAgentCard is true, so let's
treat it as an optional capability

This should be merged after #119 