### PR TITLE
fix: Add missing A2A-Version header

### DIFF
--- a/tests/compatibility/_test_helpers.py
+++ b/tests/compatibility/_test_helpers.py
@@ -98,10 +98,13 @@ def collect_events_with_timeout(
     collected: list[Any] = []
 
     def _drain() -> None:
-        for event in events_iter:
-            collected.append(event)
-            if stop_after_first:
-                break
+        try:
+            for event in events_iter:
+                collected.append(event)
+                if stop_after_first:
+                    break
+        except Exception:
+            pass
 
     thread = threading.Thread(target=_drain, daemon=True)
     thread.start()

--- a/tests/compatibility/core_operations/test_transport_behavior.py
+++ b/tests/compatibility/core_operations/test_transport_behavior.py
@@ -539,6 +539,7 @@ class TestGrpcServiceParams:
         )
         # gRPC metadata keys are lowercase per HTTP/2
         grpc_metadata = [
+            (A2A_VERSION_HEADER.lower(), A2A_VERSION),
             ("a2a-extensions", "https://example.com/ext/v1,https://example.com/ext/v2"),
         ]
         errors = []


### PR DESCRIPTION
Also, don't propagate errors when draining SSE events during cleanup
