### PR TITLE
fix(tests): tolerate completed task cancel race

### DIFF
--- a/tests/mandatory/protocol/test_tasks_cancel_method.py
+++ b/tests/mandatory/protocol/test_tasks_cancel_method.py
@@ -1,12 +1,10 @@
 import pytest
-import uuid
 
 from tests.markers import mandatory_protocol
 from tests.utils.transport_helpers import (
     transport_send_message,
     transport_cancel_task,
     is_json_rpc_success_response,
-    is_json_rpc_error_response,
     extract_task_id_from_response,
     generate_test_message_id,
 )
@@ -35,6 +33,62 @@ def created_task_id(sut_client):
     return task_id
 
 
+def assert_cancel_response_valid(resp, task_id):
+    """Validate a task cancellation response while tolerating completed-task races."""
+    if not is_json_rpc_success_response(resp):
+        error = resp.get("error", {})
+        error_code = error.get("code") if isinstance(error, dict) else None
+        assert error_code == -32002, (
+            "Task cancellation failed with an unexpected error: "
+            f"expected TaskNotCancelableError (-32002) for already-completed tasks, got: {resp}"
+        )
+        return
+
+    # Extract result from transport response
+    result = resp.get("result", resp)
+
+    # Validate cancellation response according to A2A v1.0 specification
+    assert result["id"] == task_id, f"Task ID mismatch: expected {task_id}, got {result.get('id')}"
+
+    # Check that task status indicates cancellation
+    status = result.get("status", {})
+    if isinstance(status, dict):
+        assert (
+            status.get("state") == "TASK_STATE_CANCELED"
+        ), f"Expected canceled state, got: {status.get('state')}"
+    else:
+        # Handle case where status might be a string
+        assert status == "TASK_STATE_CANCELED", f"Expected canceled status, got: {status}"
+
+
+def test_cancel_response_accepts_not_cancelable_completed_task():
+    """Completed tasks may legitimately reject cancellation as not cancelable."""
+    assert_cancel_response_valid(
+        {
+            "jsonrpc": "2.0",
+            "id": "test-request",
+            "error": {
+                "code": -32002,
+                "message": "Task cannot be canceled - current state: 3",
+            },
+        },
+        "completed-task-id",
+    )
+
+
+def test_cancel_response_rejects_unexpected_errors():
+    """Unexpected cancel errors should still fail the compliance test."""
+    with pytest.raises(AssertionError, match="unexpected error"):
+        assert_cancel_response_valid(
+            {
+                "jsonrpc": "2.0",
+                "id": "test-request",
+                "error": {"code": -32001, "message": "Task not found"},
+            },
+            "missing-task-id",
+        )
+
+
 @mandatory_protocol
 def test_tasks_cancel_valid(sut_client, created_task_id):
     """
@@ -50,21 +104,7 @@ def test_tasks_cancel_valid(sut_client, created_task_id):
     """
     # Use transport-agnostic task cancellation
     resp = transport_cancel_task(sut_client, created_task_id)
-    assert is_json_rpc_success_response(resp), f"Task cancellation failed: {resp}"
-
-    # Extract result from transport response
-    result = resp.get("result", resp)
-
-    # Validate cancellation response according to A2A v1.0 specification
-    assert result["id"] == created_task_id, f"Task ID mismatch: expected {created_task_id}, got {result.get('id')}"
-
-    # Check that task status indicates cancellation
-    status = result.get("status", {})
-    if isinstance(status, dict):
-        assert status.get("state") == "TASK_STATE_CANCELED", f"Expected canceled state, got: {status.get('state')}"
-    else:
-        # Handle case where status might be a string
-        assert status == "TASK_STATE_CANCELED", f"Expected canceled status, got: {status}"
+    assert_cancel_response_valid(resp, created_task_id)
 
 
 @mandatory_protocol
@@ -84,9 +124,13 @@ def test_tasks_cancel_nonexistent(sut_client):
     resp = transport_cancel_task(sut_client, "nonexistent-task-id")
 
     # Should receive an error response
-    assert not is_json_rpc_success_response(resp), f"Expected error for non-existent task, got: {resp}"
+    assert not is_json_rpc_success_response(
+        resp
+    ), f"Expected error for non-existent task, got: {resp}"
     assert "error" in resp, f"Response should contain error field: {resp}"
 
     # Validate A2A v1.0 TaskNotFoundError code
     error_code = resp["error"].get("code")
-    assert error_code == -32001, f"Expected TaskNotFoundError (-32001), got error code: {error_code}"
+    assert (
+        error_code == -32001
+    ), f"Expected TaskNotFoundError (-32001), got error code: {error_code}"


### PR DESCRIPTION
## Summary

- Make `test_tasks_cancel_valid` tolerate the race where a synchronous SUT completes the task before the cancel request arrives.
- Treat `TaskNotCancelableError` (`-32002`) as compliant for that already-completed task path, matching the A2A spec's terminal-state behavior.
- Keep unexpected cancel errors failing, and add regression tests for both the accepted `-32002` response and an unexpected `-32001` response.

Closes #140

## Testing

- `./.venv/bin/python -m black --check tests/mandatory/protocol/test_tasks_cancel_method.py`
- `./.venv/bin/python -m pytest tests/mandatory/protocol/test_tasks_cancel_method.py::test_cancel_response_accepts_not_cancelable_completed_task tests/mandatory/protocol/test_tasks_cancel_method.py::test_cancel_response_rejects_unexpected_errors -q` — 2 passed
- `./.venv/bin/python -m py_compile tests/mandatory/protocol/test_tasks_cancel_method.py`
- `git diff --check`

I also ran `./.venv/bin/python -m pytest tests/mandatory/protocol/test_tasks_cancel_method.py -q`; the two new regression tests passed, while the existing SUT-backed tests errored during setup because this environment did not provide `SUT_URL` (`SUT URL not provided. Cannot create transport manager.`).

## AI assistance disclosure

This draft PR was prepared with AI assistance.