### PR TITLE
fix: pin starlette dependency to >=1.1.0

### DIFF
--- a/codegen/a2a-python/pyproject.toml.j2
+++ b/codegen/a2a-python/pyproject.toml.j2
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "a2a-sdk[http-server,grpc,sqlite]>={{ a2a_python_sdk_version }}",
     "packaging",
-    "starlette",
+    "starlette>=1.1.0",
     "uvicorn",
 ]
 

--- a/sut/a2a-python/pyproject.toml
+++ b/sut/a2a-python/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "a2a-sdk[http-server,grpc,sqlite]>=0.3.0",
     "packaging",
-    "starlette",
+    "starlette>=1.1.0",
     "uvicorn",
 ]
 


### PR DESCRIPTION
## Summary
- Pin the `starlette` dependency to `>=1.1.0` in both the codegen template and the generated Python SUT `pyproject.toml`
- Previously the dependency was unpinned, accepting any version

## Test plan
- [x] Python SUT `uv sync` resolves successfully with starlette 1.1.0
- [x] Java SUT TCK tests pass (242 passed, 99% compatibility)
- [x] Pre-commit hooks pass (ruff lint + unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)