### PR TITLE
fix: handle UPB-based protobuf FieldDescriptor in proto schema validator

### DIFF
--- a/tck/validators/proto_schema.py
+++ b/tck/validators/proto_schema.py
@@ -32,11 +32,11 @@ def _is_repeated_field(field_desc: FieldDescriptor) -> bool:
     Returns:
         True if the field is repeated.
     """
-    # Try the new API first (is_repeated method)
-    if hasattr(field_desc, "is_repeated") and callable(
-        getattr(field_desc, "is_repeated", None)
-    ):
-        return field_desc.is_repeated()
+    # Try the new API first — is_repeated is a property (not callable) on
+    # newer UPB-based descriptors, or a method on older descriptors.
+    if hasattr(field_desc, "is_repeated"):
+        attr = field_desc.is_repeated
+        return attr() if callable(attr) else attr
 
     # Fall back to the deprecated label property, suppressing the warning
     with warnings.catch_warnings():


### PR DESCRIPTION
The `_is_repeated_field` helper assumed `is_repeated` was a callable method, but on newer UPB-based protobuf descriptors it is a property. The fallback to `.label` also failed because UPB descriptors don't expose that attribute, causing GRPC-SVC-001 to fail with an AttributeError.