### PR TITLE
fix: Align transport clients with latest a2a-java proto updates

### DIFF
--- a/tck/transport/grpc_client.py
+++ b/tck/transport/grpc_client.py
@@ -189,7 +189,8 @@ def _validate_push_notification_config_list(config_list: List[Dict[str, Any]]) -
             raise A2AValidationError(f"Push notification config[{i}] must be an object", TransportType.GRPC)
 
         # Validate TaskPushNotificationConfig structure
-        required_fields = ["pushNotificationConfig", "id", "taskId"]
+        # Note: 'id' field was removed from top level in proto update - it's now only in pushNotificationConfig
+        required_fields = ["pushNotificationConfig", "taskId"]
         for field in required_fields:
             if field not in config:
                 raise A2AValidationError(f"Push notification config[{i}] missing required field '{field}'", TransportType.GRPC)

--- a/tck/transport/rest_client.py
+++ b/tck/transport/rest_client.py
@@ -405,8 +405,12 @@ class RESTClient(BaseTransportClient):
             url = urljoin(self.base_url, f"/tasks/{task_id}:cancel")
             headers = self._prepare_headers(kwargs.get("extra_headers", {}))
 
+            # Build request body with only metadata (id is in URL path)
+            # According to a2a.proto, CancelTaskRequest has id in path and metadata in body
+            request_body = kwargs.get("metadata", {})
+
             # Make real HTTP request to live SUT
-            response = self.client.post(url, headers=headers)
+            response = self.client.post(url, json=request_body, headers=headers)
 
             # Handle HTTP errors
             if response.status_code >= 400:


### PR DESCRIPTION
- Remove top-level 'id' field validation from TaskPushNotificationConfig (gRPC)
- Add request body to REST cancel_task endpoint (now required)