### PR TITLE
fix: add timeout to gRPC streaming RPCs to prevent indefinite hangs 

### DIFF
--- a/codegen/java_emitter.py
+++ b/codegen/java_emitter.py
@@ -264,7 +264,7 @@ def _single_part_to_java(part: PartDef) -> str:
         )
 
     if isinstance(part, DataPartDef):
-        return f"new DataPart({_java_string(part.json_content)})"
+        return f"DataPart.fromJson({_java_string(part.json_content)})"
 
     msg = f"Unknown part type: {type(part).__name__}"
     raise ValueError(msg)

--- a/sut/a2a-java/src/main/java/org/a2aproject/sdk/TckAgentExecutorProducer.java
+++ b/sut/a2a-java/src/main/java/org/a2aproject/sdk/TckAgentExecutorProducer.java
@@ -103,7 +103,7 @@ public class TckAgentExecutorProducer {
                 }
 
                 if (messageId.startsWith("tck-artifact-data")) {
-                    emitter.addArtifact(List.of(new DataPart("{\"key\": \"value\", \"count\": 42}")), null, null, null);
+                    emitter.addArtifact(List.of(DataPart.fromJson("{\"key\": \"value\", \"count\": 42}")), null, null, null);
                     emitter.complete();
                     return;
                 }

--- a/tck/transport/grpc_client.py
+++ b/tck/transport/grpc_client.py
@@ -121,12 +121,19 @@ class GrpcClient(BaseTransportClient):
         if self._channel is not None:
             self._channel.close()
 
+    # Default timeout (seconds) for streaming RPCs.  Without a deadline the
+    # gRPC Python iterator can block indefinitely in certain environments
+    # (e.g. pytest) even when the server has already sent data.
+    _STREAMING_TIMEOUT_S = 30
+
     def _call_with_retry(
         self,
         rpc_name: str,
         request: Any,
         make_ok: callable,
         make_err: callable,
+        *,
+        timeout: float | None = None,
     ) -> TransportResponse | StreamingResponse:
         """Execute a gRPC call with one retry on connection errors.
 
@@ -135,14 +142,14 @@ class GrpcClient(BaseTransportClient):
         """
         rpc = getattr(self._stub, rpc_name)
         try:
-            return make_ok(rpc(request))
+            return make_ok(rpc(request, timeout=timeout))
         except grpc.RpcError as e:
             if e.code() not in self._RETRIABLE_CODES:
                 return make_err(e)
             self._connect()
             try:
                 rpc = getattr(self._stub, rpc_name)
-                return make_ok(rpc(request))
+                return make_ok(rpc(request, timeout=timeout))
             except grpc.RpcError as e2:
                 return make_err(e2)
 
@@ -180,6 +187,7 @@ class GrpcClient(BaseTransportClient):
             make_err=lambda e: GrpcStreamingResponse(
                 transport=self.transport, success=False, raw_response=e, events=iter([]),
             ),
+            timeout=self._STREAMING_TIMEOUT_S,
         )
 
     def send_streaming_message(


### PR DESCRIPTION
+ fix: use DataPart.fromJson() instead of constructor in a2a-java SUT