### PR TITLE
feat: add push notification webhook delivery tests

### DIFF
--- a/tck/transport/grpc_client.py
+++ b/tck/transport/grpc_client.py
@@ -899,9 +899,18 @@ class GRPCClient(BaseTransportClient):
             pb = self._pb
 
             # Build push notification config
-            push_config = pb.PushNotificationConfig(
-                id=config.get("id", "default"), url=config.get("url", ""), token=config.get("token", "")
-            )
+            push_kwargs = {
+                "id": config.get("id", "default"),
+                "url": config.get("url", ""),
+                "token": config.get("token", ""),
+            }
+            auth = config.get("authentication")
+            if auth:
+                push_kwargs["authentication"] = pb.AuthenticationInfo(
+                    schemes=auth.get("schemes", []),
+                    credentials=auth.get("credentials", ""),
+                )
+            push_config = pb.PushNotificationConfig(**push_kwargs)
 
             # Build task push notification config
             task_config = pb.TaskPushNotificationConfig(

--- a/tck/webhook/__init__.py
+++ b/tck/webhook/__init__.py
@@ -1,0 +1,1 @@
+"""Webhook receiver for push notification delivery testing."""

--- a/tck/webhook/server.py
+++ b/tck/webhook/server.py
@@ -1,0 +1,143 @@
+"""Lightweight HTTP server that captures incoming webhook requests.
+
+Used by push notification delivery tests to verify that the SUT sends
+webhook payloads when a task state changes.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+
+@dataclass
+class WebhookRequest:
+    """A captured webhook request."""
+
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: bytes
+    json_body: Any = None
+
+    def __post_init__(self) -> None:
+        if self.json_body is None and self.body:
+            with contextlib.suppress(json.JSONDecodeError, UnicodeDecodeError):
+                self.json_body = json.loads(self.body)
+
+
+@dataclass
+class WebhookReceiver:
+    """HTTP server that captures webhook requests for assertion.
+
+    Typical usage::
+
+        receiver = WebhookReceiver()
+        receiver.start()
+        try:
+            # configure SUT to POST to receiver.url()
+            request = receiver.wait_for_request(timeout=10)
+            assert request is not None
+        finally:
+            receiver.stop()
+    """
+
+    host: str = "0.0.0.0"
+    _server: HTTPServer | None = field(default=None, init=False, repr=False)
+    _thread: threading.Thread | None = field(default=None, init=False, repr=False)
+    _requests: list[WebhookRequest] = field(default_factory=list, init=False, repr=False)
+    _request_event: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+
+    @property
+    def port(self) -> int:
+        """Return the port the server is listening on."""
+        if self._server is None:
+            raise RuntimeError("Server not started")
+        return self._server.server_address[1]
+
+    def url(self, webhook_host: str = "localhost") -> str:
+        """Return the full webhook URL using the given host."""
+        return f"http://{webhook_host}:{self.port}/webhook"
+
+    def record_request(self, req: WebhookRequest) -> None:
+        """Append a captured request and signal any waiters."""
+        with self._lock:
+            self._requests.append(req)
+            self._request_event.set()
+
+    def start(self) -> None:
+        """Start the webhook receiver in a background thread."""
+        receiver = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                headers = {k.lower(): v for k, v in self.headers.items()}
+                try:
+                    length = int(headers.get("content-length", "0"))
+                except (ValueError, TypeError):
+                    length = 0
+                body = self.rfile.read(length) if length else b""
+                req = WebhookRequest(
+                    method="POST",
+                    path=self.path,
+                    headers=headers,
+                    body=body,
+                )
+                receiver.record_request(req)
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, format: str, *args: Any) -> None:
+                pass
+
+        self._server = HTTPServer((self.host, 0), _Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Shut down the server and join the background thread."""
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def clear(self) -> None:
+        """Discard all captured requests."""
+        with self._lock:
+            self._requests.clear()
+            self._request_event.clear()
+
+    def wait_for_request(self, timeout: float = 10) -> WebhookRequest | None:
+        """Block until a request arrives or *timeout* seconds elapse.
+
+        Each call consumes the oldest queued request so that sequential
+        calls return successive webhook deliveries.
+        """
+        with self._lock:
+            if self._requests:
+                req = self._requests.pop(0)
+                if not self._requests:
+                    self._request_event.clear()
+                return req
+        self._request_event.wait(timeout=timeout)
+        with self._lock:
+            if not self._requests:
+                return None
+            req = self._requests.pop(0)
+            if not self._requests:
+                self._request_event.clear()
+            return req
+
+    def get_requests(self) -> list[WebhookRequest]:
+        """Return a copy of all captured requests."""
+        with self._lock:
+            return list(self._requests)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import requests
 import uuid
 import logging
 from tck import agent_card_utils
+from tck.webhook.server import WebhookReceiver
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,12 @@ def pytest_addoption(parser):
         action="store_true",
         default=True,
         help="Enable transport equivalence testing for multi-transport SUTs",
+    )
+    parser.addoption(
+        "--webhook-host",
+        action="store",
+        default="localhost",
+        help="Hostname the SUT uses to reach the TCK webhook receiver (default: localhost)",
     )
 
 
@@ -100,6 +107,21 @@ def agent_card_data(request):
         if card is None:
             pytest.fail("Failed to fetch or parse Agent Card from the SUT. Check SUT URL and Agent Card endpoint.")
         return card
+
+
+@pytest.fixture(scope="session")
+def webhook_host(request):
+    """Return the hostname the SUT should use to reach the webhook receiver."""
+    return request.config.getoption("--webhook-host")
+
+
+@pytest.fixture(scope="session")
+def webhook_receiver():
+    """Start a webhook receiver for the duration of the test session."""
+    receiver = WebhookReceiver()
+    receiver.start()
+    yield receiver
+    receiver.stop()
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/optional/capabilities/test_push_notification_delivery.py
+++ b/tests/optional/capabilities/test_push_notification_delivery.py
@@ -1,0 +1,216 @@
+import logging
+import uuid
+
+import pytest
+
+from tck import agent_card_utils
+from tests.markers import optional_capability
+from tests.capability_validator import CapabilityValidator
+from tests.utils import transport_helpers
+
+logger = logging.getLogger(__name__)
+
+_DELIVERY_TIMEOUT_S = 15
+_AUTH_SCHEME = "Bearer"
+_AUTH_CREDENTIALS = "tck-test-token-" + str(uuid.uuid4())
+_NOTIFICATION_TOKEN = "tck-notification-token-" + str(uuid.uuid4())
+
+
+def _create_task_with_push_config(sut_client, webhook_url, config):
+    """Create a task and configure push notifications pointing at the webhook.
+
+    Returns the task ID.
+    """
+    message_params = {
+        "message": {
+            "messageId": "test-push-delivery-" + str(uuid.uuid4()),
+            "role": "user",
+            "parts": [{"kind": "text", "text": "Task for push notification delivery test"}],
+            "kind": "message",
+        }
+    }
+    resp = transport_helpers.transport_send_message(sut_client, message_params)
+    assert transport_helpers.is_json_rpc_success_response(resp), (
+        f"Failed to create task: {resp}"
+    )
+    task_id = resp["result"]["id"]
+
+    push_config = {"url": webhook_url}
+    push_config.update(config)
+    set_resp = transport_helpers.transport_set_push_notification_config(
+        sut_client, task_id, push_config
+    )
+    assert transport_helpers.is_json_rpc_success_response(set_resp), (
+        f"Failed to set push notification config: {set_resp}"
+    )
+
+    return task_id
+
+
+def _trigger_state_change(sut_client, task_id):
+    """Send a follow-up message to trigger a task state change."""
+    message_params = {
+        "message": {
+            "messageId": "test-push-trigger-" + str(uuid.uuid4()),
+            "role": "user",
+            "parts": [{"kind": "text", "text": "Complete the task to trigger push notification"}],
+            "kind": "message",
+            "taskId": task_id,
+        }
+    }
+    resp = transport_helpers.transport_send_message(sut_client, message_params)
+    assert transport_helpers.is_json_rpc_success_response(resp), (
+        f"Failed to send follow-up message: {resp}"
+    )
+
+
+def _setup_and_wait(sut_client, webhook_receiver, webhook_host, config):
+    """Create task with push config, trigger state change, wait for webhook."""
+    webhook_receiver.clear()
+    webhook_url = webhook_receiver.url(webhook_host)
+    task_id = _create_task_with_push_config(sut_client, webhook_url, config)
+    _trigger_state_change(sut_client, task_id)
+    return webhook_receiver.wait_for_request(timeout=_DELIVERY_TIMEOUT_S)
+
+
+@optional_capability
+def test_push_notification_delivery_received(
+    sut_client, agent_card_data, webhook_receiver, webhook_host
+):
+    """
+    CONDITIONAL MANDATORY: A2A Specification Section 9.5 - Push Notification Delivery
+
+    Status: MANDATORY if capabilities.pushNotifications = true
+            SKIP if capabilities.pushNotifications = false/missing
+
+    Test validates that the SUT delivers at least one webhook request when
+    a task state changes after push notification config has been set.
+    """
+    validator = CapabilityValidator(agent_card_data)
+    if not validator.is_capability_declared("pushNotifications"):
+        pytest.skip("Push notifications capability not declared - test not applicable")
+
+    config = {
+        "token": _NOTIFICATION_TOKEN,
+    }
+    req = _setup_and_wait(sut_client, webhook_receiver, webhook_host, config)
+    assert req is not None, (
+        "No webhook delivery received within timeout - agent MUST attempt "
+        "at least one delivery per configured webhook"
+    )
+
+
+@optional_capability
+def test_push_notification_delivery_token_header(
+    sut_client, agent_card_data, webhook_receiver, webhook_host
+):
+    """
+    CONDITIONAL MANDATORY: A2A Specification Section 9.5 - Push Notification Token
+
+    Status: MANDATORY if capabilities.pushNotifications = true
+            SKIP if capabilities.pushNotifications = false/missing
+
+    Test validates that the SUT includes the configured token in the
+    X-A2A-Notification-Token header of webhook requests.
+    """
+    validator = CapabilityValidator(agent_card_data)
+    if not validator.is_capability_declared("pushNotifications"):
+        pytest.skip("Push notifications capability not declared - test not applicable")
+
+    config = {
+        "token": _NOTIFICATION_TOKEN,
+    }
+    req = _setup_and_wait(sut_client, webhook_receiver, webhook_host, config)
+    assert req is not None, "No webhook delivery received within timeout"
+
+    token_header = req.headers.get("x-a2a-notification-token", "")
+    assert token_header == _NOTIFICATION_TOKEN, (
+        f"Expected X-A2A-Notification-Token header '{_NOTIFICATION_TOKEN}', "
+        f"got '{token_header}'"
+    )
+
+
+@optional_capability
+def test_push_notification_delivery_auth_header(
+    sut_client, agent_card_data, webhook_receiver, webhook_host
+):
+    """
+    CONDITIONAL MANDATORY: A2A Specification Section 9.5 - Push Notification Authentication
+
+    Status: MANDATORY if capabilities.pushNotifications = true
+            SKIP if capabilities.pushNotifications = false/missing
+
+    Test validates that the SUT includes the configured authentication
+    credentials in the Authorization header of webhook requests.
+    """
+    validator = CapabilityValidator(agent_card_data)
+    if not validator.is_capability_declared("pushNotifications"):
+        pytest.skip("Push notifications capability not declared - test not applicable")
+
+    config = {
+        "authentication": {
+            "schemes": [_AUTH_SCHEME],
+            "credentials": _AUTH_CREDENTIALS,
+        },
+    }
+    req = _setup_and_wait(sut_client, webhook_receiver, webhook_host, config)
+    assert req is not None, "No webhook delivery received within timeout"
+
+    auth_header = req.headers.get("authorization", "")
+    expected = f"{_AUTH_SCHEME} {_AUTH_CREDENTIALS}"
+    assert auth_header == expected, (
+        f"Expected Authorization header '{expected}', got '{auth_header}'"
+    )
+
+
+@optional_capability
+def test_push_notification_delivery_payload_is_task(
+    sut_client, agent_card_data, webhook_receiver, webhook_host
+):
+    """
+    CONDITIONAL MANDATORY: A2A Specification Section 9.5 - Push Notification Payload
+
+    Status: MANDATORY if capabilities.pushNotifications = true
+            SKIP if capabilities.pushNotifications = false/missing
+
+    Test validates that the webhook payload is a v0.3 Task object with
+    required fields (id, status, kind="task"), not a StreamResponse wrapper.
+    """
+    validator = CapabilityValidator(agent_card_data)
+    if not validator.is_capability_declared("pushNotifications"):
+        pytest.skip("Push notifications capability not declared - test not applicable")
+
+    config = {
+        "token": _NOTIFICATION_TOKEN,
+    }
+    req = _setup_and_wait(sut_client, webhook_receiver, webhook_host, config)
+    assert req is not None, "No webhook delivery received within timeout"
+    assert req.json_body is not None, (
+        f"Webhook body is not valid JSON: {req.body!r}"
+    )
+
+    payload = req.json_body
+
+    # v0.3 payload MUST be a Task object directly (not wrapped in StreamResponse)
+    assert "id" in payload, (
+        f"Webhook payload missing 'id' field. Got keys: {list(payload.keys())}"
+    )
+    assert "status" in payload, (
+        f"Webhook payload missing 'status' field. Got keys: {list(payload.keys())}"
+    )
+    assert payload.get("kind") == "task", (
+        f"Webhook payload 'kind' should be 'task', got: {payload.get('kind')}"
+    )
+
+    # Verify this is NOT a StreamResponse (1.0 format)
+    stream_response_keys = {"task", "message", "statusUpdate", "artifactUpdate"}
+    if set(payload.keys()) & stream_response_keys == set(payload.keys()) and len(payload) == 1:
+        pytest.fail(
+            "Webhook payload appears to be a StreamResponse wrapper (v1.0 format). "
+            "v0.3 expects a plain Task object as the payload."
+        )
+
+    # Validate status structure
+    status = payload["status"]
+    assert isinstance(status, dict), f"Task status should be an object, got: {type(status)}"
+    assert "state" in status, f"Task status missing 'state' field. Got: {status}"


### PR DESCRIPTION
Add tests that spin up a lightweight HTTP server to receive push notification webhooks from the SUT, verifying at-least-once delivery, authentication headers (both token and Authorization), and v0.3 Task object payload format.

Also fix gRPC client to pass the authentication field through when setting push notification configs.
