### PR TITLE
feat: allow additional fields in Agent Card schema validation

### DIFF
--- a/backlog/tasks/task-32 - Allow-additional-unknown-fields-in-Agent-Card-schema-validation.md
+++ b/backlog/tasks/task-32 - Allow-additional-unknown-fields-in-Agent-Card-schema-validation.md
@@ -1,0 +1,44 @@
+---
+id: TASK-32
+title: Allow additional unknown fields in Agent Card schema validation
+status: Done
+assignee: []
+created_date: '2026-05-13 08:08'
+updated_date: '2026-05-13 08:12'
+labels:
+  - schema
+  - validation
+  - agent-card
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The A2A spec allows agent cards to contain additional fields (extensions), but the current JSON schema in `specification/a2a.json` has `"additionalProperties": false` on the Agent Card definition (line 62). This causes the TCK to reject valid agent cards that include extension fields.
+
+**Problem:**
+- `JSONSchemaValidator` in `tck/validators/json_schema.py` validates agent cards against the schema as-is
+- The schema's `"additionalProperties": false` rejects any unknown fields
+- The A2A spec permits extensions/additional fields on agent cards
+
+**Approach:**
+Modify `JSONSchemaValidator` to support an `allow_additional` mode that strips `"additionalProperties": false` from the resolved schema before validation. This way:
+- All required fields and types are still validated
+- Unknown/extension fields are not rejected
+- The schema file itself stays in sync with the proto-generated source
+
+Add a recursive `_strip_additional_properties()` helper that removes `"additionalProperties": false` entries from the schema tree, and use it when validating agent cards.
+
+**Files involved:**
+- `tck/validators/json_schema.py` — add the stripping logic and `allow_additional` parameter
+- `tests/compatibility/agent_card/test_agent_card.py` — use relaxed validation for agent card tests
+- `tests/unit/validators/test_json_schema.py` — add tests for the new behavior
+<!-- SECTION:DESCRIPTION:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Added `allow_additional` parameter to `JSONSchemaValidator.validate()` with a recursive `_strip_additional_properties()` helper. Agent Card validation in the TCK now accepts unknown extension fields while still checking required fields and types. Agent Interface validation remains strict. 4 new unit tests cover the behavior. Implemented on branch `task-32/allow-additional-fields-agent-card`.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tck/validators/json_schema.py
+++ b/tck/validators/json_schema.py
@@ -251,7 +251,34 @@ class JSONSchemaValidator:
         path = self._format_json_path(list(error.absolute_path))
         return f"{path}: {error.message}"
 
-    def validate(self, response: dict[str, Any], schema_ref: str) -> ValidationResult:
+    @staticmethod
+    def _strip_additional_properties(schema: dict[str, Any]) -> dict[str, Any]:
+        """Return a copy of *schema* with all ``"additionalProperties": false`` removed.
+
+        This allows the validator to check required fields and types while
+        accepting unknown extension fields — which the A2A spec permits on
+        several structures (e.g. Agent Card).
+        """
+        def _walk(node: Any) -> None:
+            if isinstance(node, dict):
+                if node.get("additionalProperties") is False:
+                    del node["additionalProperties"]
+                for value in node.values():
+                    _walk(value)
+            elif isinstance(node, list):
+                for item in node:
+                    _walk(item)
+
+        _walk(schema)
+        return schema
+
+    def validate(
+        self,
+        response: dict[str, Any],
+        schema_ref: str,
+        *,
+        allow_additional: bool = False,
+    ) -> ValidationResult:
         """Validate a JSON response against a specific schema definition.
 
         Args:
@@ -259,6 +286,8 @@ class JSONSchemaValidator:
             schema_ref: The schema reference to validate against. Can be:
                        - A definition name (e.g., "Task")
                        - A full reference (e.g., "#/definitions/Task")
+            allow_additional: When True, strip ``"additionalProperties": false``
+                from the schema so that unknown extension fields are accepted.
 
         Returns:
             A ValidationResult with validation status and any errors.
@@ -273,6 +302,9 @@ class JSONSchemaValidator:
 
         # Resolve all $refs in the definition
         resolved_definition = self._resolve_all_refs(definition)
+
+        if allow_additional:
+            resolved_definition = self._strip_additional_properties(resolved_definition)
 
         # Create a validator
         validator_cls = validator_for(resolved_definition)

--- a/tests/compatibility/agent_card/test_agent_card.py
+++ b/tests/compatibility/agent_card/test_agent_card.py
@@ -115,7 +115,9 @@ class TestAgentCardStructure:
         """Agent card must validate against the Agent Card JSON schema."""
         req = CARD_STRUCT_001
         json_validator: JSONSchemaValidator = validators["http_json"]
-        result = json_validator.validate(agent_card, "Agent Card")
+        result = json_validator.validate(
+            agent_card, "Agent Card", allow_additional=True,
+        )
         _record(collector=compatibility_collector, req=req,
                 passed=result.valid, errors=result.errors)
         assert result.valid, _fail_msg(req, "; ".join(result.errors))

--- a/tests/unit/validators/test_json_schema.py
+++ b/tests/unit/validators/test_json_schema.py
@@ -257,3 +257,56 @@ class TestRefResolution:
         }
         result = validator.validate(task, "Task")
         assert result.valid is True
+
+
+class TestAllowAdditionalProperties:
+    """Tests for the allow_additional parameter."""
+
+    def test_extra_fields_accepted(self, validator: JSONSchemaValidator) -> None:
+        """Additional properties pass when allow_additional=True."""
+        agent_card = {
+            "name": "Test Agent",
+            "description": "A test agent",
+            "version": "1.0.0",
+            "x-custom-extension": "hello",
+        }
+        result = validator.validate(agent_card, "Agent Card", allow_additional=True)
+        assert result.valid is True
+        assert result.errors == []
+
+    def test_extra_fields_rejected_by_default(self, validator: JSONSchemaValidator) -> None:
+        """Additional properties still fail without allow_additional."""
+        agent_card = {
+            "name": "Test Agent",
+            "description": "A test agent",
+            "version": "1.0.0",
+            "x-custom-extension": "hello",
+        }
+        result = validator.validate(agent_card, "Agent Card")
+        assert result.valid is False
+        assert any("x-custom-extension" in e for e in result.errors)
+
+    def test_type_errors_still_caught(self, validator: JSONSchemaValidator) -> None:
+        """Type errors are still reported even with allow_additional=True."""
+        agent_card = {
+            "name": 123,  # Should be string
+            "description": "A test agent",
+            "version": "1.0.0",
+        }
+        result = validator.validate(agent_card, "Agent Card", allow_additional=True)
+        assert result.valid is False
+        assert any("name" in e for e in result.errors)
+
+    def test_nested_extra_fields_accepted(self, validator: JSONSchemaValidator) -> None:
+        """Additional properties in nested objects pass with allow_additional=True."""
+        task = {
+            "id": "task-123",
+            "status": {
+                "state": "TASK_STATE_WORKING",
+                "x-extra": "value",
+            },
+            "x-top-level-extra": True,
+        }
+        result = validator.validate(task, "Task", allow_additional=True)
+        assert result.valid is True
+        assert result.errors == []


### PR DESCRIPTION
The A2A spec permits extension fields on agent cards, but the JSON schema's additionalProperties:false was rejecting them. Add an allow_additional parameter to JSONSchemaValidator.validate() that strips that constraint, so the TCK validates structure and types without rejecting unknown fields.
