### PR TITLE
fix(transport): activate required Agent Card extensions on all requests

### DIFF
--- a/tck/transport/_helpers.py
+++ b/tck/transport/_helpers.py
@@ -11,7 +11,26 @@ if TYPE_CHECKING:
     import httpx
 
 A2A_VERSION_HEADER = "A2A-Version"
+A2A_EXTENSIONS_HEADER = "A2A-Extensions"
 A2A_VERSION = "1.0"
+
+
+def get_required_extensions(agent_card: dict) -> list[str]:
+    """Extract required extension URIs from an Agent Card.
+
+    Per A2A spec §8.3.3, ``capabilities.extensions[]`` entries with
+    ``required: true`` must be activated on every request via the
+    ``A2A-Extensions`` header (HTTP) or ``a2a-extensions`` metadata (gRPC).
+
+    Returns a list of extension URIs (may be empty).
+    """
+    caps = agent_card.get("capabilities", {})
+    extensions = caps.get("extensions", [])
+    return [
+        ext["uri"]
+        for ext in extensions
+        if isinstance(ext, dict) and ext.get("required") and ext.get("uri")
+    ]
 
 
 def _build_params(**kwargs: Any) -> dict:

--- a/tck/transport/base.py
+++ b/tck/transport/base.py
@@ -75,7 +75,7 @@ class BaseTransportClient(ABC):
     Method signatures expose all parameters from the A2A proto request types.
     """
 
-    def __init__(self, base_url: str, transport: str) -> None:
+    def __init__(self, base_url: str, transport: str, *, required_extensions: list[str] | None = None) -> None:
         self.base_url = base_url
         self.transport = transport
 

--- a/tck/transport/grpc_client.py
+++ b/tck/transport/grpc_client.py
@@ -17,7 +17,7 @@ import grpc
 from google.protobuf.json_format import ParseDict
 
 from specification.generated import a2a_pb2, a2a_pb2_grpc
-from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER, _build_params
+from tck.transport._helpers import A2A_EXTENSIONS_HEADER, A2A_VERSION, A2A_VERSION_HEADER, _build_params
 from tck.transport.base import BaseTransportClient, StreamingResponse, TransportResponse
 
 
@@ -98,13 +98,22 @@ class GrpcClient(BaseTransportClient):
         grpc.StatusCode.INTERNAL,
     })
 
-    _METADATA = ((A2A_VERSION_HEADER.lower(), A2A_VERSION),)
-
-    def __init__(self, base_url: str) -> None:
+    def __init__(self, base_url: str, *, required_extensions: list[str] | None = None) -> None:
         super().__init__(base_url, TRANSPORT)
+        self._required_extensions: list[str] = required_extensions or []
         self._channel: grpc.Channel | None = None
         self._stub: a2a_pb2_grpc.A2AServiceStub | None = None
         self._connect()
+
+    @property
+    def _metadata(self) -> tuple[tuple[str, str], ...]:
+        """GRPC metadata including A2A-Version and required extensions."""
+        meta: list[tuple[str, str]] = [(A2A_VERSION_HEADER.lower(), A2A_VERSION)]
+        if self._required_extensions:
+            meta.append(
+                (A2A_EXTENSIONS_HEADER.lower(), ",".join(self._required_extensions))
+            )
+        return tuple(meta)
 
     def _connect(self) -> None:
         """Create a fresh gRPC channel and stub."""
@@ -145,14 +154,14 @@ class GrpcClient(BaseTransportClient):
         """
         rpc = getattr(self._stub, rpc_name)
         try:
-            return make_ok(rpc(request, timeout=timeout, metadata=self._METADATA))
+            return make_ok(rpc(request, timeout=timeout, metadata=self._metadata))
         except grpc.RpcError as e:
             if e.code() not in self._RETRIABLE_CODES:
                 return make_err(e)
             self._connect()
             try:
                 rpc = getattr(self._stub, rpc_name)
-                return make_ok(rpc(request, timeout=timeout, metadata=self._METADATA))
+                return make_ok(rpc(request, timeout=timeout, metadata=self._metadata))
             except grpc.RpcError as e2:
                 return make_err(e2)
 
@@ -192,7 +201,7 @@ class GrpcClient(BaseTransportClient):
         for attempt in range(2):
             rpc = getattr(self._stub, rpc_name)
             try:
-                stream = rpc(request, timeout=self._STREAMING_TIMEOUT_S, metadata=self._METADATA)
+                stream = rpc(request, timeout=self._STREAMING_TIMEOUT_S, metadata=self._metadata)
                 try:
                     first = next(stream)
                 except StopIteration:

--- a/tck/transport/http_json_client.py
+++ b/tck/transport/http_json_client.py
@@ -28,7 +28,7 @@ from tck.requirements.base import (
     SEND_MESSAGE_BINDING,
     SUBSCRIBE_TO_TASK_BINDING,
 )
-from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER, _build_params, _stream_sse
+from tck.transport._helpers import A2A_EXTENSIONS_HEADER, A2A_VERSION, A2A_VERSION_HEADER, _build_params, _stream_sse
 from tck.transport.base import BaseTransportClient, StreamingResponse, TransportResponse
 
 
@@ -112,12 +112,16 @@ class HttpJsonStreamingResponse(_HttpJsonResponseMixin, StreamingResponse):
 class HttpJsonClient(BaseTransportClient):
     """HTTP+JSON (REST) transport client for A2A protocol."""
 
-    def __init__(self, base_url: str) -> None:
+    def __init__(self, base_url: str, *, required_extensions: list[str] | None = None) -> None:
         super().__init__(base_url, TRANSPORT)
+        self._required_extensions: list[str] = required_extensions or []
+        default_headers: dict[str, str] = {A2A_VERSION_HEADER: A2A_VERSION}
+        if self._required_extensions:
+            default_headers[A2A_EXTENSIONS_HEADER] = ",".join(self._required_extensions)
         self._client = httpx.Client(
             base_url=base_url,
             timeout=httpx.Timeout(5.0, read=30.0),
-            headers={A2A_VERSION_HEADER: A2A_VERSION},
+            headers=default_headers,
             follow_redirects=True,
         )
 

--- a/tck/transport/jsonrpc_client.py
+++ b/tck/transport/jsonrpc_client.py
@@ -14,7 +14,7 @@ from typing import Any
 import httpx
 
 from tck.requirements.base import OperationType
-from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER, _build_params, _stream_sse
+from tck.transport._helpers import A2A_EXTENSIONS_HEADER, A2A_VERSION, A2A_VERSION_HEADER, _build_params, _stream_sse
 from tck.transport.base import BaseTransportClient, StreamingResponse, TransportResponse
 
 
@@ -75,13 +75,17 @@ class JsonRpcStreamingResponse(_JsonRpcResponseMixin, StreamingResponse):
 class JsonRpcClient(BaseTransportClient):
     """JSON-RPC 2.0 over HTTP transport client for A2A protocol."""
 
-    def __init__(self, base_url: str) -> None:
+    def __init__(self, base_url: str, *, required_extensions: list[str] | None = None) -> None:
         super().__init__(base_url, TRANSPORT)
+        self._required_extensions: list[str] = required_extensions or []
         self._id_counter = itertools.count(1)
+        default_headers: dict[str, str] = {A2A_VERSION_HEADER: A2A_VERSION}
+        if self._required_extensions:
+            default_headers[A2A_EXTENSIONS_HEADER] = ",".join(self._required_extensions)
         self._client = httpx.Client(
             base_url=base_url,
             timeout=httpx.Timeout(5.0, read=30.0),
-            headers={A2A_VERSION_HEADER: A2A_VERSION},
+            headers=default_headers,
             follow_redirects=True,
         )
 

--- a/tests/compatibility/conftest.py
+++ b/tests/compatibility/conftest.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 
 from tck.reporting.collector import CompatibilityCollector
+from tck.transport._helpers import get_required_extensions
 from tck.transport.grpc_client import GrpcClient
 from tck.transport.http_json_client import HttpJsonClient
 from tck.transport.jsonrpc_client import JsonRpcClient
@@ -134,6 +135,7 @@ def transport_clients(
         transport_filter = {t.strip() for t in raw.split(",") if t.strip()}
 
     clients: dict[str, BaseTransportClient] = {}
+    required_extensions = get_required_extensions(agent_card)
     for iface in interfaces:
         binding = iface.get("protocolBinding", "")
         url = iface.get("url", "")
@@ -150,7 +152,7 @@ def transport_clients(
 
         # First interface per transport wins (preference order)
         if transport_name not in clients:
-            clients[transport_name] = client_class(url)
+            clients[transport_name] = client_class(url, required_extensions=required_extensions)
 
     if not clients:
         declared = [iface.get("protocolBinding", "?") for iface in interfaces]


### PR DESCRIPTION
## What

When a SUT declares required extensions in its Agent Card (`capabilities.extensions[]` with `required: true`), the TCK transport clients now automatically include the `A2A-Extensions` header (HTTP) or `a2a-extensions` metadata (gRPC) on every request.

**Before:** transport clients only sent `A2A-Version`. SUTs enforcing required extensions returned `ExtensionSupportRequiredError` on every positive test — breaking CORE-SEND-*, CORE-STREAM-*, GRPC-ERR-*, and related tests.

**After:** required extensions are activated automatically. SUTs that declare and enforce extensions can pass the full conformance suite.

## Changes

- **`tck/transport/_helpers.py`**: add `get_required_extensions()` and `A2A_EXTENSIONS_HEADER` constant
- **`tck/transport/base.py`**: accept `required_extensions` keyword in `BaseTransportClient.__init__()`
- **`tck/transport/http_json_client.py`**: include `A2A-Extensions` in default `httpx.Client` headers
- **`tck/transport/jsonrpc_client.py`**: same treatment
- **`tck/transport/grpc_client.py`**: replace static `_METADATA` with dynamic `_metadata` property that appends `a2a-extensions` tuple
- **`tests/compatibility/conftest.py`**: extract extensions from `agent_card` fixture and pass to all transport client constructors

## Design decisions

- **No breaking changes.** All transport client constructors default `required_extensions=None`, preserving backward compatibility for direct instantiation without extensions.
- **Negative tests unaffected.** `test_error_handling.py` uses raw `_jsonrpc_call` / `_rest_call` helpers that bypass transport clients entirely.
- **Empty = no-op.** When the Agent Card has no required extensions, the transport clients behave identically to before.
- **HTTP header format:** comma-separated URIs per spec §8.3.3 (`A2A-Extensions: uri1,uri2`).

## Test results

```
make lint    → All checks passed!
make unit-test → 253 passed
```

This fixes #193