### PR TITLE
feat: add push notification delivery tests with webhook receiver

### DIFF
--- a/backlog/tasks/task-11.7 - Implement-push-notification-conformance-tests.md
+++ b/backlog/tasks/task-11.7 - Implement-push-notification-conformance-tests.md
@@ -1,0 +1,70 @@
+---
+id: TASK-11.7
+title: Implement push notification conformance tests
+status: To Do
+assignee: []
+created_date: '2026-04-22 07:42'
+updated_date: '2026-04-22 07:45'
+labels:
+  - conformance-tests
+  - push-notification
+  - validators
+dependencies:
+  - TASK-11.1
+parent_task_id: TASK-11
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement conformance tests and payload validators for push notification requirements (PUSH-* prefix).
+
+## TCK webhook receiver
+The TCK will spin up a lightweight HTTP server during push notification tests to act as a webhook receiver. This makes the PUSH-DELIVER-* requirements automatable:
+1. TCK starts an HTTP server on a free port
+2. Test creates a push notification config pointing at the TCK's webhook URL
+3. Test triggers a task update (e.g. send a message)
+4. TCK webhook server captures the incoming request
+5. Test asserts on the webhook payload (StreamResponse format), headers (auth credentials), and delivery guarantees
+
+## CRUD requirements (~7 tests)
+These test the push notification config lifecycle via JSON-RPC/gRPC calls:
+
+- **PUSH-CREATE-001**: CreatePushNotificationConfig establishes webhook endpoint — validate response contains push config with required fields
+- **PUSH-CREATE-002**: Push config persists until task completion or deletion — validate config persists across multiple retrievals
+- **PUSH-GET-001**: GetPushNotificationConfig returns configuration details — validate response matches created config
+- **PUSH-GET-002**: GetPushNotificationConfig fails for nonexistent config — validate error response
+- **PUSH-LIST-001**: ListPushNotificationConfigs returns all active configs — validate response is array of configs
+- **PUSH-DEL-001**: DeletePushNotificationConfig permanently removes config — validate successful deletion response
+- **PUSH-DEL-002**: DeletePushNotificationConfig is idempotent — validate repeated deletions succeed
+
+## Webhook delivery requirements (~3 tests)
+These test end-to-end push notification delivery using the TCK webhook receiver:
+
+- **PUSH-DELIVER-001**: Agent includes authentication in webhook requests — assert auth credentials in received request headers
+- **PUSH-DELIVER-002**: Agent attempts delivery at least once per webhook — assert at least one request received per config
+- **PUSH-DELIVER-003**: Webhook payload uses StreamResponse format — validate received payload structure
+
+## Key files
+- `tck/requirements/push_notifications.py` — existing requirement definitions
+- `tck/tests/` — conformance test location
+- `tck/validators/` — payload validator location
+
+## Approach
+1. Implement a reusable TCK webhook receiver (HTTP server with request capture and async wait)
+2. Add payload validators for PUSH-CREATE, PUSH-GET, PUSH-LIST, PUSH-DEL responses
+3. Write Gherkin scenarios for all 10 push notification requirements
+4. Implement step definitions for push notification tests
+5. Ensure tests work across both JSON-RPC and gRPC transports
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Reusable TCK webhook receiver implemented (HTTP server with request capture and configurable timeout)
+- [ ] #2 Payload validators exist for PUSH-CREATE-001, PUSH-GET-001, PUSH-LIST-001, PUSH-DEL-001 responses
+- [ ] #3 Conformance tests cover all 7 CRUD PUSH-* requirements
+- [ ] #4 Conformance tests cover all 3 PUSH-DELIVER-* requirements using the TCK webhook receiver
+- [ ] #5 Tests pass against a2a-java and a2a-python SUTs that support push notifications
+- [ ] #6 make lint and make unit-test pass
+<!-- AC:END -->

--- a/codegen/a2a-java/TckAgentCardProducer.java.j2
+++ b/codegen/a2a-java/TckAgentCardProducer.java.j2
@@ -39,6 +39,7 @@ public class TckAgentCardProducer {
                         new AgentInterface(TransportProtocol.HTTP_JSON.asString(), sutRestUrl)))
                 .capabilities(AgentCapabilities.builder()
                         .streaming({{ has_streaming | lower }})
+                        .pushNotifications({{ has_push_notifications | lower }})
                         .build())
                 .defaultInputModes(List.of("text"))
                 .defaultOutputModes(List.of("text"))

--- a/codegen/java_emitter.py
+++ b/codegen/java_emitter.py
@@ -34,7 +34,7 @@ from codegen.model import (
 
 _TEMPLATES_DIR = Path(__file__).parent / "a2a-java"
 
-_DEFAULT_A2A_JAVA_SDK_VERSION = "1.0.0.Beta1-SNAPSHOT"
+_DEFAULT_A2A_JAVA_SDK_VERSION = "1.0.0.Beta2-SNAPSHOT"
 
 _JAVA_PACKAGE = "org.a2aproject.sdk.sut"
 _JAVA_PACKAGE_DIR = _JAVA_PACKAGE.replace(".", "/")

--- a/codegen/java_emitter.py
+++ b/codegen/java_emitter.py
@@ -71,6 +71,7 @@ def emit_java_project(scenarios: list[Scenario], output_dir: Path) -> list[Path]
     context = {
         "handlers": handlers,
         "has_streaming": has_streaming,
+        "has_push_notifications": True,
         "package": _JAVA_PACKAGE,
         "a2a_java_sdk_version": a2a_java_sdk_version,
     }

--- a/sut/a2a-java/pom.xml
+++ b/sut/a2a-java/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <quarkus.platform.version>3.30.6</quarkus.platform.version>
-        <a2a-java-sdk.version>1.0.0.Beta1-SNAPSHOT</a2a-java-sdk.version>
+        <a2a-java-sdk.version>1.0.0.Beta2-SNAPSHOT</a2a-java-sdk.version>
         <protobuf-java.version>4.33.1</protobuf-java.version>
     </properties>
 

--- a/sut/a2a-java/src/main/java/org/a2aproject/sdk/sut/TckAgentCardProducer.java
+++ b/sut/a2a-java/src/main/java/org/a2aproject/sdk/sut/TckAgentCardProducer.java
@@ -39,6 +39,7 @@ public class TckAgentCardProducer {
                         new AgentInterface(TransportProtocol.HTTP_JSON.asString(), sutRestUrl)))
                 .capabilities(AgentCapabilities.builder()
                         .streaming(true)
+                        .pushNotifications(true)
                         .build())
                 .defaultInputModes(List.of("text"))
                 .defaultOutputModes(List.of("text"))

--- a/tck/requirements/push_notifications.py
+++ b/tck/requirements/push_notifications.py
@@ -27,7 +27,6 @@ from tck.requirements.tags import (
     IDEMPOTENT,
     LIST,
     MULTI_OPERATION,
-    NOT_AUTOMATABLE,
     PUSH_NOTIFICATION,
 )
 
@@ -162,7 +161,7 @@ PUSH_NOTIFICATION_REQUIREMENTS: list[RequirementSpec] = [
         ),
         expected_behavior="Webhook requests include configured auth credentials",
         spec_url=f"{SPEC_BASE}433-push-notification-payload",
-        tags=[PUSH_NOTIFICATION, DELIVERY, AUTH, NOT_AUTOMATABLE],
+        tags=[PUSH_NOTIFICATION, DELIVERY, AUTH],
     ),
     RequirementSpec(
         id="PUSH-DELIVER-002",
@@ -175,7 +174,7 @@ PUSH_NOTIFICATION_REQUIREMENTS: list[RequirementSpec] = [
         ),
         expected_behavior="At-least-once delivery attempted",
         spec_url=f"{SPEC_BASE}433-push-notification-payload",
-        tags=[PUSH_NOTIFICATION, DELIVERY, NOT_AUTOMATABLE],
+        tags=[PUSH_NOTIFICATION, DELIVERY],
     ),
     RequirementSpec(
         id="PUSH-DELIVER-003",
@@ -188,6 +187,6 @@ PUSH_NOTIFICATION_REQUIREMENTS: list[RequirementSpec] = [
         ),
         expected_behavior="Payload is valid StreamResponse with single field",
         spec_url=f"{SPEC_BASE}433-push-notification-payload",
-        tags=[PUSH_NOTIFICATION, DELIVERY, FORMAT, NOT_AUTOMATABLE],
+        tags=[PUSH_NOTIFICATION, DELIVERY, FORMAT],
     ),
 ]

--- a/tck/transport/http_json_client.py
+++ b/tck/transport/http_json_client.py
@@ -145,7 +145,7 @@ class HttpJsonClient(BaseTransportClient):
                     headers=resp_headers,
                     status_code=response.status_code,
                 )
-            body = response.json()
+            body = response.json() if response.content else {}
             return HttpJsonResponse(
                 transport=self.transport,
                 success=True,

--- a/tck/webhook/__init__.py
+++ b/tck/webhook/__init__.py
@@ -1,0 +1,1 @@
+"""Webhook receiver for push notification delivery testing."""

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -78,7 +78,7 @@ class WebhookReceiver:
                 """Handle POST requests from the SUT."""
                 length = int(self.headers.get("Content-Length", 0))
                 body = self.rfile.read(length) if length else b""
-                headers = dict(self.headers.items())
+                headers = {k.lower(): v for k, v in self.headers.items()}
                 req = WebhookRequest(
                     method="POST",
                     path=self.path,

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -100,6 +100,7 @@ class WebhookReceiver:
         """Shut down the server and join the background thread."""
         if self._server is not None:
             self._server.shutdown()
+            self._server.server_close()
             self._server = None
         if self._thread is not None:
             self._thread.join(timeout=5)

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -52,6 +52,7 @@ class WebhookReceiver:
     _thread: threading.Thread | None = field(default=None, init=False, repr=False)
     _requests: list[WebhookRequest] = field(default_factory=list, init=False, repr=False)
     _request_event: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     @property
     def port(self) -> int:

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -76,9 +76,12 @@ class WebhookReceiver:
         class _Handler(BaseHTTPRequestHandler):
             def do_POST(self) -> None:
                 """Handle POST requests from the SUT."""
-                length = int(self.headers.get("Content-Length", 0))
-                body = self.rfile.read(length) if length else b""
                 headers = {k.lower(): v for k, v in self.headers.items()}
+                try:
+                    length = int(headers.get("content-length", "0"))
+                except (ValueError, TypeError):
+                    length = 0
+                body = self.rfile.read(length) if length else b""
                 req = WebhookRequest(
                     method="POST",
                     path=self.path,

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -118,13 +118,22 @@ class WebhookReceiver:
             self._request_event.clear()
 
     def wait_for_request(self, timeout: float = 10) -> WebhookRequest | None:
-        """Block until a request arrives or *timeout* seconds elapse."""
+        """Block until a request arrives or *timeout* seconds elapse.
+
+        Each call consumes the oldest queued request so that sequential
+        calls return successive webhook deliveries.
+        """
         with self._lock:
             if self._requests:
-                return self._requests[0]
+                return self._requests.pop(0)
         self._request_event.wait(timeout=timeout)
         with self._lock:
-            return self._requests[0] if self._requests else None
+            if not self._requests:
+                return None
+            req = self._requests.pop(0)
+            if not self._requests:
+                self._request_event.clear()
+            return req
 
     def get_requests(self) -> list[WebhookRequest]:
         """Return a copy of all captured requests."""

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -1,0 +1,122 @@
+"""Lightweight HTTP server that captures incoming webhook requests.
+
+Used by push notification delivery tests (PUSH-DELIVER-*) to verify
+that the SUT sends webhook payloads when a task state changes.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+
+@dataclass
+class WebhookRequest:
+    """A captured webhook request."""
+
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: bytes
+    json_body: Any = None
+
+    def __post_init__(self) -> None:  # noqa: D105
+        if self.json_body is None and self.body:
+            with contextlib.suppress(json.JSONDecodeError, UnicodeDecodeError):
+                self.json_body = json.loads(self.body)
+
+
+@dataclass
+class WebhookReceiver:
+    """HTTP server that captures webhook requests for assertion.
+
+    Typical usage::
+
+        receiver = WebhookReceiver()
+        receiver.start()
+        try:
+            # configure SUT to POST to receiver.url
+            request = receiver.wait_for_request(timeout=10)
+            assert request is not None
+        finally:
+            receiver.stop()
+    """
+
+    host: str = "0.0.0.0"
+    _server: HTTPServer | None = field(default=None, init=False, repr=False)
+    _thread: threading.Thread | None = field(default=None, init=False, repr=False)
+    _requests: list[WebhookRequest] = field(default_factory=list, init=False, repr=False)
+    _request_event: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
+
+    @property
+    def port(self) -> int:
+        """Return the port the server is listening on."""
+        if self._server is None:
+            raise RuntimeError("Server not started")
+        return self._server.server_address[1]
+
+    def url(self, webhook_host: str = "localhost") -> str:
+        """Return the full webhook URL using the given host."""
+        return f"http://{webhook_host}:{self.port}/webhook"
+
+    def record_request(self, req: WebhookRequest) -> None:
+        """Append a captured request and signal any waiters."""
+        self._requests.append(req)
+        self._request_event.set()
+
+    def start(self) -> None:
+        """Start the webhook receiver in a background thread."""
+        receiver = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                """Handle POST requests from the SUT."""
+                length = int(self.headers.get("Content-Length", 0))
+                body = self.rfile.read(length) if length else b""
+                headers = dict(self.headers.items())
+                req = WebhookRequest(
+                    method="POST",
+                    path=self.path,
+                    headers=headers,
+                    body=body,
+                )
+                receiver.record_request(req)
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, format: str, *args: Any) -> None:
+                """Suppress request logging."""
+
+        self._server = HTTPServer((self.host, 0), _Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Shut down the server and join the background thread."""
+        if self._server is not None:
+            self._server.shutdown()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def clear(self) -> None:
+        """Discard all captured requests."""
+        self._requests.clear()
+        self._request_event.clear()
+
+    def wait_for_request(self, timeout: float = 10) -> WebhookRequest | None:
+        """Block until a request arrives or *timeout* seconds elapse."""
+        if self._requests:
+            return self._requests[0]
+        self._request_event.wait(timeout=timeout)
+        return self._requests[0] if self._requests else None
+
+    def get_requests(self) -> list[WebhookRequest]:
+        """Return a copy of all captured requests."""
+        return list(self._requests)

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -113,8 +113,9 @@ class WebhookReceiver:
 
     def clear(self) -> None:
         """Discard all captured requests."""
-        self._requests.clear()
-        self._request_event.clear()
+        with self._lock:
+            self._requests.clear()
+            self._request_event.clear()
 
     def wait_for_request(self, timeout: float = 10) -> WebhookRequest | None:
         """Block until a request arrives or *timeout* seconds elapse."""

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -65,10 +65,11 @@ class WebhookReceiver:
         """Return the full webhook URL using the given host."""
         return f"http://{webhook_host}:{self.port}/webhook"
 
-    def record_request(self, req: WebhookRequest) -> None:
+    def record_request(self, req: WebhookRequest) -> None: 
         """Append a captured request and signal any waiters."""
-        self._requests.append(req)
-        self._request_event.set()
+        with self._lock:
+            self._requests.append(req)
+            self._request_event.set()
 
     def start(self) -> None:
         """Start the webhook receiver in a background thread."""

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -65,7 +65,7 @@ class WebhookReceiver:
         """Return the full webhook URL using the given host."""
         return f"http://{webhook_host}:{self.port}/webhook"
 
-    def record_request(self, req: WebhookRequest) -> None: 
+    def record_request(self, req: WebhookRequest) -> None:
         """Append a captured request and signal any waiters."""
         with self._lock:
             self._requests.append(req)

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -119,10 +119,12 @@ class WebhookReceiver:
 
     def wait_for_request(self, timeout: float = 10) -> WebhookRequest | None:
         """Block until a request arrives or *timeout* seconds elapse."""
-        if self._requests:
-            return self._requests[0]
+        with self._lock:
+            if self._requests:
+                return self._requests[0]
         self._request_event.wait(timeout=timeout)
-        return self._requests[0] if self._requests else None
+        with self._lock:
+            return self._requests[0] if self._requests else None
 
     def get_requests(self) -> list[WebhookRequest]:
         """Return a copy of all captured requests."""

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -128,4 +128,5 @@ class WebhookReceiver:
 
     def get_requests(self) -> list[WebhookRequest]:
         """Return a copy of all captured requests."""
-        return list(self._requests)
+        with self._lock:
+            return list(self._requests)

--- a/tests/compatibility/conftest.py
+++ b/tests/compatibility/conftest.py
@@ -17,6 +17,7 @@ from tck.transport.jsonrpc_client import JsonRpcClient
 from tck.validators.json_schema import JSONSchemaValidator
 from tck.validators.jsonrpc.response_validator import JsonRpcResponseValidator
 from tck.validators.proto_schema import ProtoSchemaValidator
+from tck.webhook.server import WebhookReceiver
 
 
 if TYPE_CHECKING:
@@ -65,6 +66,15 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         dest="compatibility_report",
         default=None,
         help="Output path for the compatibility report.",
+    )
+    group.addoption(
+        "--webhook-host",
+        dest="webhook_host",
+        default="localhost",
+        help=(
+            "Hostname the SUT uses to reach the TCK webhook receiver "
+            "(default: localhost)."
+        ),
     )
 
 
@@ -166,6 +176,21 @@ def validators() -> dict[str, Any]:
         "jsonrpc": JsonRpcResponseValidator(json_schema_validator),
         "http_json": json_schema_validator,
     }
+
+
+@pytest.fixture(scope="session")
+def webhook_host(request: pytest.FixtureRequest) -> str:
+    """Return the hostname the SUT should use to reach the webhook receiver."""
+    return request.config.getoption("--webhook-host")
+
+
+@pytest.fixture(scope="session")
+def webhook_receiver() -> WebhookReceiver:
+    """Start a webhook receiver for the duration of the test session."""
+    receiver = WebhookReceiver()
+    receiver.start()
+    yield receiver
+    receiver.stop()
 
 
 @pytest.fixture(scope="session")

--- a/tests/compatibility/core_operations/test_push_notifications.py
+++ b/tests/compatibility/core_operations/test_push_notifications.py
@@ -427,7 +427,7 @@ class TestPushNotificationDelivery:
         if webhook_req is None:
             errors.append("No webhook request received within timeout")
         else:
-            auth_header = webhook_req.headers.get("Authorization", "")
+            auth_header = webhook_req.headers.get("authorization", "")
             expected = f"{_AUTH_SCHEME} {_AUTH_CREDENTIALS}"
             if auth_header != expected:
                 errors.append(

--- a/tests/compatibility/core_operations/test_push_notifications.py
+++ b/tests/compatibility/core_operations/test_push_notifications.py
@@ -373,7 +373,7 @@ def _setup_push_and_trigger(
     """Create a task with inline push config, then trigger a state change.
 
     Sends the push notification config alongside the initial SendMessage
-    via the ``configuration.pushNotificationConfig`` field, then sends a
+    via the ``configuration.taskPushNotificationConfig`` field, then sends a
     follow-up message to complete the task and trigger webhook delivery.
 
     Returns (push_config, task_id).

--- a/tests/compatibility/core_operations/test_push_notifications.py
+++ b/tests/compatibility/core_operations/test_push_notifications.py
@@ -1,16 +1,19 @@
-"""Cross-transport push notification CRUD tests.
+"""Cross-transport push notification tests.
 
 Validates push notification configuration lifecycle operations
-that require a real task to exist first.
+and webhook delivery behavior.
 
 Requirements tested:
-    PUSH-CREATE-001 — CreatePushNotificationConfig returns config
-    PUSH-CREATE-002 — Config persists after creation
-    PUSH-GET-001    — GetPushNotificationConfig returns config details
-    PUSH-GET-002    — GetPushNotificationConfig for nonexistent returns error
-    PUSH-LIST-001   — ListPushNotificationConfigs includes created config
-    PUSH-DEL-001    — DeletePushNotificationConfig removes config
-    PUSH-DEL-002    — Delete is idempotent
+    PUSH-CREATE-001  — CreatePushNotificationConfig returns config
+    PUSH-CREATE-002  — Config persists after creation
+    PUSH-GET-001     — GetPushNotificationConfig returns config details
+    PUSH-GET-002     — GetPushNotificationConfig for nonexistent returns error
+    PUSH-LIST-001    — ListPushNotificationConfigs includes created config
+    PUSH-DEL-001     — DeletePushNotificationConfig removes config
+    PUSH-DEL-002     — Delete is idempotent
+    PUSH-DELIVER-001 — Agent includes auth in webhook requests
+    PUSH-DELIVER-002 — Agent attempts delivery at least once
+    PUSH-DELIVER-003 — Webhook payload uses StreamResponse format
 """
 
 from __future__ import annotations
@@ -22,13 +25,15 @@ import pytest
 from tck.requirements.base import tck_id
 from tck.requirements.registry import get_requirement_by_id
 from tck.transport import ALL_TRANSPORTS
-from tests.compatibility._task_helpers import create_completed_task
+from tests.compatibility._task_helpers import create_completed_task, create_working_task
 from tests.compatibility._test_helpers import assert_and_record, get_client, record
 from tests.compatibility.markers import must
 
 
 if TYPE_CHECKING:
     from tck.transport.base import BaseTransportClient
+    from tck.validators.json_schema import JSONSchemaValidator
+    from tck.webhook.server import WebhookReceiver
 
 
 # ---------------------------------------------------------------------------
@@ -42,6 +47,17 @@ PUSH_GET_002 = get_requirement_by_id("PUSH-GET-002")
 PUSH_LIST_001 = get_requirement_by_id("PUSH-LIST-001")
 PUSH_DEL_001 = get_requirement_by_id("PUSH-DEL-001")
 PUSH_DEL_002 = get_requirement_by_id("PUSH-DEL-002")
+PUSH_DELIVER_001 = get_requirement_by_id("PUSH-DELIVER-001")
+PUSH_DELIVER_002 = get_requirement_by_id("PUSH-DELIVER-002")
+PUSH_DELIVER_003 = get_requirement_by_id("PUSH-DELIVER-003")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_AUTH_SCHEME = "Bearer"
+_AUTH_CREDENTIALS = f"tck-test-token-{tck_id('auth')}"
 
 
 # ---------------------------------------------------------------------------
@@ -55,6 +71,29 @@ def _push_config() -> dict:
         "id": tck_id("push"),
         "url": "https://example.com/tck-push-webhook",
     }
+
+
+def _push_config_with_webhook(webhook_url: str) -> dict:
+    """Generate a push notification config pointing at the TCK webhook receiver."""
+    return {
+        "id": tck_id("push"),
+        "url": webhook_url,
+        "authentication": {
+            "scheme": _AUTH_SCHEME,
+            "credentials": _AUTH_CREDENTIALS,
+        },
+    }
+
+
+def _trigger_state_change(client: Any) -> tuple[str, str | None]:
+    """Create a task in input_required state, then complete it.
+
+    Returns (task_id, context_id) so the caller can register a push
+    config between creation and completion.  This helper only does the
+    first step (creating the working task).
+    """
+    info = create_working_task(client)
+    return info.task_id, info.context_id
 
 
 # ---------------------------------------------------------------------------
@@ -316,5 +355,151 @@ class TestPushNotificationCrud:
                 f"Second delete should be idempotent (no error), "
                 f"but returned: {second_del.error}"
             )
+
+        assert_and_record(compatibility_collector, req, transport, errors)
+
+
+# ---------------------------------------------------------------------------
+# Push notification delivery tests
+# ---------------------------------------------------------------------------
+
+_DELIVERY_TIMEOUT_S = 15
+
+
+def _setup_push_and_trigger(
+    client: Any,
+    webhook_url: str,
+) -> tuple[dict, str]:
+    """Create a working task, register a push config, and trigger a state change.
+
+    Returns (push_config, task_id).
+    """
+    task_id, _ = _trigger_state_change(client)
+
+    config = _push_config_with_webhook(webhook_url)
+    create_resp = client.create_push_notification_config(
+        task_id=task_id,
+        config=config,
+    )
+    if not create_resp.success:
+        pytest.skip(f"CreatePushNotificationConfig failed: {create_resp.error}")
+
+    followup: dict[str, Any] = {
+        "role": "ROLE_USER",
+        "parts": [{"text": "TCK trigger push notification delivery"}],
+        "messageId": tck_id("complete-task"),
+        "taskId": task_id,
+    }
+    response = client.send_message(message=followup)
+    if not response.success:
+        pytest.skip(f"Follow-up send_message failed: {response.error}")
+
+    return config, task_id
+
+
+@must
+@pytest.mark.parametrize("transport", ALL_TRANSPORTS)
+class TestPushNotificationDelivery:
+    """Tests for push notification webhook delivery."""
+
+    def test_delivery_includes_auth(
+        self,
+        transport: str,
+        transport_clients: dict[str, BaseTransportClient],
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+        webhook_receiver: WebhookReceiver,
+        webhook_host: str,
+    ) -> None:
+        """PUSH-DELIVER-001: Agent includes auth credentials in webhook requests."""
+        req = PUSH_DELIVER_001
+        caps = agent_card.get("capabilities", {})
+        if not caps.get("pushNotifications"):
+            record(collector=compatibility_collector, req=req, transport=transport, passed=False, skipped=True)
+            pytest.skip("Agent does not support push notifications")
+        client = get_client(transport_clients, transport, compatibility_collector=compatibility_collector, req=req)
+
+        webhook_receiver.clear()
+        _setup_push_and_trigger(client, webhook_receiver.url(webhook_host))
+        webhook_req = webhook_receiver.wait_for_request(timeout=_DELIVERY_TIMEOUT_S)
+
+        errors: list[str] = []
+        if webhook_req is None:
+            errors.append("No webhook request received within timeout")
+        else:
+            auth_header = webhook_req.headers.get("Authorization", "")
+            expected = f"{_AUTH_SCHEME} {_AUTH_CREDENTIALS}"
+            if auth_header != expected:
+                errors.append(
+                    f"Expected Authorization header '{expected}', "
+                    f"got '{auth_header}'"
+                )
+
+        assert_and_record(compatibility_collector, req, transport, errors)
+
+    def test_delivery_at_least_once(
+        self,
+        transport: str,
+        transport_clients: dict[str, BaseTransportClient],
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+        webhook_receiver: WebhookReceiver,
+        webhook_host: str,
+    ) -> None:
+        """PUSH-DELIVER-002: Agent attempts delivery at least once per webhook."""
+        req = PUSH_DELIVER_002
+        caps = agent_card.get("capabilities", {})
+        if not caps.get("pushNotifications"):
+            record(collector=compatibility_collector, req=req, transport=transport, passed=False, skipped=True)
+            pytest.skip("Agent does not support push notifications")
+        client = get_client(transport_clients, transport, compatibility_collector=compatibility_collector, req=req)
+
+        webhook_receiver.clear()
+        _setup_push_and_trigger(client, webhook_receiver.url(webhook_host))
+        webhook_req = webhook_receiver.wait_for_request(timeout=_DELIVERY_TIMEOUT_S)
+
+        errors: list[str] = []
+        if webhook_req is None:
+            errors.append(
+                "No webhook delivery received — agent MUST attempt "
+                "at least one delivery per configured webhook"
+            )
+
+        assert_and_record(compatibility_collector, req, transport, errors)
+
+    def test_delivery_payload_format(
+        self,
+        transport: str,
+        transport_clients: dict[str, BaseTransportClient],
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+        webhook_receiver: WebhookReceiver,
+        webhook_host: str,
+        validators: dict[str, Any],
+    ) -> None:
+        """PUSH-DELIVER-003: Webhook payload uses StreamResponse format."""
+        req = PUSH_DELIVER_003
+        caps = agent_card.get("capabilities", {})
+        if not caps.get("pushNotifications"):
+            record(collector=compatibility_collector, req=req, transport=transport, passed=False, skipped=True)
+            pytest.skip("Agent does not support push notifications")
+        client = get_client(transport_clients, transport, compatibility_collector=compatibility_collector, req=req)
+
+        webhook_receiver.clear()
+        _setup_push_and_trigger(client, webhook_receiver.url(webhook_host))
+        webhook_req = webhook_receiver.wait_for_request(timeout=_DELIVERY_TIMEOUT_S)
+
+        errors: list[str] = []
+        if webhook_req is None:
+            errors.append("No webhook request received within timeout")
+        elif webhook_req.json_body is None:
+            errors.append(
+                f"Webhook body is not valid JSON: {webhook_req.body!r}"
+            )
+        else:
+            json_validator: JSONSchemaValidator = validators["http_json"]
+            result = json_validator.validate(webhook_req.json_body, "Stream Response")
+            if not result.valid:
+                errors.extend(result.errors)
 
         assert_and_record(compatibility_collector, req, transport, errors)

--- a/tests/compatibility/core_operations/test_push_notifications.py
+++ b/tests/compatibility/core_operations/test_push_notifications.py
@@ -370,19 +370,29 @@ def _setup_push_and_trigger(
     client: Any,
     webhook_url: str,
 ) -> tuple[dict, str]:
-    """Create a working task, register a push config, and trigger a state change.
+    """Create a task with inline push config, then trigger a state change.
+
+    Sends the push notification config alongside the initial SendMessage
+    via the ``configuration.pushNotificationConfig`` field, then sends a
+    follow-up message to complete the task and trigger webhook delivery.
 
     Returns (push_config, task_id).
     """
-    task_id, _ = _trigger_state_change(client)
-
     config = _push_config_with_webhook(webhook_url)
-    create_resp = client.create_push_notification_config(
-        task_id=task_id,
-        config=config,
-    )
-    if not create_resp.success:
-        pytest.skip(f"CreatePushNotificationConfig failed: {create_resp.error}")
+
+    message: dict[str, Any] = {
+        "role": "ROLE_USER",
+        "parts": [{"text": "TCK prerequisite task creation"}],
+        "messageId": tck_id("input-required"),
+    }
+    configuration = {"taskPushNotificationConfig": config}
+    response = client.send_message(message=message, configuration=configuration)
+    if not response.success:
+        pytest.skip(f"send_message failed: {response.error}")
+
+    task_id = response.task_id
+    if not task_id:
+        pytest.skip("Could not extract task ID from send_message response")
 
     followup: dict[str, Any] = {
         "role": "ROLE_USER",

--- a/tests/unit/webhook/test_server.py
+++ b/tests/unit/webhook/test_server.py
@@ -135,7 +135,10 @@ class TestWebhookReceiver:
                     headers={"Content-Type": "application/json"},
                 )
             import time
-            time.sleep(0.2)
+            for _ in range(20):
+                if len(receiver.get_requests()) == num_requests:
+                    break
+                time.sleep(0.1)
             requests = receiver.get_requests()
             assert len(requests) == num_requests
             for i, req in enumerate(requests):

--- a/tests/unit/webhook/test_server.py
+++ b/tests/unit/webhook/test_server.py
@@ -80,7 +80,7 @@ class TestWebhookReceiver:
             assert req is not None
             assert req.method == "POST"
             assert req.json_body == payload
-            assert req.headers.get("Authorization") == "Bearer test-token"
+            assert req.headers.get("authorization") == "Bearer test-token"
         finally:
             receiver.stop()
 

--- a/tests/unit/webhook/test_server.py
+++ b/tests/unit/webhook/test_server.py
@@ -1,0 +1,144 @@
+"""Tests for the webhook receiver server."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from tck.webhook.server import WebhookReceiver, WebhookRequest
+
+
+class TestWebhookRequest:
+    """Tests for WebhookRequest dataclass."""
+
+    def test_json_body_parsed(self) -> None:
+        """JSON body is parsed automatically."""
+        req = WebhookRequest(
+            method="POST",
+            path="/webhook",
+            headers={},
+            body=b'{"task": {"id": "123"}}',
+        )
+        assert req.json_body == {"task": {"id": "123"}}
+
+    def test_invalid_json_body(self) -> None:
+        """Non-JSON body leaves json_body as None."""
+        req = WebhookRequest(
+            method="POST",
+            path="/webhook",
+            headers={},
+            body=b"not json",
+        )
+        assert req.json_body is None
+
+    def test_empty_body(self) -> None:
+        """Empty body leaves json_body as None."""
+        req = WebhookRequest(
+            method="POST",
+            path="/webhook",
+            headers={},
+            body=b"",
+        )
+        assert req.json_body is None
+
+
+class TestWebhookReceiver:
+    """Tests for WebhookReceiver lifecycle and request capture."""
+
+    def test_start_and_stop(self) -> None:
+        """Server starts on a random port and stops cleanly."""
+        receiver = WebhookReceiver()
+        receiver.start()
+        try:
+            assert receiver.port > 0
+        finally:
+            receiver.stop()
+
+    def test_url(self) -> None:
+        """URL includes the correct host and port."""
+        receiver = WebhookReceiver()
+        receiver.start()
+        try:
+            assert receiver.url() == f"http://localhost:{receiver.port}/webhook"
+            assert receiver.url("myhost") == f"http://myhost:{receiver.port}/webhook"
+        finally:
+            receiver.stop()
+
+    def test_captures_post_request(self) -> None:
+        """POST requests are captured with headers and body."""
+        receiver = WebhookReceiver()
+        receiver.start()
+        try:
+            payload = {"statusUpdate": {"state": "TASK_STATE_COMPLETED"}}
+            httpx.post(
+                receiver.url(),
+                json=payload,
+                headers={"Authorization": "Bearer test-token"},
+            )
+            req = receiver.wait_for_request(timeout=5)
+            assert req is not None
+            assert req.method == "POST"
+            assert req.json_body == payload
+            assert req.headers.get("Authorization") == "Bearer test-token"
+        finally:
+            receiver.stop()
+
+    def test_wait_for_request_timeout(self) -> None:
+        """wait_for_request returns None on timeout."""
+        receiver = WebhookReceiver()
+        receiver.start()
+        try:
+            req = receiver.wait_for_request(timeout=0.1)
+            assert req is None
+        finally:
+            receiver.stop()
+
+    def test_clear(self) -> None:
+        """clear() discards captured requests."""
+        receiver = WebhookReceiver()
+        receiver.start()
+        try:
+            httpx.post(receiver.url(), json={"task": {}})
+            assert receiver.wait_for_request(timeout=5) is not None
+
+            receiver.clear()
+            assert receiver.get_requests() == []
+            assert receiver.wait_for_request(timeout=0.1) is None
+        finally:
+            receiver.stop()
+
+    def test_get_requests_returns_copy(self) -> None:
+        """get_requests() returns a snapshot, not a live reference."""
+        receiver = WebhookReceiver()
+        receiver.start()
+        try:
+            httpx.post(receiver.url(), json={"task": {}})
+            receiver.wait_for_request(timeout=5)
+            requests = receiver.get_requests()
+            assert len(requests) == 1
+            receiver.clear()
+            assert len(requests) == 1
+        finally:
+            receiver.stop()
+
+    def test_multiple_requests(self) -> None:
+        """Multiple requests are all captured."""
+        receiver = WebhookReceiver()
+        receiver.start()
+        num_requests = 3
+        try:
+            for i in range(num_requests):
+                httpx.post(
+                    receiver.url(),
+                    content=json.dumps({"index": i}).encode(),
+                    headers={"Content-Type": "application/json"},
+                )
+            import time
+            time.sleep(0.2)
+            requests = receiver.get_requests()
+            assert len(requests) == num_requests
+            for i, req in enumerate(requests):
+                assert req.json_body["index"] == i
+        finally:
+            receiver.stop()

--- a/tests/unit/webhook/test_server.py
+++ b/tests/unit/webhook/test_server.py
@@ -112,13 +112,32 @@ class TestWebhookReceiver:
         """get_requests() returns a snapshot, not a live reference."""
         receiver = WebhookReceiver()
         receiver.start()
+        num_requests = 2
         try:
-            httpx.post(receiver.url(), json={"task": {}})
-            receiver.wait_for_request(timeout=5)
+            for _ in range(num_requests):
+                httpx.post(receiver.url(), json={"task": {}})
+            import time
+            time.sleep(0.5)
             requests = receiver.get_requests()
-            assert len(requests) == 1
+            assert len(requests) == num_requests
             receiver.clear()
-            assert len(requests) == 1
+            assert len(requests) == num_requests
+        finally:
+            receiver.stop()
+
+    def test_wait_for_request_consumes(self) -> None:
+        """wait_for_request() returns successive requests on each call."""
+        receiver = WebhookReceiver()
+        receiver.start()
+        try:
+            httpx.post(receiver.url(), json={"first": True})
+            httpx.post(receiver.url(), json={"second": True})
+            import time
+            time.sleep(0.5)
+            r1 = receiver.wait_for_request(timeout=5)
+            r2 = receiver.wait_for_request(timeout=5)
+            assert r1 is not None and r1.json_body == {"first": True}
+            assert r2 is not None and r2.json_body == {"second": True}
         finally:
             receiver.stop()
 


### PR DESCRIPTION
* add TASK-11.7 for push notification conformance tests
* Implements TASK-11.7: the TCK now spins up a lightweight HTTP server during tests to receive push notification webhooks, making all three PUSH-DELIVER-* requirements automatable.
* enable push notification capability in a2a-java SUT

Changes:
- Add tck/webhook/server.py with WebhookReceiver (captures requests for assertion in tests)
- Add delivery tests for PUSH-DELIVER-001 (auth headers), PUSH-DELIVER-002 (at-least-once delivery), PUSH-DELIVER-003 (StreamResponse payload format)
- Add --webhook-host CLI option for remote SUT setups
- Remove NOT_AUTOMATABLE tag from PUSH-DELIVER-* requirements
- Add unit tests for WebhookReceiver
- Add has_push_notifications flag to Java emitter context
- Update agent card template with .pushNotifications(true)
- Regenerate a2a-java SUT