### PR TITLE
fix: align package license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11"
 authors = [
     {name = "A2A Protocol Developers"}
 ]
-license = "MIT"
+license = "Apache-2.0"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11"
 authors = [
     {name = "A2A Protocol Developers"}
 ]
-license = "Apache-2.0"
+license = {file = "LICENSE"}
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
# Description

## Summary

Align the PEP 621 package metadata with the Apache License 2.0 declared by the repository license, README, and contribution terms.

## Validation

- [x] Followed the `CONTRIBUTING.md` guide.
- [x] Used a Conventional Commit title.
- [x] `make lint`
- [x] `PYTHONUTF8=1 make unit-test` (253 passed)
- [x] No README updates are required; it already names Apache License 2.0.

Fixes #198