### PR TITLE
docs: remove outdated gRPC hang workaround from skills

### DIFF
--- a/.agents/skills/a2a-java-sut/SKILL.md
+++ b/.agents/skills/a2a-java-sut/SKILL.md
@@ -173,11 +173,6 @@ Read `reports/compatibility.json` for structured results. For detailed diagnosis
 2. **Agent card 404** — Wrong URL; the a2a-java SDK serves at `/.well-known/agent-card.json`
 3. **Unmatched messageId prefix** — The scenario prefix doesn't match what the TCK test sends; check `tck_id()` usage in tests vs prefix in `.feature` file
 4. **Missing action** — Scenario doesn't handle the expected behavior; add the appropriate Then/And step
-5. **gRPC SubscribeToTask hangs** — The gRPC `test_subscribe_first_event_is_task` test hangs indefinitely because the SUT's gRPC SubscribeToTask stream never sends the first Task event. Deselect it when running the TCK:
-   ```bash
-   uv run ./run_tck.py --sut-host http://localhost:9999 -v -- --deselect "tests/compatibility/grpc/test_streaming.py::TestGrpcStreaming::test_subscribe_first_event_is_task"
-   ```
-
 ## Step 6: Iterate
 
 The typical development cycle is:

--- a/.agents/skills/run-tck/SKILL.md
+++ b/.agents/skills/run-tck/SKILL.md
@@ -137,7 +137,7 @@ run to completion while the stuck test is investigated separately.
 4. **Schema validation failures** — Response payloads don't match the A2A JSON Schema or protobuf definitions
 5. **Missing required fields** — Response is missing MUST-level fields per the spec
 6. **Wrong error codes** — SUT returns incorrect error codes for error scenarios
-7. **Test hangs indefinitely** — Usually a streaming test where the SUT never closes the stream or never sends the first event. Deselect the test and file an issue against the SUT
+7. **Test hangs indefinitely** — Usually a streaming test where the SUT never closes the stream. The TCK's gRPC client uses a 30s timeout on streaming RPCs to prevent indefinite hangs, but if a test still hangs, deselect it and investigate
 
 ### Tips
 


### PR DESCRIPTION
The gRPC SubscribeToTask hang was a TCK bug (missing timeout on streaming RPCs fixed in #153 ), not a SUT bug. Remove the --deselect workaround from the a2a-java-sut skill and update the run-tck skill to reflect the built-in 30s timeout.
