### PR TITLE
fix: binary data support is not tested properly.

### DIFF
--- a/tests/optional/capabilities/test_transport_specific_features.py
+++ b/tests/optional/capabilities/test_transport_specific_features.py
@@ -496,7 +496,7 @@ class TestMultiModalFeatures:
             "role": "ROLE_USER",
             "parts": [
                 {"text": "Processing binary data"},
-                {"raw": encoded_data, "mediaType": "application/octet-stream"},
+                {"raw": encoded_data, "mediaType": "application/octet-stream", "filename":"test.txt"},
             ],
         }
 
@@ -510,5 +510,5 @@ class TestMultiModalFeatures:
         elif "error" in response:
             error = response["error"]
             # Should not be method not found
-            assert error.get("code") == -32601, "Binary data should be supported in A2A v1.0.0"
+            assert error.get("code") != -32601, "Binary data should be supported in A2A v1.0.0"
             logger.info(f"⚠️  Binary data handling error: {error}")


### PR DESCRIPTION
When a SUT returns a non--32601 error (e.g., a processing error), the test fails with "Binary data should be supported in A2A v1.0.0", which is confusing because the server does support it ->  it just had a different error.
The intent is: if the server returns an error, it should NOT be a "method not found" (-32601) error, because binary data handling should be a supported feature. But the current code asserts the opposite -> it passes only if the error IS "method not found", which contradicts the
error message.


Fixes #<issue_number_goes_here> 🦕