### PR TITLE
fix: add A2A-Version: 1.0 header to all requests in tests

### DIFF
--- a/tck/transport/_helpers.py
+++ b/tck/transport/_helpers.py
@@ -10,6 +10,9 @@ from typing import TYPE_CHECKING, Any, Iterator
 if TYPE_CHECKING:
     import httpx
 
+A2A_VERSION_HEADER = "A2A-Version"
+A2A_VERSION = "1.0"
+
 
 def _build_params(**kwargs: Any) -> dict:
     """Build a params dict, omitting None values."""

--- a/tck/transport/grpc_client.py
+++ b/tck/transport/grpc_client.py
@@ -17,7 +17,7 @@ import grpc
 from google.protobuf.json_format import ParseDict
 
 from specification.generated import a2a_pb2, a2a_pb2_grpc
-from tck.transport._helpers import _build_params
+from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER, _build_params
 from tck.transport.base import BaseTransportClient, StreamingResponse, TransportResponse
 
 
@@ -98,6 +98,8 @@ class GrpcClient(BaseTransportClient):
         grpc.StatusCode.INTERNAL,
     })
 
+    _METADATA = ((A2A_VERSION_HEADER.lower(), A2A_VERSION),)
+
     def __init__(self, base_url: str) -> None:
         super().__init__(base_url, TRANSPORT)
         self._channel: grpc.Channel | None = None
@@ -143,14 +145,14 @@ class GrpcClient(BaseTransportClient):
         """
         rpc = getattr(self._stub, rpc_name)
         try:
-            return make_ok(rpc(request, timeout=timeout))
+            return make_ok(rpc(request, timeout=timeout, metadata=self._METADATA))
         except grpc.RpcError as e:
             if e.code() not in self._RETRIABLE_CODES:
                 return make_err(e)
             self._connect()
             try:
                 rpc = getattr(self._stub, rpc_name)
-                return make_ok(rpc(request, timeout=timeout))
+                return make_ok(rpc(request, timeout=timeout, metadata=self._METADATA))
             except grpc.RpcError as e2:
                 return make_err(e2)
 
@@ -190,7 +192,7 @@ class GrpcClient(BaseTransportClient):
         for attempt in range(2):
             rpc = getattr(self._stub, rpc_name)
             try:
-                stream = rpc(request, timeout=self._STREAMING_TIMEOUT_S)
+                stream = rpc(request, timeout=self._STREAMING_TIMEOUT_S, metadata=self._METADATA)
                 try:
                     first = next(stream)
                 except StopIteration:

--- a/tck/transport/http_json_client.py
+++ b/tck/transport/http_json_client.py
@@ -27,7 +27,7 @@ from tck.requirements.base import (
     SEND_MESSAGE_BINDING,
     SUBSCRIBE_TO_TASK_BINDING,
 )
-from tck.transport._helpers import _build_params, _stream_sse
+from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER, _build_params, _stream_sse
 from tck.transport.base import BaseTransportClient, StreamingResponse, TransportResponse
 
 
@@ -113,6 +113,7 @@ class HttpJsonClient(BaseTransportClient):
         self._client = httpx.Client(
             base_url=base_url,
             timeout=httpx.Timeout(5.0, read=30.0),
+            headers={A2A_VERSION_HEADER: A2A_VERSION},
         )
 
     def close(self) -> None:

--- a/tck/transport/jsonrpc_client.py
+++ b/tck/transport/jsonrpc_client.py
@@ -14,7 +14,7 @@ from typing import Any
 import httpx
 
 from tck.requirements.base import OperationType
-from tck.transport._helpers import _build_params, _stream_sse
+from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER, _build_params, _stream_sse
 from tck.transport.base import BaseTransportClient, StreamingResponse, TransportResponse
 
 
@@ -81,6 +81,7 @@ class JsonRpcClient(BaseTransportClient):
         self._client = httpx.Client(
             base_url=base_url,
             timeout=httpx.Timeout(5.0, read=30.0),
+            headers={A2A_VERSION_HEADER: A2A_VERSION},
         )
 
     def close(self) -> None:

--- a/tests/compatibility/core_operations/test_error_handling.py
+++ b/tests/compatibility/core_operations/test_error_handling.py
@@ -22,6 +22,7 @@ import pytest
 
 from tck.requirements.base import tck_id
 from tck.requirements.registry import get_requirement_by_id
+from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER
 from tck.validators.error_info import validate_error_info
 from tests.compatibility._test_helpers import assert_and_record, get_client, record
 from tests.compatibility.markers import core, grpc, http_json, jsonrpc, must
@@ -87,7 +88,7 @@ def _jsonrpc_call(
         "method": method,
         "params": params,
     }
-    hdrs = {"Content-Type": "application/json"}
+    hdrs = {"Content-Type": "application/json", A2A_VERSION_HEADER: A2A_VERSION}
     if headers:
         hdrs.update(headers)
     return httpx.post(base_url, json=payload, headers=hdrs)
@@ -102,7 +103,7 @@ def _rest_call(
     headers: dict[str, str] | None = None,
 ) -> httpx.Response:
     """Make a raw HTTP request for REST binding."""
-    hdrs = {}
+    hdrs = {A2A_VERSION_HEADER: A2A_VERSION}
     if json_body is not None:
         hdrs["Content-Type"] = "application/json"
     if headers:
@@ -339,7 +340,7 @@ class TestVersionErrors:
             client.base_url,
             "SendMessage",
             {"message": msg},
-            headers={"A2A-Version": "99.0"},
+            headers={A2A_VERSION_HEADER: "99.0"},
         )
         body = response.json()
         passed = "error" in body
@@ -366,7 +367,7 @@ class TestVersionErrors:
             "POST",
             "/message:send",
             json_body={"message": msg},
-            headers={"A2A-Version": "99.0"},
+            headers={A2A_VERSION_HEADER: "99.0"},
         )
         passed = response.status_code >= _HTTP_ERROR_STATUS
         errors = [] if passed else [f"Expected error for unsupported version, got {response.status_code}"]
@@ -391,7 +392,7 @@ class TestVersionErrors:
             client.base_url,
             "SendMessage",
             {"message": msg},
-            headers={"A2A-Version": ""},
+            headers={A2A_VERSION_HEADER: ""},
         )
         body = response.json()
         # Empty version should be treated as 0.3. Server must return either

--- a/tests/compatibility/core_operations/test_transport_behavior.py
+++ b/tests/compatibility/core_operations/test_transport_behavior.py
@@ -21,6 +21,7 @@ import pytest
 
 from tck.requirements.base import tck_id
 from tck.requirements.registry import get_requirement_by_id
+from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER
 from tests.compatibility._test_helpers import assert_and_record, get_client, record
 from tests.compatibility.markers import grpc, http_json, jsonrpc, must, streaming
 
@@ -183,6 +184,7 @@ class TestJsonRpcServiceParams:
             json=payload,
             headers={
                 "Content-Type": "application/json",
+                A2A_VERSION_HEADER: A2A_VERSION,
                 "A2A-Extensions": "https://example.com/ext/v1,https://example.com/ext/v2",
             },
         )
@@ -303,6 +305,7 @@ class TestRestServiceParams:
             json={"message": msg},
             headers={
                 "Content-Type": "application/json",
+                A2A_VERSION_HEADER: A2A_VERSION,
                 "A2A-Extensions": "https://example.com/ext/v1,https://example.com/ext/v2",
             },
         )

--- a/tests/compatibility/http_json/test_http_status.py
+++ b/tests/compatibility/http_json/test_http_status.py
@@ -18,6 +18,7 @@ import pytest
 
 from tck.requirements.base import SEND_MESSAGE_BINDING, tck_id
 from tck.requirements.registry import get_requirement_by_id
+from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER
 from tck.transport.http_json_client import TRANSPORT
 from tck.validators.http_json.error_validator import validate_http_json_error
 from tests.compatibility._test_helpers import assert_and_record, fail_msg, get_client, record
@@ -146,7 +147,7 @@ class TestHttpJsonStatusCodes:
         response = httpx.post(
             f"{client.base_url}{SEND_MESSAGE_BINDING.http_json_path}",
             content=json.dumps({"message": {"role": "ROLE_USER", "parts": [{"text": "ct test"}], "messageId": tck_id("status-ct-004")}}).encode(),
-            headers={"Content-Type": "text/plain"},
+            headers={"Content-Type": "text/plain", A2A_VERSION_HEADER: A2A_VERSION},
         )
 
         if response.status_code < _HTTP_ERROR_MIN:
@@ -205,7 +206,7 @@ class TestHttpJsonStatusCodes:
             json={"message": msg},
             headers={
                 "Content-Type": "application/json",
-                "A2A-Version": "99.0",
+                A2A_VERSION_HEADER: "99.0",
             },
         )
 

--- a/tests/compatibility/jsonrpc/test_error_codes.py
+++ b/tests/compatibility/jsonrpc/test_error_codes.py
@@ -16,6 +16,7 @@ import pytest
 
 from tck.requirements.base import tck_id
 from tck.requirements.registry import get_requirement_by_id
+from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER
 from tck.transport.jsonrpc_client import TRANSPORT
 from tck.validators.jsonrpc.error_validator import validate_jsonrpc_error
 from tests.compatibility._test_helpers import assert_and_record, fail_msg, get_client, record
@@ -65,7 +66,7 @@ def _jsonrpc_call(
         "method": method,
         "params": params,
     }
-    hdrs = {"Content-Type": "application/json"}
+    hdrs = {"Content-Type": "application/json", A2A_VERSION_HEADER: A2A_VERSION}
     if headers:
         hdrs.update(headers)
     return httpx.post(base_url, json=payload, headers=hdrs)
@@ -218,7 +219,7 @@ class TestJsonRpcErrorCodeMappings:
         response = httpx.post(
             client.base_url,
             content=str(payload).encode(),
-            headers={"Content-Type": "text/plain"},
+            headers={"Content-Type": "text/plain", A2A_VERSION_HEADER: A2A_VERSION},
         )
 
         # The server may reject the wrong Content-Type at the HTTP level
@@ -261,7 +262,7 @@ class TestJsonRpcErrorCodeMappings:
             client.base_url,
             "SendMessage",
             {"message": msg},
-            headers={"A2A-Version": "99.0"},
+            headers={A2A_VERSION_HEADER: "99.0"},
         )
         body = response.json()
         if "error" not in body:
@@ -332,7 +333,7 @@ class TestJsonRpcErrorCodeRange:
                 client.base_url,
                 "SendMessage",
                 {"message": msg},
-                headers={"A2A-Version": "99.0"},
+                headers={A2A_VERSION_HEADER: "99.0"},
             )
             body = raw.json()
 


### PR DESCRIPTION
Tests that bypass the transport client and make direct httpx calls were missing the A2A-Version header, which could cause failures on SUTs that enforce version checking.
