### PR TITLE
fix: align Part JSON serialization with a2a.proto spec

### DIFF
--- a/tck/transport/grpc_client.py
+++ b/tck/transport/grpc_client.py
@@ -125,14 +125,13 @@ def _validate_part_object(part: Dict[str, Any], context: str = "part") -> None:
         if not isinstance(part["text"], str):
             raise A2AValidationError(f"{context} TextPart 'text' must be a string", TransportType.GRPC)
 
-    elif "file" in part:
-        file_obj = part["file"]
-        if not isinstance(file_obj, dict):
-            raise A2AValidationError(f"{context} FilePart 'file' must be an object", TransportType.GRPC)
+    elif "url" in part:
+        if not isinstance(part["url"], str):
+            raise A2AValidationError(f"{context} Part 'url' must be a string", TransportType.GRPC)
 
-        # FilePart must have either 'bytes' or 'uri'
-        if "bytes" not in file_obj and "uri" not in file_obj:
-            raise A2AValidationError(f"{context} FilePart must have either 'bytes' or 'uri'", TransportType.GRPC)
+    elif "raw" in part:
+        if not isinstance(part["raw"], str):
+            raise A2AValidationError(f"{context} Part 'raw' must be a base64-encoded string", TransportType.GRPC)
 
     elif "data" in part:
         if "data" not in part["data"]:
@@ -1230,22 +1229,11 @@ class GRPCClient(BaseTransportClient):
                 value = Value()
                 value.struct_value.CopyFrom(struct)
                 parts.append(pb.Part(data=value))
-            #FIXME incorrect serialization of FilePart payload
-            elif p.get("kind") == "file" and (("file" in p and "uri" in p["file"]) or ("file" in p and "bytes" in p["file"]) or "fileUri" in p or "fileBytes" in p):
-                # Handle FilePart
-                file_part = pb.FilePart()
-                if "fileUri" in p:
-                    file_part.file_with_uri = p["fileUri"]
-                elif "fileBytes" in p:
-                    file_part.file_with_bytes = p["fileBytes"]
-                elif "file" in p:
-                    if "uri" in p["file"]:
-                        file_part.file_with_uri = p["file"]["uri"]
-                    elif "bytes" in p["file"]:
-                        file_part.file_with_bytes = p["file"]["bytes"]
-                if "mimeType" in p:
-                    file_part.mime_type = p["mimeType"]
-                parts.append(pb.Part(file=file_part))
+            elif "url" in p:
+                parts.append(pb.Part(url=p["url"], filename=p.get("filename", ""), media_type=p.get("mediaType", "")))
+            elif "raw" in p:
+                raw_bytes = base64.b64decode(p["raw"])
+                parts.append(pb.Part(raw=raw_bytes, filename=p.get("filename", ""), media_type=p.get("mediaType", "")))
             else:
                 # Empty or unrecognized part structure
                 parts.append(pb.Part())
@@ -1318,32 +1306,24 @@ class GRPCClient(BaseTransportClient):
             # Check which oneof field is set
             if part.HasField('text'):
                 json_parts.append({"kind": "text", "text": part.text})
-            elif part.HasField('file'):
-                file_part = part.file
-                file_dict = {"kind": "file", "file": {}}
-
-                # FilePart has oneof: file_with_uri or file_with_bytes
-                if file_part.HasField('file_with_uri'):
-                    file_dict["file"]["fileWithUri"] = file_part.file_with_uri
-                elif file_part.HasField('file_with_bytes'):
-                    # Base64 encode bytes for JSON
-                    file_dict["file"]["fileWithBytes"] = base64.b64encode(file_part.file_with_bytes).decode('utf-8')
-
-                # Add optional fields using spec-compliant camelCase names
-                if file_part.media_type:
-                    file_dict["file"]["mediaType"] = file_part.media_type
-                if file_part.name:
-                    file_dict["file"]["name"] = file_part.name
-
-                json_parts.append(file_dict)
+            elif part.HasField('url'):
+                part_dict = {"url": part.url}
+                if part.filename:
+                    part_dict["filename"] = part.filename
+                if part.media_type:
+                    part_dict["mediaType"] = part.media_type
+                json_parts.append(part_dict)
+            elif part.HasField('raw'):
+                part_dict = {"raw": base64.b64encode(part.raw).decode('utf-8')}
+                if part.filename:
+                    part_dict["filename"] = part.filename
+                if part.media_type:
+                    part_dict["mediaType"] = part.media_type
+                json_parts.append(part_dict)
             elif part.HasField('data'):
-                # DataPart contains a google.protobuf.Struct
-                # Convert Struct to dict using existing gRPC JSON parsing
-                data_dict = json_format.MessageToDict(part.data.data, preserving_proto_field_name=False)
-                json_parts.append({
-                    "kind": "data",
-                    "data": data_dict
-                })
+                # data is google.protobuf.Value
+                data_dict = json_format.MessageToDict(part.data, preserving_proto_field_name=False)
+                json_parts.append({"data": data_dict})
 
         return json_parts
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,19 +159,16 @@ def valid_text_message_params():
 
 @pytest.fixture
 def valid_file_message_params():
-    # Valid params for SendMessage with FilePart
-    # Note: mimeType is RECOMMENDED per A2A Specification §6.6.2 FileWithUri Object
+    # Valid params for SendMessage with a file Part (url variant)
     return {
         "message": {
             "messageId": "test-file-message-id-" + str(uuid.uuid4()),
             "role": "ROLE_USER",
             "parts": [
                 {
-                    "file": {
-                        "name": "test.txt",
-                        "mediaType": "text/plain",  # RECOMMENDED: Media Type per A2A Spec §6.6.2
-                        "fileWithUri": "https://example.com/test.txt",
-                    },
+                    "url": "https://example.com/test.txt",
+                    "filename": "test.txt",
+                    "mediaType": "text/plain",
                 }
             ],
         }

--- a/tests/mandatory/protocol/test_message_send_method.py
+++ b/tests/mandatory/protocol/test_message_send_method.py
@@ -30,19 +30,16 @@ def valid_text_message_params():
 
 @pytest.fixture
 def valid_file_message_params():
-    # Valid params for SendMessage with FilePart
-    # Note: mimeType is RECOMMENDED per A2A v1.0 §4.1.7 FilePart
+    # Valid params for SendMessage with a file Part (url variant)
     return {
         "message": {
             "messageId": generate_test_message_id("file"),
             "role": "ROLE_USER",
             "parts": [
                 {
-                    "file": {
-                        "name": "test.txt",
-                        "mimeType": "text/plain",
-                        "fileWithUri": "https://example.com/test.txt",
-                    },
+                    "url": "https://example.com/test.txt",
+                    "filename": "test.txt",
+                    "mediaType": "text/plain",
                 }
             ],
         }

--- a/tests/optional/capabilities/test_transport_specific_features.py
+++ b/tests/optional/capabilities/test_transport_specific_features.py
@@ -456,7 +456,9 @@ class TestMultiModalFeatures:
             "parts": [
                 {"text": "Please analyze this file"},
                 {
-                    "file": {"fileWithUri": "https://example.com/test-file.txt", "mediaType": "text/plain", "name": "test-file.txt"},
+                    "url": "https://example.com/test-file.txt",
+                    "filename": "test-file.txt",
+                    "mediaType": "text/plain",
                 },
             ],
         }
@@ -494,7 +496,7 @@ class TestMultiModalFeatures:
             "role": "ROLE_USER",
             "parts": [
                 {"text": "Processing binary data"},
-                {"data": {"data": {"mimeType": "application/octet-stream", "data": encoded_data}}},
+                {"raw": encoded_data, "mediaType": "application/octet-stream"},
             ],
         }
 

--- a/tests/optional/features/test_invalid_business_logic.py
+++ b/tests/optional/features/test_invalid_business_logic.py
@@ -39,11 +39,9 @@ def test_invalid_file_part(sut_client):
             "role": "ROLE_USER",
             "parts": [
                 {
-                    "file": {
-                        "name": "test.txt",
-                        "mediaType": "text/plain",  # RECOMMENDED: Media Type per A2A Spec §6.6.2
-                        "fileWithUri": "invalid://url.com/file.txt",  # Invalid URL (note: uri, not url)
-                    },
+                    "url": "invalid://url.com/file.txt",  # Invalid URL
+                    "filename": "test.txt",
+                    "mediaType": "text/plain",
                 }
             ],
         }
@@ -243,11 +241,9 @@ def test_file_part_without_mimetype(sut_client):
             "role": "ROLE_USER",
             "parts": [
                 {
-                    "file": {
-                        "name": "test.txt",
-                        # mimeType is RECOMMENDED but not required per A2A Spec §6.6.2
-                        "fileWithUri": "https://example.com/test.txt",
-                    },
+                    "url": "https://example.com/test.txt",
+                    "filename": "test.txt",
+                    # mediaType is RECOMMENDED but not required per A2A Spec
                 }
             ],
         }


### PR DESCRIPTION
Replace the incorrect nested file object format with the flat Part fields defined in the proto (url, raw, filename, mediaType).

- Test fixtures in conftest.py and test files updated accordingly
- grpc_client: _json_to_send_message_request handles url/raw parts
- grpc_client: _convert_parts_to_json uses HasField(url/raw)
- grpc_client: fix data part deserialization (part.data not part.data.data)
- grpc_client: _validate_part_object checks url/raw instead of file


Fixes #132 🦕