### PR TITLE
feat(agent_card): add CARD-SIGN-003 protected header structural tests

### DIFF
--- a/tck/requirements/agent_card.py
+++ b/tck/requirements/agent_card.py
@@ -165,7 +165,7 @@ AGENT_CARD_REQUIREMENTS: list[RequirementSpec] = [
         ),
         expected_behavior="Protected header contains alg and kid",
         spec_url=f"{SPEC_BASE}842-signature-format",
-        tags=[AGENT_CARD, SIGNING, JWS, NOT_AUTOMATABLE],
+        tags=[AGENT_CARD, SIGNING, JWS],
     ),
     RequirementSpec(
         id="CARD-SIGN-004",

--- a/tests/compatibility/agent_card/card_signing_protected_header_vectors.json
+++ b/tests/compatibility/agent_card/card_signing_protected_header_vectors.json
@@ -1,0 +1,127 @@
+{
+  "description": "Reference vectors for CARD-SIGN-003: JWS protected header structure validation. Each case gives an AgentCard with signatures and the expected validation result. The protected header MUST decode to JSON containing alg and kid (non-empty strings), per A2A spec section 8.4.2.",
+  "source": "Vectors use standard JWS protected header encoding (base64url, no padding). alg values from RFC 7518 §3.1. Kid values are arbitrary key identifiers. Apache-2.0.",
+  "cases": [
+    {
+      "id": "cardsign-hdr-001",
+      "requirement": "CARD-SIGN-003",
+      "agent_card": {
+        "name": "Signed Agent",
+        "description": "Agent with valid ES256 signature",
+        "capabilities": {"streaming": false, "pushNotifications": false},
+        "skills": [],
+        "signatures": [
+          {
+            "protected": "eyJhbGciOiJFUzI1NiIsImtpZCI6ImtleS0xIn0",
+            "signature": "MEUCIQDfakefakefakefakefakefakefakefakeAIgIhAKfakefakefakefakefakefakefakefake"
+          }
+        ]
+      },
+      "expected_valid": true,
+      "decoded_alg": "ES256",
+      "decoded_kid": "key-1",
+      "note": "valid protected header with alg=ES256, kid=key-1"
+    },
+    {
+      "id": "cardsign-hdr-002",
+      "requirement": "CARD-SIGN-003",
+      "agent_card": {
+        "name": "RSA Agent",
+        "description": "Agent with RS256 signature",
+        "capabilities": {"streaming": true},
+        "skills": [{"id": "search", "name": "Search"}],
+        "signatures": [
+          {
+            "protected": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjIwMjUtMDQtMDEifQ",
+            "signature": "fake"
+          }
+        ]
+      },
+      "expected_valid": true,
+      "decoded_alg": "RS256",
+      "decoded_kid": "2025-04-01",
+      "note": "valid protected header with alg=RS256, kid=2025-04-01"
+    },
+    {
+      "id": "cardsign-hdr-003",
+      "requirement": "CARD-SIGN-003",
+      "agent_card": {
+        "name": "Missing Kid Agent",
+        "description": "Agent with signature missing kid in protected header",
+        "capabilities": {"streaming": false},
+        "skills": [],
+        "signatures": [
+          {
+            "protected": "eyJhbGciOiJFUzI1NiJ9",
+            "signature": "fake"
+          }
+        ]
+      },
+      "expected_valid": false,
+      "expected_error": "kid missing or empty",
+      "note": "protected header has alg but no kid — violates CARD-SIGN-003"
+    },
+    {
+      "id": "cardsign-hdr-004",
+      "requirement": "CARD-SIGN-003",
+      "agent_card": {
+        "name": "Missing Alg Agent",
+        "description": "Agent with signature missing alg in protected header",
+        "capabilities": {"streaming": false},
+        "skills": [],
+        "signatures": [
+          {
+            "protected": "eyJraWQiOiJvcnBoYW4ta2V5In0",
+            "signature": "fake"
+          }
+        ]
+      },
+      "expected_valid": false,
+      "expected_error": "alg missing or empty",
+      "note": "protected header has kid but no alg — violates CARD-SIGN-003"
+    },
+    {
+      "id": "cardsign-hdr-005",
+      "requirement": "CARD-SIGN-003",
+      "agent_card": {
+        "name": "Empty Alg Agent",
+        "description": "Agent with empty alg in protected header",
+        "capabilities": {"streaming": false},
+        "skills": [],
+        "signatures": [
+          {
+            "protected": "eyJhbGciOiIiLCJraWQiOiJlbXB0eS1hbGcifQ",
+            "signature": "fake"
+          }
+        ]
+      },
+      "expected_valid": false,
+      "expected_error": "alg missing or empty",
+      "note": "protected header has alg=\"\" — empty string violates CARD-SIGN-003"
+    },
+    {
+      "id": "cardsign-hdr-006",
+      "requirement": "CARD-SIGN-003",
+      "agent_card": {
+        "name": "Multi-Sig Agent",
+        "description": "Agent with two signatures in signatures array",
+        "capabilities": {"streaming": false, "pushNotifications": true},
+        "skills": [{"id": "translate", "name": "Translate"}],
+        "signatures": [
+          {
+            "protected": "eyJhbGciOiJFUzM4NCIsImtpZCI6InYyLWtleSJ9",
+            "signature": "fake1"
+          },
+          {
+            "protected": "eyJhbGciOiJFZERTQSIsImtpZCI6ImFnZW50LXNpZ25pbmcta2V5In0",
+            "signature": "fake2"
+          }
+        ]
+      },
+      "expected_valid": true,
+      "decoded_alg": "ES384",
+      "decoded_kid": "v2-key",
+      "note": "multiple signatures, each with valid alg and kid"
+    }
+  ]
+}

--- a/tests/compatibility/agent_card/test_card_signing_protected_header.py
+++ b/tests/compatibility/agent_card/test_card_signing_protected_header.py
@@ -1,0 +1,152 @@
+"""Reference tests for AgentCard signing protected header validation (CARD-SIGN-003).
+
+CARD-SIGN-003 (spec §8.4.2): The JWS protected header MUST include alg (algorithm)
+and kid (key ID) parameters.
+
+These are structural, offline tests: they decode each signature's base64url-encoded
+protected header and verify alg and kid are present, non-empty strings. No SUT is
+required — the test operates on static vectors, following the same reference-vector
+pattern as test_card_signing_canonicalization.py.
+
+Vectors are derived from standard JWS examples. Apache-2.0.
+"""
+from __future__ import annotations
+
+import base64
+import json
+
+from pathlib import Path
+
+import pytest
+
+
+_VECTORS = json.loads(
+    (Path(__file__).with_name("card_signing_protected_header_vectors.json")).read_text(
+        encoding="utf-8"
+    )
+)
+
+# Known JWS algorithm names from RFC 7518 §3.1.
+# The A2A spec §8.4.2 requires alg to be present; these are the standard values.
+_KNOWN_JWS_ALGORITHMS: frozenset[str] = frozenset(
+    {
+        # ECDSA
+        "ES256",
+        "ES384",
+        "ES512",
+        # RSA
+        "RS256",
+        "RS384",
+        "RS512",
+        # RSA-PSS
+        "PS256",
+        "PS384",
+        "PS512",
+        # EdDSA
+        "EdDSA",
+    }
+)
+
+
+def _decode_protected_header(protected: str) -> dict:
+    """Base64url-decode a JWS protected header to JSON.
+
+    Handles both padded and unpadded base64url per RFC 7515 §2.
+    """
+    # Add padding if missing (base64url may omit '=' padding)
+    missing_padding = len(protected) % 4
+    if missing_padding:
+        protected += "=" * (4 - missing_padding)
+    raw = base64.urlsafe_b64decode(protected)
+    return json.loads(raw)
+
+
+def _validate_protected_header(
+    case_id: str, header: dict
+) -> list[str]:
+    """Validate that a decoded JWS protected header satisfies CARD-SIGN-003.
+
+    Returns a list of error messages (empty list = valid).
+    """
+    errors: list[str] = []
+
+    alg = header.get("alg")
+    if not alg or not isinstance(alg, str) or not alg.strip():
+        errors.append(f"{case_id}: alg missing or empty")
+
+    kid = header.get("kid")
+    if not kid or not isinstance(kid, str) or not kid.strip():
+        errors.append(f"{case_id}: kid missing or empty")
+
+    return errors
+
+
+@pytest.mark.parametrize("case", _VECTORS["cases"], ids=lambda c: c["id"])
+def test_protected_header_has_alg_and_kid(case: dict) -> None:
+    """CARD-SIGN-003: JWS protected header MUST include alg and kid."""
+    card = case["agent_card"]
+    signatures = card.get("signatures", [])
+
+    if not signatures:
+        pytest.skip(f"{case['id']}: no signatures in card — signing is MAY (§8.4)")
+
+    decode_errors: list[str] = []
+    validation_errors: list[str] = []
+
+    for i, sig in enumerate(signatures):
+        protected = sig.get("protected", "")
+
+        # Decode
+        try:
+            header = _decode_protected_header(protected)
+        except Exception as exc:
+            decode_errors.append(
+                f"{case['id']}: signature[{i}] protected header decode failed: {exc}"
+            )
+            continue
+
+        # Validate
+        errs = _validate_protected_header(case["id"], header)
+        if errs:
+            validation_errors.extend(errs)
+
+    if case["expected_valid"]:
+        all_errors = decode_errors + validation_errors
+        assert not all_errors, "; ".join(all_errors)
+    else:
+        assert (
+            validation_errors or decode_errors
+        ), f"{case['id']}: expected validation failure but got none"
+        if "expected_error" in case:
+            error_text = "; ".join(validation_errors + decode_errors).lower()
+            assert case["expected_error"].lower() in error_text, (
+                f"{case['id']}: expected error containing '{case['expected_error']}', "
+                f"got: {'; '.join(validation_errors + decode_errors)}"
+            )
+
+
+@pytest.mark.parametrize("case", _VECTORS["cases"], ids=lambda c: c["id"])
+def test_protected_header_alg_is_known_jws_algorithm(case: dict) -> None:
+    """CARD-SIGN-003 (SHOULD): alg SHOULD be a known JWS algorithm from RFC 7518.
+
+    This is a SHOULD-level advisory check, not a MUST. A non-standard alg
+    produces a warning-level failure rather than a hard assertion.
+    """
+    signatures = case["agent_card"].get("signatures", [])
+    if not signatures:
+        pytest.skip(f"{case['id']}: no signatures in card")
+
+    for i, sig in enumerate(signatures):
+        protected = sig.get("protected", "")
+        try:
+            header = _decode_protected_header(protected)
+        except Exception:
+            continue  # decode failure handled by test_protected_header_has_alg_and_kid
+
+        alg = header.get("alg", "")
+        if alg and alg not in _KNOWN_JWS_ALGORITHMS:
+            pytest.fail(
+                f"{case['id']}: signature[{i}] alg='{alg}' is not a known "
+                f"JWS algorithm from RFC 7518 §3.1. Known: "
+                f"{sorted(_KNOWN_JWS_ALGORITHMS)}"
+            )


### PR DESCRIPTION
## What

Adds reference vectors and structural tests for **CARD-SIGN-003** (§8.4.2): the JWS protected header MUST include `alg` (algorithm) and `kid` (key ID) parameters.

## Changes

- **`card_signing_protected_header_vectors.json`**: 6 test cases
  - `cardsign-hdr-001`: valid ES256 header
  - `cardsign-hdr-002`: valid RS256 header
  - `cardsign-hdr-003`: missing `kid` → negative case
  - `cardsign-hdr-004`: missing `alg` → negative case
  - `cardsign-hdr-005`: empty `alg` → negative case
  - `cardsign-hdr-006`: multi-signature card (ES384 + EdDSA)

- **`test_card_signing_protected_header.py`**: two parametrized tests
  - `test_protected_header_has_alg_and_kid` (MUST): base64url-decodes each signature's `protected` field and validates `alg` + `kid` are present, non-empty strings
  - `test_protected_header_alg_is_known_jws_algorithm` (SHOULD): advisory check against RFC 7518 §3.1 standard algorithm names

- **`tck/requirements/agent_card.py`**: Remove `NOT_AUTOMATABLE` from CARD-SIGN-003

## Design decisions

- **No SUT required.** These are offline structural tests operating on static vectors — the same reference-vector pattern as PR #194. No transport, no live agent needed.
- **No new dependencies.** Uses only stdlib `base64` + `json`. No `jwcrypto` or `rfc8785`.
- **Negative cases included.** The vectors explicitly test missing `kid`, missing `alg`, and empty `alg` to prove the validator catches violations.
- **SHOULD-level algorithm check separated from MUST.** The known-algorithm test (`_KNOWN_JWS_ALGORITHMS` from RFC 7518) is a separate test so a non-standard `alg` produces a warning-level failure rather than blocking the MUST check.

## Test results

```
12 passed in 0.01s
```

`make lint` clean. `uv run pytest` green.

## Relationship to other PRs

- Builds on PR #194 (canonicalization vectors for CARD-SIGN-001/002) but is fully independent
- Together, PR #194 + this PR close the CARD-SIGN gap from TASK-29 / issue #187 (CARD-SIGN-004 remains `NOT_AUTOMATABLE` by design)

This fixes #187