### PR TITLE
fix: remove _validate_from_stream related to STREAM-SUB-004

### DIFF
--- a/tck/validators/error_binding.py
+++ b/tck/validators/error_binding.py
@@ -1,7 +1,6 @@
 """Cross-transport expected-error validator.
 
-Validates that a transport response (including streaming responses where
-errors may arrive during iteration) matches the expected ErrorBinding
+Validates that a transport response matches the expected ErrorBinding
 from a requirement specification.
 """
 
@@ -12,7 +11,6 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from tck.requirements.base import ErrorBinding
-    from tck.transport.base import StreamingResponse
 
 
 def validate_expected_error(
@@ -22,20 +20,10 @@ def validate_expected_error(
 ) -> list[str]:
     """Validate that a response matches the expected error binding.
 
-    For non-streaming responses, checks ``response.success`` and
-    ``response.error_code``.  For streaming responses where
-    ``success=True``, delegates to :func:`_validate_from_stream`
-    because the error may arrive during iteration (e.g. gRPC status)
-    or as an error event (e.g. JSON-RPC envelope).
-
     Returns:
         A list of error strings (empty means validation passed).
     """
-    from tck.transport.base import StreamingResponse
-
     if response.success:
-        if isinstance(response, StreamingResponse):
-            return _validate_from_stream(response, transport, expected)
         return [f"Expected {expected.name} but operation succeeded"]
 
     expected_code = expected.expected_code(transport)
@@ -47,51 +35,3 @@ def validate_expected_error(
         ]
 
     return []
-
-
-def _validate_from_stream(
-    response: StreamingResponse,
-    transport: str,
-    expected: ErrorBinding,
-) -> list[str]:
-    """Check if the expected error arrives during streaming iteration.
-
-    Handles three delivery patterns:
-
-    1. **gRPC**: Error raised as an exception (e.g. ``grpc.RpcError``)
-       when iterating events.  The exception's ``.code().name`` is
-       compared to the expected gRPC status.
-    2. **JSON-RPC**: Error delivered as an SSE event containing an
-       ``"error"`` key with a JSON-RPC error code.
-    3. **HTTP+JSON**: Error delivered as an SSE event containing an
-       ``"error"`` key (same check as JSON-RPC).
-    """
-    try:
-        first_event = next(response.events)
-    except StopIteration:
-        return [f"Expected {expected.name} but stream was empty (no error)"]
-    except Exception as exc:
-        # gRPC: error arrives as an exception during iteration
-        actual_code = None
-        if hasattr(exc, "code"):
-            actual_code = exc.code().name
-        expected_code = expected.expected_code(transport)
-        if expected_code is not None and actual_code != expected_code:
-            return [
-                f"Expected error code {expected_code} "
-                f"({expected.name}), got {actual_code}"
-            ]
-        return []
-
-    # JSON-RPC / HTTP+JSON: error may arrive as an event with an "error" key
-    if isinstance(first_event, dict) and "error" in first_event:
-        actual_code = first_event["error"].get("code")
-        expected_code = expected.expected_code(transport)
-        if expected_code is not None and actual_code != expected_code:
-            return [
-                f"Expected error code {expected_code} "
-                f"({expected.name}), got {actual_code}"
-            ]
-        return []
-
-    return [f"Expected {expected.name} but streaming produced events"]

--- a/tests/compatibility/jsonrpc/test_sse_streaming.py
+++ b/tests/compatibility/jsonrpc/test_sse_streaming.py
@@ -191,9 +191,11 @@ class TestSseSubscribeToTask:
 
         response = client.subscribe_to_task(id=tck_id("nonexistent-subscribe-001"))
 
-        # The server may return a plain JSON-RPC error (not SSE) for
-        # non-existent tasks — detected via success=False on the client.
-        if not response.success and response.error_code is not None:
+        if response.success:
+            errors = [
+                "Expected TaskNotFoundError but operation succeeded"
+            ]
+        else:
             code = response.error_code
             passed = code == _TASK_NOT_FOUND_CODE
             errors = (
@@ -201,23 +203,6 @@ class TestSseSubscribeToTask:
                 if passed
                 else [f"Expected TaskNotFoundError (-32001), got code {code}"]
             )
-        else:
-            # Try consuming events — some servers may send error as SSE event
-            events = list(response.events)
-            if events and "error" in events[0]:
-                code = events[0]["error"].get("code")
-                passed = code == _TASK_NOT_FOUND_CODE
-                errors = (
-                    []
-                    if passed
-                    else [
-                        f"Expected TaskNotFoundError (-32001), got code {code}"
-                    ]
-                )
-            else:
-                pytest.skip(
-                    "Server did not return an error for non-existent task subscribe"
-                )
 
         assert_and_record(compatibility_collector, req, transport, errors)
 

--- a/tests/compatibility/jsonrpc/test_sse_streaming.py
+++ b/tests/compatibility/jsonrpc/test_sse_streaming.py
@@ -19,6 +19,7 @@ from tck.requirements.base import tck_id
 from tck.requirements.registry import get_requirement_by_id
 from tck.transport.jsonrpc_client import TRANSPORT
 from tck.validators import STREAM_RESPONSE
+from tck.validators.streaming import drain_stream
 from tests.compatibility._task_helpers import create_working_task
 from tests.compatibility._test_helpers import assert_and_record, get_client, record
 from tests.compatibility.markers import jsonrpc, must, streaming
@@ -192,11 +193,10 @@ class TestSseSubscribeToTask:
         response = client.subscribe_to_task(id=tck_id("nonexistent-subscribe-001"))
 
         if response.success:
+            drain_stream(response)
             errors = [
                 "Expected TaskNotFoundError but operation succeeded"
             ]
-            from tck.validators.streaming import drain_stream
-            drain_stream(response)
         else:
             code = response.error_code
             passed = code == _TASK_NOT_FOUND_CODE

--- a/tests/compatibility/jsonrpc/test_sse_streaming.py
+++ b/tests/compatibility/jsonrpc/test_sse_streaming.py
@@ -195,6 +195,8 @@ class TestSseSubscribeToTask:
             errors = [
                 "Expected TaskNotFoundError but operation succeeded"
             ]
+            from tck.validators.streaming import drain_stream
+            drain_stream(response)
         else:
             code = response.error_code
             passed = code == _TASK_NOT_FOUND_CODE


### PR DESCRIPTION
The _validate_from_stream function attempted to extract error codes from SSE events for streaming responses that returned success=True. This crashed with `AttributeError: 'str' object has no attribute 'get'` when a non-conformant server sent an error field as a string instead of an object.

The function was based on a false premise: that errors can arrive as SSE events during streaming. Per the A2A spec, all three transports deliver errors *before* a stream is established:

- JSON-RPC: plain JSON-RPC error response (non-SSE content type), caught by the client which sets success=False
- HTTP+JSON: HTTP error status code (e.g. 404), caught by the client which sets success=False
- gRPC: RpcError on the initial next() call, caught by _streaming_call which sets success=False

In all cases the transport client already sets success=False and populates error_code, so the non-streaming validation path handles them correctly. The streaming fallback was unreachable for conformant servers and a crash site for non-conformant ones.

The same incorrect assumption existed in the jsonrpc STREAM-SUB-004 test, which had a fallback branch parsing SSE events for error codes. Simplified to check response.success and error_code directly.

Closes #151 
