### PR TITLE
fix: exclude CORE-SEND-002 from parametrized runner

### DIFF
--- a/tck/requirements/core_operations.py
+++ b/tck/requirements/core_operations.py
@@ -88,15 +88,7 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
         expected_behavior="UnsupportedOperationError returned for terminal task",
         expected_error=UNSUPPORTED_OPERATION_ERROR,
         spec_url=f"{SPEC_BASE}311-send-message",
-        tags=[CORE, SEND_MESSAGE, ERROR],
-        sample_input={
-            "message": {
-                "role": "ROLE_USER",
-                "parts": [{"text": "Message to terminal task"}],
-                "messageId": tck_id("send-002"),
-                "taskId": tck_id("complete-task"),
-            },
-        },
+        tags=[CORE, SEND_MESSAGE, ERROR, MULTI_OPERATION],
 
     ),
     RequirementSpec(


### PR DESCRIPTION
CORE-SEND-002 requires a completed task to exist before it can test sending a message to a terminal task. The parametrized runner in test_requirements.py dispatches a single operation and cannot create prerequisite tasks. The dedicated test in test_task_lifecycle.py handles the setup correctly.

Tag the requirement as multi-operation so _parametrize_requirements skips it.