### PR TITLE
fix: detect immediate stream errors in gRPC and JSON-RPC streaming clients

### DIFF
--- a/tck/transport/grpc_client.py
+++ b/tck/transport/grpc_client.py
@@ -7,6 +7,7 @@ from the A2A specification.
 from __future__ import annotations
 
 import contextlib
+import itertools
 
 from dataclasses import dataclass
 from typing import Any
@@ -178,17 +179,35 @@ class GrpcClient(BaseTransportClient):
         return self._unary_call("SendMessage", proto_request)
 
     def _streaming_call(self, rpc_name: str, request: Any) -> StreamingResponse:
-        """Execute a streaming gRPC call with one retry on connection errors."""
-        return self._call_with_retry(
-            rpc_name, request,
-            make_ok=lambda s: GrpcStreamingResponse(
-                transport=self.transport, success=True, raw_response=s, events=s,
-            ),
-            make_err=lambda e: GrpcStreamingResponse(
-                transport=self.transport, success=False, raw_response=e, events=iter([]),
-            ),
-            timeout=self._STREAMING_TIMEOUT_S,
-        )
+        """Execute a streaming gRPC call with one retry on connection errors.
+
+        Peeks at the first event to detect an empty stream early.  Any
+        ``grpc.RpcError`` raised during iteration (including on the first
+        ``next()`` call, where gRPC often defers the network request) bubbles
+        up to the outer handler so that retriable errors trigger a reconnect
+        and a second attempt.
+        """
+        for attempt in range(2):
+            rpc = getattr(self._stub, rpc_name)
+            try:
+                stream = rpc(request, timeout=self._STREAMING_TIMEOUT_S)
+                try:
+                    first = next(stream)
+                except StopIteration:
+                    return GrpcStreamingResponse(
+                        transport=self.transport, success=True, raw_response=stream, events=iter([]),
+                    )
+                return GrpcStreamingResponse(
+                    transport=self.transport, success=True, raw_response=stream,
+                    events=itertools.chain([first], stream),
+                )
+            except grpc.RpcError as e:
+                if e.code() not in self._RETRIABLE_CODES or attempt == 1:
+                    return GrpcStreamingResponse(
+                        transport=self.transport, success=False, raw_response=e, events=iter([]),
+                    )
+                self._connect()
+        raise AssertionError("unreachable: retry loop always returns on the final attempt")
 
     def send_streaming_message(
         self,

--- a/tck/transport/jsonrpc_client.py
+++ b/tck/transport/jsonrpc_client.py
@@ -122,8 +122,10 @@ class JsonRpcClient(BaseTransportClient):
     def _call_streaming(self, method: str, params: dict) -> StreamingResponse:
         """Make a JSON-RPC 2.0 streaming call and return a StreamingResponse.
 
-        Uses httpx streaming so that SSE events are yielded incrementally
-        as they arrive, rather than blocking until the full body is read.
+        If the server responds with ``text/event-stream``, events are yielded
+        incrementally via SSE.  If the server responds with a plain JSON body
+        (e.g. an immediate error before opening a stream), the body is parsed
+        as a JSON-RPC response and ``success`` is set accordingly.
         """
         payload = {
             "jsonrpc": "2.0",
@@ -142,6 +144,22 @@ class JsonRpcClient(BaseTransportClient):
                 },
             )
             response = self._client.send(request, stream=True)
+            content_type = response.headers.get("content-type", "")
+            if "text/event-stream" not in content_type:
+                # Server returned a plain JSON-RPC response (e.g. an immediate error)
+                response.read()
+                try:
+                    body = response.json()
+                except Exception:
+                    body = response.text
+                return JsonRpcStreamingResponse(
+                    transport=self.transport,
+                    success=isinstance(body, dict) and "error" not in body,
+                    raw_response=body,
+                    events=iter([]),
+                    headers=dict(response.headers),
+                    status_code=response.status_code,
+                )
             return JsonRpcStreamingResponse(
                 transport=self.transport,
                 success=True,

--- a/tests/compatibility/jsonrpc/test_error_info.py
+++ b/tests/compatibility/jsonrpc/test_error_info.py
@@ -73,15 +73,14 @@ class TestJsonRpcErrorInfo:
         body = _get_error_response(client)
 
         data = body["error"].get("data")
-        if data is None:
-            pytest.skip("error.data is absent")
-
         valid = isinstance(data, list)
         errors = (
             []
             if valid
             else [
-                f"error.data must be an array, got {type(data).__name__}"
+                "error.data is absent — A2A errors MUST include ErrorInfo in data array"
+                if data is None
+                else f"error.data must be an array, got {type(data).__name__}"
             ]
         )
         record(
@@ -105,6 +104,7 @@ class TestJsonRpcErrorInfo:
 
         data = body["error"].get("data")
         if not isinstance(data, list):
+            record(collector=compatibility_collector, req=req, transport=TRANSPORT, passed=False, skipped=True)
             pytest.skip("error.data is not an array")
 
         valid = find_error_info(data) is not None
@@ -136,6 +136,7 @@ class TestJsonRpcErrorInfo:
 
         data = body["error"].get("data")
         if not isinstance(data, list):
+            record(collector=compatibility_collector, req=req, transport=TRANSPORT, passed=False, skipped=True)
             pytest.skip("error.data is not an array")
 
         result = validate_error_info(data)
@@ -161,6 +162,7 @@ class TestJsonRpcErrorInfo:
 
         data = body["error"].get("data")
         if not isinstance(data, list):
+            record(collector=compatibility_collector, req=req, transport=TRANSPORT, passed=False, skipped=True)
             pytest.skip("error.data is not an array")
 
         result = validate_error_info(data, expected_reason=TASK_NOT_FOUND_ERROR.reason)

--- a/tests/compatibility/jsonrpc/test_sse_streaming.py
+++ b/tests/compatibility/jsonrpc/test_sse_streaming.py
@@ -11,8 +11,6 @@ Requirements tested:
 
 from __future__ import annotations
 
-import contextlib
-
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -187,21 +185,15 @@ class TestSseSubscribeToTask:
 
         response = client.subscribe_to_task(id=tck_id("nonexistent-subscribe-001"))
 
-        # The server may return a normal JSON-RPC error (not SSE) for
-        # non-existent tasks. Check the raw httpx response.
-        body: dict | None = None
-        with contextlib.suppress(Exception):
-            body = response.raw_response.json()
-
-        if body and "error" in body:
-            code = body["error"].get("code")
+        # The server may return a plain JSON-RPC error (not SSE) for
+        # non-existent tasks — detected via success=False on the client.
+        if not response.success and response.error_code is not None:
+            code = response.error_code
             passed = code == _TASK_NOT_FOUND_CODE
             errors = (
                 []
                 if passed
-                else [
-                    f"Expected TaskNotFoundError (-32001), got code {code}"
-                ]
+                else [f"Expected TaskNotFoundError (-32001), got code {code}"]
             )
         else:
             # Try consuming events — some servers may send error as SSE event
@@ -246,15 +238,9 @@ class TestSseSubscribeToTask:
         # Subscribe to the task
         sub_response = client.subscribe_to_task(id=info.task_id)
 
-        # Check for error response (non-SSE)
-        sub_body: dict | None = None
-        with contextlib.suppress(Exception):
-            sub_body = sub_response.raw_response.json()
-        if isinstance(sub_body, dict) and "error" in sub_body:
-            pytest.skip(
-                f"SubscribeToTask returned error: "
-                f"{sub_body['error'].get('message', sub_body['error'])}"
-            )
+        # Check for error response (non-SSE) — detected via success=False on the client.
+        if not sub_response.success:
+            pytest.skip(f"SubscribeToTask returned error: {sub_response.error}")
 
         first_event = next(iter(sub_response.events), None)
         if first_event is None:


### PR DESCRIPTION
- grpc: rewrite _streaming_call to peek at the first event so that UNIMPLEMENTED / connection errors surface as success=False instead of being silently deferred; fix retry bug where rpc was not re-fetched from the new stub after reconnect
- jsonrpc: check Content-Type before entering SSE mode so that plain JSON-RPC error responses are parsed and reflected in success/error_code
- tests: replace raw response inspection with response.success / response.error_code; drop unused contextlib import
