### PR TITLE
fix: Fixing the TCK to check for the plain response body for error

### DIFF
--- a/tck/transport/jsonrpc_client.py
+++ b/tck/transport/jsonrpc_client.py
@@ -142,6 +142,21 @@ class JsonRpcClient(BaseTransportClient):
                 },
             )
             response = self._client.send(request, stream=True)
+            # If the server responded with JSON instead of SSE (e.g. an immediate
+            # JSON-RPC error before any stream is opened), treat it as a regular
+            # non-streaming response so validators can inspect the error code.
+            content_type = response.headers.get("content-type", "")
+            if "text/event-stream" not in content_type:
+                response.read()
+                body = response.json()
+                return JsonRpcStreamingResponse(
+                    transport=self.transport,
+                    success="error" not in body,
+                    raw_response=body,
+                    events=iter([]),
+                    headers=dict(response.headers),
+                    status_code=response.status_code,
+                )
             return JsonRpcStreamingResponse(
                 transport=self.transport,
                 success=True,

--- a/tests/compatibility/core_operations/test_task_lifecycle.py
+++ b/tests/compatibility/core_operations/test_task_lifecycle.py
@@ -449,7 +449,8 @@ class TestSubscribeLifecycle:
         if sub_response.success:
             # Some servers may return success but deliver an error on iteration
             try:
-                collect_events_with_timeout(sub_response.events)[0]
+                events, _ = collect_events_with_timeout(sub_response.events)
+                _ = events[0]  # raises IndexError if no events were received
                 errors.append(
                     "SubscribeToTask on a terminal task should return an error, "
                     "but succeeded"

--- a/tests/compatibility/jsonrpc/test_sse_streaming.py
+++ b/tests/compatibility/jsonrpc/test_sse_streaming.py
@@ -188,10 +188,12 @@ class TestSseSubscribeToTask:
         response = client.subscribe_to_task(id=tck_id("nonexistent-subscribe-001"))
 
         # The server may return a normal JSON-RPC error (not SSE) for
-        # non-existent tasks. Check the raw httpx response.
+        # non-existent tasks. Check the raw response — may be an httpx.Response
+        # or an already-parsed dict (when the client detected a non-SSE reply).
         body: dict | None = None
         with contextlib.suppress(Exception):
-            body = response.raw_response.json()
+            raw = response.raw_response
+            body = raw if isinstance(raw, dict) else raw.json()
 
         if body and "error" in body:
             code = body["error"].get("code")


### PR DESCRIPTION
instead of expecting a SSE event with the error payload.

STREAM-SUB-003 and STREAM-SUB-004 should be passing now.
