### PR TITLE
fix: inject auth headers in transport clients

### DIFF
--- a/docs/AUTHENTICATION_SETUP.md
+++ b/docs/AUTHENTICATION_SETUP.md
@@ -87,10 +87,10 @@ Once configured, run tests normally:
 
 ```bash
 # Run all tests with authentication
-./run_tck.py --sut-url https://your-sut.example.com --category all
+uv run --env-file .env ./run_tck.py --sut-host https://your-sut.example.com
 
-# Run mandatory tests only
-./run_tck.py --sut-url https://your-sut.example.com --category mandatory
+# Run MUST-level requirements only
+uv run --env-file .env ./run_tck.py --sut-host https://your-sut.example.com --level must
 ```
 
 The TCK will automatically inject authentication headers into every request.
@@ -168,7 +168,7 @@ The TCK includes tests to verify authentication enforcement:
 
 ```bash
 # Run with verbose logging to see headers
-./run_tck.py --sut-url https://your-sut.example.com --category mandatory --verbose-log
+uv run --env-file .env ./run_tck.py --sut-host https://your-sut.example.com --level must --verbose-log
 ```
 
 ### Authentication headers not being sent
@@ -180,7 +180,7 @@ The TCK includes tests to verify authentication enforcement:
 2. Verify format (no extra spaces, valid JSON for `A2A_AUTH_HEADERS`)
 3. Restart the test run after modifying `.env`
 
-### "Failed to parse A2A_AUTH_HEADERS" warning
+### "A2A_AUTH_HEADERS must contain a JSON object" error
 
 **Cause**: `A2A_AUTH_HEADERS` contains invalid JSON.
 
@@ -188,6 +188,8 @@ The TCK includes tests to verify authentication enforcement:
 - Ensure JSON is valid: `{"key":"value"}` not `{key:value}`
 - Use double quotes, not single quotes
 - Escape special characters if needed
+
+The TCK stops before sending requests when the configured headers are invalid.
 
 ### SUT accepts requests without authentication
 
@@ -209,7 +211,7 @@ A2A_AUTH_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Y2stdGVzdCJ9.abc
 
 ```bash
 # Run tests
-./run_tck.py --sut-url https://my-sut.example.com --category all
+uv run --env-file .env ./run_tck.py --sut-host https://my-sut.example.com
 ```
 
 ### Example 2: Testing a SUT with API Key
@@ -223,7 +225,7 @@ A2A_AUTH_HEADER=X-API-Key
 
 ```bash
 # Run tests
-./run_tck.py --sut-url https://api.example.com --category mandatory
+uv run --env-file .env ./run_tck.py --sut-host https://api.example.com --level must
 ```
 
 ### Example 3: Testing a SUT with Basic Auth
@@ -237,7 +239,7 @@ A2A_AUTH_PASSWORD=testpass123
 
 ```bash
 # Run tests
-./run_tck.py --sut-url http://localhost:9999 --category all
+uv run --env-file .env ./run_tck.py --sut-host http://localhost:9999
 ```
 
 ### Example 4: Testing with Multiple Headers
@@ -249,7 +251,7 @@ A2A_AUTH_HEADERS={"Authorization":"Bearer token123","X-Tenant-ID":"tenant-001","
 
 ```bash
 # Run tests
-./run_tck.py --sut-url https://multi-tenant.example.com --category all
+uv run --env-file .env ./run_tck.py --sut-host https://multi-tenant.example.com
 ```
 
 ## Security Best Practices
@@ -272,7 +274,7 @@ For CI/CD pipelines, set environment variables directly instead of using `.env`:
 # GitHub Actions example
 export A2A_AUTH_TYPE=bearer
 export A2A_AUTH_TOKEN=${{ secrets.TCK_AUTH_TOKEN }}
-./run_tck.py --sut-url ${{ secrets.SUT_URL }} --category all
+uv run ./run_tck.py --sut-host ${{ secrets.SUT_URL }}
 ```
 
 ## See Also

--- a/tck/transport/_helpers.py
+++ b/tck/transport/_helpers.py
@@ -2,16 +2,84 @@
 
 from __future__ import annotations
 
+import base64
 import json
+import os
 
 from typing import TYPE_CHECKING, Any, Iterator
 
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import httpx
 
 A2A_VERSION_HEADER = "A2A-Version"
 A2A_VERSION = "1.0"
+
+
+def get_auth_headers(env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Build authentication headers from the documented environment variables.
+
+    ``A2A_AUTH_HEADERS`` supplements the headers derived from
+    ``A2A_AUTH_TYPE`` and takes precedence when the same header is present.
+    """
+    environment = os.environ if env is None else env
+    headers: dict[str, str] = {}
+    auth_type = environment.get("A2A_AUTH_TYPE", "").strip().lower()
+
+    if auth_type == "bearer":
+        headers["Authorization"] = f"Bearer {_required_auth_value(environment, 'A2A_AUTH_TOKEN')}"
+    elif auth_type == "basic":
+        username = _required_auth_value(environment, "A2A_AUTH_USERNAME")
+        password = _required_auth_value(environment, "A2A_AUTH_PASSWORD")
+        credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {credentials}"
+    elif auth_type in {"apikey", "custom"}:
+        header_name = environment.get("A2A_AUTH_HEADER")
+        if not header_name:
+            header_name = "X-API-Key" if auth_type == "apikey" else None
+        if not header_name:
+            raise ValueError("A2A_AUTH_HEADER must be set when A2A_AUTH_TYPE is custom")
+        headers[header_name] = _required_auth_value(environment, "A2A_AUTH_TOKEN")
+    elif auth_type:
+        raise ValueError(f"Unsupported A2A_AUTH_TYPE: {auth_type}")
+
+    raw_headers = environment.get("A2A_AUTH_HEADERS")
+    if raw_headers:
+        try:
+            configured_headers = json.loads(raw_headers)
+        except json.JSONDecodeError as exc:
+            raise ValueError("A2A_AUTH_HEADERS must contain a JSON object") from exc
+        if not isinstance(configured_headers, dict) or not all(
+            isinstance(name, str) and isinstance(value, str)
+            for name, value in configured_headers.items()
+        ):
+            raise ValueError("A2A_AUTH_HEADERS must contain string header names and values")
+        headers = merge_headers(headers, configured_headers)
+
+    return merge_headers(headers)
+
+
+def build_default_headers(env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Build headers shared by all transport clients."""
+    return merge_headers({A2A_VERSION_HEADER: A2A_VERSION}, get_auth_headers(env))
+
+
+def merge_headers(*header_sets: Mapping[str, str] | None) -> dict[str, str]:
+    """Merge HTTP headers case-insensitively, with later values overriding."""
+    merged: dict[str, str] = {}
+    for headers in header_sets:
+        if headers:
+            merged.update({name.lower(): value for name, value in headers.items()})
+    return merged
+
+
+def _required_auth_value(environment: Mapping[str, str], name: str) -> str:
+    value = environment.get(name)
+    if not value:
+        raise ValueError(f"{name} must be set when authentication is configured")
+    return value
 
 
 def _build_params(**kwargs: Any) -> dict:

--- a/tck/transport/base.py
+++ b/tck/transport/base.py
@@ -86,6 +86,7 @@ class BaseTransportClient(ABC):
         *,
         configuration: dict | None = None,
         metadata: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse: ...
 
     @abstractmethod
@@ -95,6 +96,7 @@ class BaseTransportClient(ABC):
         *,
         configuration: dict | None = None,
         metadata: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> StreamingResponse: ...
 
     @abstractmethod
@@ -103,6 +105,7 @@ class BaseTransportClient(ABC):
         id: str,
         *,
         history_length: int | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse: ...
 
     @abstractmethod
@@ -116,19 +119,22 @@ class BaseTransportClient(ABC):
         history_length: int | None = None,
         status_timestamp_after: str | None = None,
         include_artifacts: bool | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse: ...
 
     @abstractmethod
-    def cancel_task(self, id: str) -> TransportResponse: ...
+    def cancel_task(self, id: str, *, extra_headers: dict[str, str] | None = None) -> TransportResponse: ...
 
     @abstractmethod
-    def subscribe_to_task(self, id: str) -> StreamingResponse: ...
+    def subscribe_to_task(self, id: str, *, extra_headers: dict[str, str] | None = None) -> StreamingResponse: ...
 
     @abstractmethod
     def create_push_notification_config(
         self,
         task_id: str,
         config: dict,
+        *,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse: ...
 
     @abstractmethod
@@ -136,6 +142,8 @@ class BaseTransportClient(ABC):
         self,
         task_id: str,
         id: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse: ...
 
     @abstractmethod
@@ -145,6 +153,7 @@ class BaseTransportClient(ABC):
         *,
         page_size: int | None = None,
         page_token: str | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse: ...
 
     @abstractmethod
@@ -152,10 +161,12 @@ class BaseTransportClient(ABC):
         self,
         task_id: str,
         id: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse: ...
 
     @abstractmethod
-    def get_extended_agent_card(self) -> TransportResponse: ...
+    def get_extended_agent_card(self, *, extra_headers: dict[str, str] | None = None) -> TransportResponse: ...
 
     def close(self) -> None:
         """Clean up resources. Override in subclasses if needed."""

--- a/tck/transport/grpc_client.py
+++ b/tck/transport/grpc_client.py
@@ -17,7 +17,7 @@ import grpc
 from google.protobuf.json_format import ParseDict
 
 from specification.generated import a2a_pb2, a2a_pb2_grpc
-from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER, _build_params
+from tck.transport._helpers import _build_params, build_default_headers, merge_headers
 from tck.transport.base import BaseTransportClient, StreamingResponse, TransportResponse
 
 
@@ -98,10 +98,9 @@ class GrpcClient(BaseTransportClient):
         grpc.StatusCode.INTERNAL,
     })
 
-    _METADATA = ((A2A_VERSION_HEADER.lower(), A2A_VERSION),)
-
     def __init__(self, base_url: str) -> None:
         super().__init__(base_url, TRANSPORT)
+        self._headers = build_default_headers()
         self._channel: grpc.Channel | None = None
         self._stub: a2a_pb2_grpc.A2AServiceStub | None = None
         self._connect()
@@ -124,6 +123,10 @@ class GrpcClient(BaseTransportClient):
         if self._channel is not None:
             self._channel.close()
 
+    def _metadata(self, extra_headers: dict[str, str] | None = None) -> tuple[tuple[str, str], ...]:
+        """Build gRPC metadata from default and per-call headers."""
+        return tuple(merge_headers(self._headers, extra_headers).items())
+
     # Default timeout (seconds) for streaming RPCs.  Without a deadline the
     # gRPC Python iterator can block indefinitely in certain environments
     # (e.g. pytest) even when the server has already sent data.
@@ -137,6 +140,7 @@ class GrpcClient(BaseTransportClient):
         make_err: callable,
         *,
         timeout: float | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse | StreamingResponse:
         """Execute a gRPC call with one retry on connection errors.
 
@@ -144,19 +148,26 @@ class GrpcClient(BaseTransportClient):
         build the transport-specific result object.
         """
         rpc = getattr(self._stub, rpc_name)
+        metadata = self._metadata(extra_headers)
         try:
-            return make_ok(rpc(request, timeout=timeout, metadata=self._METADATA))
+            return make_ok(rpc(request, timeout=timeout, metadata=metadata))
         except grpc.RpcError as e:
             if e.code() not in self._RETRIABLE_CODES:
                 return make_err(e)
             self._connect()
             try:
                 rpc = getattr(self._stub, rpc_name)
-                return make_ok(rpc(request, timeout=timeout, metadata=self._METADATA))
+                return make_ok(rpc(request, timeout=timeout, metadata=metadata))
             except grpc.RpcError as e2:
                 return make_err(e2)
 
-    def _unary_call(self, rpc_name: str, request: Any) -> TransportResponse:
+    def _unary_call(
+        self,
+        rpc_name: str,
+        request: Any,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> TransportResponse:
         """Execute a unary gRPC call with one retry on connection errors."""
         return self._call_with_retry(
             rpc_name, request,
@@ -166,6 +177,7 @@ class GrpcClient(BaseTransportClient):
             make_err=lambda e: GrpcResponse(
                 transport=self.transport, success=False, raw_response=e,
             ),
+            extra_headers=extra_headers,
         )
 
     def send_message(
@@ -174,13 +186,20 @@ class GrpcClient(BaseTransportClient):
         *,
         configuration: dict | None = None,
         metadata: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """Send a message to the agent."""
         params = _build_params(message=message, configuration=configuration, metadata=metadata)
         proto_request = _dict_to_proto(params, a2a_pb2.SendMessageRequest)
-        return self._unary_call("SendMessage", proto_request)
+        return self._unary_call("SendMessage", proto_request, extra_headers=extra_headers)
 
-    def _streaming_call(self, rpc_name: str, request: Any) -> StreamingResponse:
+    def _streaming_call(
+        self,
+        rpc_name: str,
+        request: Any,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> StreamingResponse:
         """Execute a streaming gRPC call with one retry on connection errors.
 
         Peeks at the first event to detect an empty stream early.  Any
@@ -192,7 +211,7 @@ class GrpcClient(BaseTransportClient):
         for attempt in range(2):
             rpc = getattr(self._stub, rpc_name)
             try:
-                stream = rpc(request, timeout=self._STREAMING_TIMEOUT_S, metadata=self._METADATA)
+                stream = rpc(request, timeout=self._STREAMING_TIMEOUT_S, metadata=self._metadata(extra_headers))
                 try:
                     first = next(stream)
                 except StopIteration:
@@ -217,22 +236,24 @@ class GrpcClient(BaseTransportClient):
         *,
         configuration: dict | None = None,
         metadata: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> StreamingResponse:
         """Send a streaming message to the agent."""
         params = _build_params(message=message, configuration=configuration, metadata=metadata)
         proto_request = _dict_to_proto(params, a2a_pb2.SendMessageRequest)
-        return self._streaming_call("SendStreamingMessage", proto_request)
+        return self._streaming_call("SendStreamingMessage", proto_request, extra_headers=extra_headers)
 
     def get_task(
         self,
         id: str,
         *,
         history_length: int | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """Get a task by ID."""
         params = _build_params(id=id, history_length=history_length)
         proto_request = _dict_to_proto(params, a2a_pb2.GetTaskRequest)
-        return self._unary_call("GetTask", proto_request)
+        return self._unary_call("GetTask", proto_request, extra_headers=extra_headers)
 
     def list_tasks(
         self,
@@ -244,6 +265,7 @@ class GrpcClient(BaseTransportClient):
         history_length: int | None = None,
         status_timestamp_after: str | None = None,
         include_artifacts: bool | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """List tasks filtered by context ID."""
         params = _build_params(
@@ -256,33 +278,41 @@ class GrpcClient(BaseTransportClient):
         )
         params["context_id"] = context_id
         proto_request = _dict_to_proto(params, a2a_pb2.ListTasksRequest)
-        return self._unary_call("ListTasks", proto_request)
+        return self._unary_call("ListTasks", proto_request, extra_headers=extra_headers)
 
-    def cancel_task(self, id: str) -> TransportResponse:
+    def cancel_task(self, id: str, *, extra_headers: dict[str, str] | None = None) -> TransportResponse:
         """Cancel a task by ID."""
         proto_request = _dict_to_proto({"id": id}, a2a_pb2.CancelTaskRequest)
-        return self._unary_call("CancelTask", proto_request)
+        return self._unary_call("CancelTask", proto_request, extra_headers=extra_headers)
 
-    def subscribe_to_task(self, id: str) -> StreamingResponse:
+    def subscribe_to_task(self, id: str, *, extra_headers: dict[str, str] | None = None) -> StreamingResponse:
         """Subscribe to task updates."""
         proto_request = _dict_to_proto({"id": id}, a2a_pb2.SubscribeToTaskRequest)
-        return self._streaming_call("SubscribeToTask", proto_request)
+        return self._streaming_call("SubscribeToTask", proto_request, extra_headers=extra_headers)
 
     def create_push_notification_config(
         self,
         task_id: str,
         config: dict,
+        *,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """Create a push notification config for a task."""
         params = {"task_id": task_id, **config}
         proto_request = _dict_to_proto(params, a2a_pb2.TaskPushNotificationConfig)
-        return self._unary_call("CreateTaskPushNotificationConfig", proto_request)
+        return self._unary_call("CreateTaskPushNotificationConfig", proto_request, extra_headers=extra_headers)
 
-    def get_push_notification_config(self, task_id: str, id: str) -> TransportResponse:
+    def get_push_notification_config(
+        self,
+        task_id: str,
+        id: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> TransportResponse:
         """Get a push notification config by task and config ID."""
         params = {"task_id": task_id, "id": id}
         proto_request = _dict_to_proto(params, a2a_pb2.GetTaskPushNotificationConfigRequest)
-        return self._unary_call("GetTaskPushNotificationConfig", proto_request)
+        return self._unary_call("GetTaskPushNotificationConfig", proto_request, extra_headers=extra_headers)
 
     def list_push_notification_configs(
         self,
@@ -290,19 +320,26 @@ class GrpcClient(BaseTransportClient):
         *,
         page_size: int | None = None,
         page_token: str | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """List push notification configs for a task."""
         params = _build_params(task_id=task_id, page_size=page_size, page_token=page_token)
         proto_request = _dict_to_proto(params, a2a_pb2.ListTaskPushNotificationConfigsRequest)
-        return self._unary_call("ListTaskPushNotificationConfigs", proto_request)
+        return self._unary_call("ListTaskPushNotificationConfigs", proto_request, extra_headers=extra_headers)
 
-    def delete_push_notification_config(self, task_id: str, id: str) -> TransportResponse:
+    def delete_push_notification_config(
+        self,
+        task_id: str,
+        id: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> TransportResponse:
         """Delete a push notification config by task and config ID."""
         params = {"task_id": task_id, "id": id}
         proto_request = _dict_to_proto(params, a2a_pb2.DeleteTaskPushNotificationConfigRequest)
-        return self._unary_call("DeleteTaskPushNotificationConfig", proto_request)
+        return self._unary_call("DeleteTaskPushNotificationConfig", proto_request, extra_headers=extra_headers)
 
-    def get_extended_agent_card(self) -> TransportResponse:
+    def get_extended_agent_card(self, *, extra_headers: dict[str, str] | None = None) -> TransportResponse:
         """Get the extended agent card."""
         proto_request = a2a_pb2.GetExtendedAgentCardRequest()
-        return self._unary_call("GetExtendedAgentCard", proto_request)
+        return self._unary_call("GetExtendedAgentCard", proto_request, extra_headers=extra_headers)

--- a/tck/transport/http_json_client.py
+++ b/tck/transport/http_json_client.py
@@ -27,7 +27,7 @@ from tck.requirements.base import (
     SEND_MESSAGE_BINDING,
     SUBSCRIBE_TO_TASK_BINDING,
 )
-from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER, _build_params, _stream_sse
+from tck.transport._helpers import _build_params, _stream_sse, build_default_headers, merge_headers
 from tck.transport.base import BaseTransportClient, StreamingResponse, TransportResponse
 
 
@@ -110,10 +110,11 @@ class HttpJsonClient(BaseTransportClient):
 
     def __init__(self, base_url: str) -> None:
         super().__init__(base_url, TRANSPORT)
+        self._headers = build_default_headers()
         self._client = httpx.Client(
             base_url=base_url,
             timeout=httpx.Timeout(5.0, read=30.0),
-            headers={A2A_VERSION_HEADER: A2A_VERSION},
+            headers=self._headers,
         )
 
     def close(self) -> None:
@@ -127,6 +128,7 @@ class HttpJsonClient(BaseTransportClient):
         *,
         json_body: dict | None = None,
         params: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """Make an HTTP request and return a TransportResponse."""
         try:
@@ -135,7 +137,11 @@ class HttpJsonClient(BaseTransportClient):
                 path,
                 json=json_body,
                 params=params,
-                headers={"Content-Type": "application/json"} if method.upper() == "POST" else None,
+                headers=merge_headers(
+                    self._headers,
+                    {"Content-Type": "application/json"} if method.upper() == "POST" else None,
+                    extra_headers,
+                ),
             )
             resp_headers = dict(response.headers)
             if response.status_code >= _HTTP_ERROR_MIN:
@@ -165,6 +171,7 @@ class HttpJsonClient(BaseTransportClient):
         path: str,
         *,
         json_body: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> StreamingResponse:
         """Make an HTTP request expecting an SSE streaming response.
 
@@ -176,10 +183,14 @@ class HttpJsonClient(BaseTransportClient):
                 method,
                 path,
                 json=json_body,
-                headers={
-                    "Content-Type": "application/json",
-                    "Accept": "text/event-stream",
-                },
+                headers=merge_headers(
+                    self._headers,
+                    {
+                        "Content-Type": "application/json",
+                        "Accept": "text/event-stream",
+                    },
+                    extra_headers,
+                ),
             )
             response = self._client.send(request, stream=True)
             resp_headers = dict(response.headers)
@@ -219,6 +230,7 @@ class HttpJsonClient(BaseTransportClient):
         *,
         configuration: dict | None = None,
         metadata: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """Send a message to the agent via ``POST /message:send``."""
         body = _build_params(message=message, configuration=configuration, metadata=metadata)
@@ -226,6 +238,7 @@ class HttpJsonClient(BaseTransportClient):
             SEND_MESSAGE_BINDING.http_json_method,
             PATH_MESSAGE_SEND,
             json_body=body,
+            extra_headers=extra_headers,
         )
 
     def send_streaming_message(
@@ -234,6 +247,7 @@ class HttpJsonClient(BaseTransportClient):
         *,
         configuration: dict | None = None,
         metadata: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> StreamingResponse:
         """Send a streaming message to the agent via ``POST /message:stream``."""
         body = _build_params(message=message, configuration=configuration, metadata=metadata)
@@ -241,6 +255,7 @@ class HttpJsonClient(BaseTransportClient):
             SEND_MESSAGE_BINDING.http_json_method,
             PATH_MESSAGE_STREAM,
             json_body=body,
+            extra_headers=extra_headers,
         )
 
     # -- Task Operations --
@@ -250,6 +265,7 @@ class HttpJsonClient(BaseTransportClient):
         id: str,
         *,
         history_length: int | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """Get a task by ID via ``GET /tasks/{id}``."""
         params = _build_params(historyLength=history_length)
@@ -257,6 +273,7 @@ class HttpJsonClient(BaseTransportClient):
             GET_TASK_BINDING.http_json_method,
             GET_TASK_BINDING.http_json_path.format(id=id),
             params=params or None,
+            extra_headers=extra_headers,
         )
 
     def list_tasks(
@@ -269,6 +286,7 @@ class HttpJsonClient(BaseTransportClient):
         history_length: int | None = None,
         status_timestamp_after: str | None = None,
         include_artifacts: bool | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """List tasks filtered by context ID via ``GET /tasks``."""
         params = _build_params(
@@ -284,20 +302,23 @@ class HttpJsonClient(BaseTransportClient):
             LIST_TASKS_BINDING.http_json_method,
             LIST_TASKS_BINDING.http_json_path,
             params=params,
+            extra_headers=extra_headers,
         )
 
-    def cancel_task(self, id: str) -> TransportResponse:
+    def cancel_task(self, id: str, *, extra_headers: dict[str, str] | None = None) -> TransportResponse:
         """Cancel a task by ID via ``POST /tasks/{id}:cancel``."""
         return self._request(
             CANCEL_TASK_BINDING.http_json_method,
             CANCEL_TASK_BINDING.http_json_path.format(id=id),
+            extra_headers=extra_headers,
         )
 
-    def subscribe_to_task(self, id: str) -> StreamingResponse:
+    def subscribe_to_task(self, id: str, *, extra_headers: dict[str, str] | None = None) -> StreamingResponse:
         """Subscribe to task updates via ``POST /tasks/{id}:subscribe``."""
         return self._request_streaming(
             SUBSCRIBE_TO_TASK_BINDING.http_json_method,
             SUBSCRIBE_TO_TASK_BINDING.http_json_path.format(id=id),
+            extra_headers=extra_headers,
         )
 
     # -- Push Notification Configuration --
@@ -306,6 +327,8 @@ class HttpJsonClient(BaseTransportClient):
         self,
         task_id: str,
         config: dict,
+        *,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """Create a push notification config via ``POST /tasks/{id}/pushNotificationConfigs``."""
         body = config
@@ -313,13 +336,21 @@ class HttpJsonClient(BaseTransportClient):
             CREATE_PUSH_CONFIG_BINDING.http_json_method,
             CREATE_PUSH_CONFIG_BINDING.http_json_path.format(id=task_id),
             json_body=body,
+            extra_headers=extra_headers,
         )
 
-    def get_push_notification_config(self, task_id: str, id: str) -> TransportResponse:
+    def get_push_notification_config(
+        self,
+        task_id: str,
+        id: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> TransportResponse:
         """Get a push notification config via ``GET /tasks/{id}/pushNotificationConfigs/{configId}``."""
         return self._request(
             GET_PUSH_CONFIG_BINDING.http_json_method,
             GET_PUSH_CONFIG_BINDING.http_json_path.format(id=task_id, configId=id),
+            extra_headers=extra_headers,
         )
 
     def list_push_notification_configs(
@@ -328,6 +359,7 @@ class HttpJsonClient(BaseTransportClient):
         *,
         page_size: int | None = None,
         page_token: str | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """List push notification configs via ``GET /tasks/{id}/pushNotificationConfigs``."""
         params = _build_params(pageSize=page_size, pageToken=page_token)
@@ -335,20 +367,29 @@ class HttpJsonClient(BaseTransportClient):
             LIST_PUSH_CONFIGS_BINDING.http_json_method,
             LIST_PUSH_CONFIGS_BINDING.http_json_path.format(id=task_id),
             params=params or None,
+            extra_headers=extra_headers,
         )
 
-    def delete_push_notification_config(self, task_id: str, id: str) -> TransportResponse:
+    def delete_push_notification_config(
+        self,
+        task_id: str,
+        id: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> TransportResponse:
         """Delete a push notification config via ``DELETE /tasks/{id}/pushNotificationConfigs/{configId}``."""
         return self._request(
             DELETE_PUSH_CONFIG_BINDING.http_json_method,
             DELETE_PUSH_CONFIG_BINDING.http_json_path.format(id=task_id, configId=id),
+            extra_headers=extra_headers,
         )
 
     # -- Agent Card --
 
-    def get_extended_agent_card(self) -> TransportResponse:
+    def get_extended_agent_card(self, *, extra_headers: dict[str, str] | None = None) -> TransportResponse:
         """Get the extended agent card via ``GET /extendedAgentCard``."""
         return self._request(
             GET_EXTENDED_AGENT_CARD_BINDING.http_json_method,
             GET_EXTENDED_AGENT_CARD_BINDING.http_json_path,
+            extra_headers=extra_headers,
         )

--- a/tck/transport/jsonrpc_client.py
+++ b/tck/transport/jsonrpc_client.py
@@ -14,7 +14,7 @@ from typing import Any
 import httpx
 
 from tck.requirements.base import OperationType
-from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER, _build_params, _stream_sse
+from tck.transport._helpers import _build_params, _stream_sse, build_default_headers, merge_headers
 from tck.transport.base import BaseTransportClient, StreamingResponse, TransportResponse
 
 
@@ -78,10 +78,11 @@ class JsonRpcClient(BaseTransportClient):
     def __init__(self, base_url: str) -> None:
         super().__init__(base_url, TRANSPORT)
         self._id_counter = itertools.count(1)
+        self._headers = build_default_headers()
         self._client = httpx.Client(
             base_url=base_url,
             timeout=httpx.Timeout(5.0, read=30.0),
-            headers={A2A_VERSION_HEADER: A2A_VERSION},
+            headers=self._headers,
         )
 
     def close(self) -> None:
@@ -92,7 +93,13 @@ class JsonRpcClient(BaseTransportClient):
         """Generate the next unique request ID."""
         return next(self._id_counter)
 
-    def _call(self, method: str, params: dict) -> TransportResponse:
+    def _call(
+        self,
+        method: str,
+        params: dict,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> TransportResponse:
         """Make a JSON-RPC 2.0 call and return a TransportResponse."""
         payload = {
             "jsonrpc": "2.0",
@@ -104,7 +111,7 @@ class JsonRpcClient(BaseTransportClient):
             response = self._client.post(
                 "/",
                 json=payload,
-                headers={"Content-Type": "application/json"},
+                headers=merge_headers(self._headers, {"Content-Type": "application/json"}, extra_headers),
             )
             body = response.json()
             resp_headers = dict(response.headers)
@@ -120,7 +127,13 @@ class JsonRpcClient(BaseTransportClient):
                 transport=self.transport, success=False, raw_response=e,
             )
 
-    def _call_streaming(self, method: str, params: dict) -> StreamingResponse:
+    def _call_streaming(
+        self,
+        method: str,
+        params: dict,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> StreamingResponse:
         """Make a JSON-RPC 2.0 streaming call and return a StreamingResponse.
 
         If the server responds with ``text/event-stream``, events are yielded
@@ -139,10 +152,14 @@ class JsonRpcClient(BaseTransportClient):
                 "POST",
                 "/",
                 json=payload,
-                headers={
-                    "Content-Type": "application/json",
-                    "Accept": "text/event-stream",
-                },
+                headers=merge_headers(
+                    self._headers,
+                    {
+                        "Content-Type": "application/json",
+                        "Accept": "text/event-stream",
+                    },
+                    extra_headers,
+                ),
             )
             response = self._client.send(request, stream=True)
             content_type = response.headers.get("content-type", "")
@@ -185,10 +202,11 @@ class JsonRpcClient(BaseTransportClient):
         *,
         configuration: dict | None = None,
         metadata: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """Send a message to the agent."""
         params = _build_params(message=message, configuration=configuration, metadata=metadata)
-        return self._call(OperationType.SEND_MESSAGE.value, params)
+        return self._call(OperationType.SEND_MESSAGE.value, params, extra_headers=extra_headers)
 
     def send_streaming_message(
         self,
@@ -196,20 +214,22 @@ class JsonRpcClient(BaseTransportClient):
         *,
         configuration: dict | None = None,
         metadata: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> StreamingResponse:
         """Send a streaming message to the agent."""
         params = _build_params(message=message, configuration=configuration, metadata=metadata)
-        return self._call_streaming(OperationType.SEND_STREAMING_MESSAGE.value, params)
+        return self._call_streaming(OperationType.SEND_STREAMING_MESSAGE.value, params, extra_headers=extra_headers)
 
     def get_task(
         self,
         id: str,
         *,
         history_length: int | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """Get a task by ID."""
         params = _build_params(id=id, history_length=history_length)
-        return self._call(OperationType.GET_TASK.value, params)
+        return self._call(OperationType.GET_TASK.value, params, extra_headers=extra_headers)
 
     def list_tasks(
         self,
@@ -221,6 +241,7 @@ class JsonRpcClient(BaseTransportClient):
         history_length: int | None = None,
         status_timestamp_after: str | None = None,
         include_artifacts: bool | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """List tasks filtered by context ID."""
         params = _build_params(
@@ -232,28 +253,40 @@ class JsonRpcClient(BaseTransportClient):
             include_artifacts=include_artifacts,
         )
         params["context_id"] = context_id
-        return self._call(OperationType.LIST_TASKS.value, params)
+        return self._call(OperationType.LIST_TASKS.value, params, extra_headers=extra_headers)
 
-    def cancel_task(self, id: str) -> TransportResponse:
+    def cancel_task(self, id: str, *, extra_headers: dict[str, str] | None = None) -> TransportResponse:
         """Cancel a task by ID."""
-        return self._call(OperationType.CANCEL_TASK.value, {"id": id})
+        return self._call(OperationType.CANCEL_TASK.value, {"id": id}, extra_headers=extra_headers)
 
-    def subscribe_to_task(self, id: str) -> StreamingResponse:
+    def subscribe_to_task(self, id: str, *, extra_headers: dict[str, str] | None = None) -> StreamingResponse:
         """Subscribe to task updates."""
-        return self._call_streaming(OperationType.SUBSCRIBE_TO_TASK.value, {"id": id})
+        return self._call_streaming(OperationType.SUBSCRIBE_TO_TASK.value, {"id": id}, extra_headers=extra_headers)
 
     def create_push_notification_config(
         self,
         task_id: str,
         config: dict,
+        *,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """Create a push notification config for a task."""
         params = {"task_id": task_id, **config}
-        return self._call(OperationType.CREATE_PUSH_CONFIG.value, params)
+        return self._call(OperationType.CREATE_PUSH_CONFIG.value, params, extra_headers=extra_headers)
 
-    def get_push_notification_config(self, task_id: str, id: str) -> TransportResponse:
+    def get_push_notification_config(
+        self,
+        task_id: str,
+        id: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> TransportResponse:
         """Get a push notification config by task and config ID."""
-        return self._call(OperationType.GET_PUSH_CONFIG.value, {"task_id": task_id, "id": id})
+        return self._call(
+            OperationType.GET_PUSH_CONFIG.value,
+            {"task_id": task_id, "id": id},
+            extra_headers=extra_headers,
+        )
 
     def list_push_notification_configs(
         self,
@@ -261,15 +294,26 @@ class JsonRpcClient(BaseTransportClient):
         *,
         page_size: int | None = None,
         page_token: str | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> TransportResponse:
         """List push notification configs for a task."""
         params = _build_params(task_id=task_id, page_size=page_size, page_token=page_token)
-        return self._call(OperationType.LIST_PUSH_CONFIGS.value, params)
+        return self._call(OperationType.LIST_PUSH_CONFIGS.value, params, extra_headers=extra_headers)
 
-    def delete_push_notification_config(self, task_id: str, id: str) -> TransportResponse:
+    def delete_push_notification_config(
+        self,
+        task_id: str,
+        id: str,
+        *,
+        extra_headers: dict[str, str] | None = None,
+    ) -> TransportResponse:
         """Delete a push notification config by task and config ID."""
-        return self._call(OperationType.DELETE_PUSH_CONFIG.value, {"task_id": task_id, "id": id})
+        return self._call(
+            OperationType.DELETE_PUSH_CONFIG.value,
+            {"task_id": task_id, "id": id},
+            extra_headers=extra_headers,
+        )
 
-    def get_extended_agent_card(self) -> TransportResponse:
+    def get_extended_agent_card(self, *, extra_headers: dict[str, str] | None = None) -> TransportResponse:
         """Get the extended agent card."""
-        return self._call(OperationType.GET_EXTENDED_AGENT_CARD.value, {})
+        return self._call(OperationType.GET_EXTENDED_AGENT_CARD.value, {}, extra_headers=extra_headers)

--- a/tests/unit/transport/test_auth_headers.py
+++ b/tests/unit/transport/test_auth_headers.py
@@ -1,0 +1,150 @@
+"""Tests for configured authentication headers in transport clients."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tck.transport import grpc_client
+from tck.transport._helpers import build_default_headers, get_auth_headers, merge_headers
+from tck.transport.grpc_client import GrpcClient
+from tck.transport.http_json_client import HttpJsonClient
+from tck.transport.jsonrpc_client import JsonRpcClient
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        (
+            {"A2A_AUTH_TYPE": "bearer", "A2A_AUTH_TOKEN": "token"},
+            {"authorization": "Bearer token"},
+        ),
+        (
+            {"A2A_AUTH_TYPE": "basic", "A2A_AUTH_USERNAME": "user", "A2A_AUTH_PASSWORD": "pass"},
+            {"authorization": "Basic dXNlcjpwYXNz"},
+        ),
+        (
+            {"A2A_AUTH_TYPE": "apikey", "A2A_AUTH_TOKEN": "key"},
+            {"x-api-key": "key"},
+        ),
+        (
+            {
+                "A2A_AUTH_TYPE": "custom",
+                "A2A_AUTH_HEADER": "X-Service-Token",
+                "A2A_AUTH_TOKEN": "token",
+            },
+            {"x-service-token": "token"},
+        ),
+        (
+            {"A2A_AUTH_HEADERS": '{"Authorization":"Bearer token","X-Tenant-ID":"tenant"}'},
+            {"authorization": "Bearer token", "x-tenant-id": "tenant"},
+        ),
+    ],
+)
+def test_get_auth_headers(env: dict[str, str], expected: dict[str, str]) -> None:
+    """All documented authentication formats produce request headers."""
+    assert get_auth_headers(env) == expected
+
+
+def test_get_auth_headers_combines_explicit_headers_with_auth_type() -> None:
+    """Explicit JSON headers override a derived authentication header."""
+    headers = get_auth_headers(
+        {
+            "A2A_AUTH_TYPE": "bearer",
+            "A2A_AUTH_TOKEN": "default",
+            "A2A_AUTH_HEADERS": '{"authorization":"Bearer replacement","X-Tenant-ID":"tenant"}',
+        }
+    )
+
+    assert headers == {"authorization": "Bearer replacement", "x-tenant-id": "tenant"}
+
+
+def test_get_auth_headers_rejects_invalid_json() -> None:
+    """Malformed JSON is reported before requests are sent."""
+    with pytest.raises(ValueError, match="A2A_AUTH_HEADERS must contain a JSON object"):
+        get_auth_headers({"A2A_AUTH_HEADERS": "not-json"})
+
+
+def test_merge_headers_is_case_insensitive() -> None:
+    """Per-call headers replace configured headers regardless of casing."""
+    assert merge_headers({"Authorization": "Bearer default"}, {"authorization": "Bearer override"}) == {
+        "authorization": "Bearer override"
+    }
+
+
+@pytest.mark.parametrize("client_type", [HttpJsonClient, JsonRpcClient])
+def test_http_clients_inject_and_override_auth_headers(
+    monkeypatch: pytest.MonkeyPatch,
+    client_type: type[HttpJsonClient | JsonRpcClient],
+) -> None:
+    """HTTP clients send configured auth and allow per-call overrides."""
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={})
+
+    original_client = httpx.Client
+
+    def create_client(*args: object, **kwargs: object) -> httpx.Client:
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return original_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", create_client)
+    monkeypatch.setenv("A2A_AUTH_TYPE", "bearer")
+    monkeypatch.setenv("A2A_AUTH_TOKEN", "default")
+
+    client = client_type("https://sut.example")
+    try:
+        client.get_extended_agent_card(extra_headers={"Authorization": "Bearer override"})
+    finally:
+        client.close()
+
+    assert len(requests) == 1
+    assert requests[0].headers["authorization"] == "Bearer override"
+    assert requests[0].headers["a2a-version"] == "1.0"
+
+
+def test_grpc_client_injects_and_overrides_auth_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GRPC metadata contains the configured and per-call authentication header."""
+    captured_metadata: tuple[tuple[str, str], ...] | None = None
+
+    class FakeChannel:
+        def close(self) -> None:
+            pass
+
+    class FakeStub:
+        def GetExtendedAgentCard(  # noqa: N802
+            self,
+            _request: object,
+            *,
+            timeout: float | None,
+            metadata: tuple[tuple[str, str], ...],
+        ) -> object:
+            nonlocal captured_metadata
+            captured_metadata = metadata
+            return object()
+
+    monkeypatch.setattr(grpc_client.grpc, "insecure_channel", lambda _target: FakeChannel())
+    monkeypatch.setattr(grpc_client.a2a_pb2_grpc, "A2AServiceStub", lambda _channel: FakeStub())
+    monkeypatch.setenv("A2A_AUTH_TYPE", "bearer")
+    monkeypatch.setenv("A2A_AUTH_TOKEN", "default")
+
+    client = GrpcClient("sut.example:443")
+    try:
+        client.get_extended_agent_card(extra_headers={"authorization": "Bearer override"})
+    finally:
+        client.close()
+
+    assert dict(captured_metadata or ()) == {
+        "a2a-version": "1.0",
+        "authorization": "Bearer override",
+    }
+
+
+def test_default_headers_include_protocol_version_and_auth() -> None:
+    """The common header builder keeps the protocol header with authentication."""
+    assert build_default_headers({"A2A_AUTH_TYPE": "bearer", "A2A_AUTH_TOKEN": "token"}) == {
+        "a2a-version": "1.0",
+        "authorization": "Bearer token",
+    }


### PR DESCRIPTION
# Description

## Summary

- Read the documented `A2A_AUTH_*` configuration once when each transport client is created.
- Inject configured headers into HTTP+JSON, JSON-RPC, and gRPC requests, including streaming and extended-agent-card operations.
- Add `extra_headers` to the shared transport API so a test can override the configured credentials for a single call.
- Update the authentication guide to use `uv run --env-file .env`, `--sut-host`, and valid `--level` values.

## Root cause

The authentication guide documented environment-based configuration, but transport clients only sent the A2A version header. Authenticated SUTs therefore received no configured credentials.

## Validation

- [x] Followed `CONTRIBUTING.md`.
- [x] Used a Conventional Commit title.
- [x] `make lint`
- [x] `PYTHONUTF8=1 make unit-test` (265 passed)
- [x] `uv run pytest tests/unit/transport/test_auth_headers.py -q` (12 passed)
- [x] Verified all BaseTransportClient operations accept `extra_headers` in all three implementations.
- [x] Verified the authentication guide contains no `--sut-url` or `--category` examples.

Fixes #163