### PR TITLE
feat!: update tests for the agent card's protocolVersions

### DIFF
--- a/tck/conftest.py
+++ b/tck/conftest.py
@@ -70,7 +70,7 @@ def agent_card_data(request):
         return None
 
     # Check for minimally required fields (optional check)
-    required_fields = ["name", "id", "protocolVersion"]
+    required_fields = ["name", "id", "protocolVersions"]
     missing_fields = [field for field in required_fields if field not in agent_card]
 
     if missing_fields:

--- a/tck/transport/grpc_client.py
+++ b/tck/transport/grpc_client.py
@@ -163,7 +163,7 @@ def _validate_agent_card_object(agent_card: Dict[str, Any]) -> None:
     """
     Validate that an AgentCard object conforms to A2A specification.
     """
-    required_fields = ["protocolVersion", "name", "description", "url", "preferredTransport"]
+    required_fields = ["protocolVersions", "name", "description", "url", "preferredTransport"]
     for field in required_fields:
         if field not in agent_card:
             raise A2AValidationError(f"AgentCard missing required field '{field}'", TransportType.GRPC)

--- a/tests/mandatory/protocol/test_a2a_v030_new_methods.py
+++ b/tests/mandatory/protocol/test_a2a_v030_new_methods.py
@@ -195,7 +195,7 @@ class TestAuthenticatedExtendedCard:
 
             # Validate it's a proper AgentCard
             assert isinstance(extended_card, dict)
-            assert "protocolVersion" in extended_card
+            assert "protocolVersions" in extended_card
             assert "name" in extended_card
             assert "description" in extended_card
             assert "url" in extended_card
@@ -203,7 +203,8 @@ class TestAuthenticatedExtendedCard:
             assert "capabilities" in extended_card
 
             # Should be version 0.3.0 or compatible
-            protocol_version = extended_card["protocolVersion"]
+            #FIXME
+            protocol_version = extended_card["protocolVersions"][0]
             assert protocol_version.startswith("0.3"), f"Expected v0.3.x, got: {protocol_version}"
 
         except Exception as e:

--- a/tests/mandatory/protocol/test_agent_card.py
+++ b/tests/mandatory/protocol/test_agent_card.py
@@ -78,6 +78,7 @@ def test_mandatory_fields_present(fetched_agent_card):
         "name",
         "skills",
         "version",
+        "protocolVersions",
     ]
 
     deprecatedFields = [

--- a/tests/mandatory/protocol/test_agent_card_mandatory.py
+++ b/tests/mandatory/protocol/test_agent_card_mandatory.py
@@ -66,7 +66,7 @@ def test_agent_card_mandatory_fields(fetched_agent_card):
         "defaultOutputModes",
         "description",
         "name",
-        "protocolVersion",
+        "protocolVersions",
         "skills",
         "version",
     ]

--- a/tests/optional/features/test_agent_card_utils.py
+++ b/tests/optional/features/test_agent_card_utils.py
@@ -17,7 +17,7 @@ SAMPLE_AGENT_CARD = {
     "name": "Test Agent",
     "description": "A test agent for TCK",
     "id": "test-agent-id",
-    "protocolVersion": "1.0",
+    "protocolVersions": ["1.0"],
     "url": "https://example.com/agent",
     "endpoint": "https://example.com/agent/jsonrpc",
     "capabilities": {


### PR DESCRIPTION
The protocolVersion field was replaced by the protocolVersions field in https://github.com/a2aproject/A2A/commit/a4afeea788b3877101f7a63c2e50091709490058
