### PR TITLE
fix: validate conditional requirement error outcomes

### DIFF
--- a/tck/requirements/base.py
+++ b/tck/requirements/base.py
@@ -102,6 +102,7 @@ class RequirementSpec:
     spec_url: str = ""
     tags: list[str] = field(default_factory=list)
     validators: list[Callable[[Any, str], list[str]]] = field(default_factory=list)
+    allows_error: bool = False
 
 
 # Shared spec URL base pointing to the local specification file.

--- a/tck/requirements/core_operations.py
+++ b/tck/requirements/core_operations.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from tck.requirements.base import (
     CANCEL_TASK_BINDING,
+    CONTENT_TYPE_NOT_SUPPORTED_ERROR,
     GET_TASK_BINDING,
     LIST_TASKS_BINDING,
     SEND_MESSAGE_BINDING,
@@ -43,7 +44,13 @@ from tck.requirements.tags import (
     TASK_ID,
     VALIDATION,
 )
-from tck.validators.payload import validate_message_response_contains_field
+from tck.validators.payload import (
+    validate_message_response_contains_field,
+    validate_message_response_field_equals,
+)
+
+
+_REJECTED_CLIENT_CONTEXT_ID = tck_id("client-context-rejected")
 
 
 CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
@@ -105,6 +112,7 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
         binding=SEND_MESSAGE_BINDING,
         proto_request_type="SendMessageRequest",
         expected_behavior="ContentTypeNotSupportedError returned",
+        expected_error=CONTENT_TYPE_NOT_SUPPORTED_ERROR,
         spec_url=f"{SPEC_BASE}311-send-message",
         tags=[CORE, SEND_MESSAGE, ERROR],
         sample_input={
@@ -594,6 +602,7 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
         operation=OperationType.SEND_MESSAGE,
         binding=SEND_MESSAGE_BINDING,
         expected_behavior="Error returned when client contextId not accepted",
+        allows_error=True,
         spec_url=f"{SPEC_BASE}341-context-identifier-semantics",
         tags=[CORE, MULTI_TURN, CONTEXT, ERROR],
         sample_input={
@@ -601,9 +610,15 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
                 "role": "ROLE_USER",
                 "parts": [{"text": "Message with client contextId"}],
                 "messageId": tck_id("complete-task"),
-                "contextId": tck_id("client-context-rejected"),
+                "contextId": _REJECTED_CLIENT_CONTEXT_ID,
             },
         },
+        validators=[
+            validate_message_response_field_equals(
+                "contextId",
+                _REJECTED_CLIENT_CONTEXT_ID,
+            ),
+        ],
     ),
     RequirementSpec(
         id="CORE-MULTI-003",

--- a/tck/validators/_json.py
+++ b/tck/validators/_json.py
@@ -146,3 +146,19 @@ def validate_message_response_contains_field(
     if inner.get(field) is None:
         return [f"{error_prefix} must include '{field}'"]
     return []
+
+
+def validate_message_response_field_equals(
+    result: dict[str, Any],
+    field: str,
+    expected: Any,
+) -> list[str]:
+    """Validate a field value in an unwrapped SendMessageResponse dict."""
+    inner = result.get("task") or result.get("message") or result
+    actual = inner.get(field) if isinstance(inner, dict) else None
+    if actual != expected:
+        return [
+            f"Expected response field '{field}' to equal "
+            f"'{expected}', got '{actual}'"
+        ]
+    return []

--- a/tck/validators/grpc/payload.py
+++ b/tck/validators/grpc/payload.py
@@ -155,3 +155,20 @@ def validate_message_response_contains_field(
     if value is None:
         return [f"Response must include '{field}'"]
     return []
+
+
+def validate_message_response_field_equals(
+    response: Any,
+    field: str,
+    expected: Any,
+) -> list[str]:
+    """Validate a field value in a SendMessageResponse."""
+    msg = response.raw_response
+    inner = getattr(msg, "task", None) or getattr(msg, "message", None) or msg
+    actual = getattr(inner, field, None)
+    if actual != expected:
+        return [
+            f"Expected response field '{field}' to equal '{expected}', "
+            f"got '{actual}'"
+        ]
+    return []

--- a/tck/validators/http_json/payload.py
+++ b/tck/validators/http_json/payload.py
@@ -73,3 +73,15 @@ def validate_message_response_contains_field(
     if not data:
         return [f"Response is not a JSON object, cannot check for '{field}'"]
     return _json.validate_message_response_contains_field(data, field)
+
+
+def validate_message_response_field_equals(
+    response: Any,
+    field: str,
+    expected: Any,
+) -> list[str]:
+    """Validate a field value in the SendMessageResponse body."""
+    data = _unwrap(response)
+    if not data:
+        return [f"Response is not a JSON object, cannot check '{field}'"]
+    return _json.validate_message_response_field_equals(data, field, expected)

--- a/tck/validators/jsonrpc/payload.py
+++ b/tck/validators/jsonrpc/payload.py
@@ -74,3 +74,16 @@ def validate_message_response_contains_field(
     return _json.validate_message_response_contains_field(
         _unwrap_result(response), field, error_prefix="Response result",
     )
+
+
+def validate_message_response_field_equals(
+    response: Any,
+    field: str,
+    expected: Any,
+) -> list[str]:
+    """Validate a field value in the SendMessageResponse result."""
+    return _json.validate_message_response_field_equals(
+        _unwrap_result(response),
+        field,
+        expected,
+    )

--- a/tck/validators/payload.py
+++ b/tck/validators/payload.py
@@ -29,6 +29,12 @@ _TRANSPORT_VALIDATORS = {
     "http_json": _http_json.validate_message_response_contains_field,
 }
 
+_TRANSPORT_EQUALITY_VALIDATORS = {
+    "grpc": _grpc.validate_message_response_field_equals,
+    "jsonrpc": _jsonrpc.validate_message_response_field_equals,
+    "http_json": _http_json.validate_message_response_field_equals,
+}
+
 _STATE_VALIDATORS = {
     "grpc": _grpc.validate_task_state,
     "jsonrpc": _jsonrpc.validate_task_state,
@@ -83,6 +89,23 @@ def validate_message_response_contains_field(
             return []
         f = grpc_field if transport == "grpc" else field
         return validate(response, f)
+
+    return _validate
+
+
+def validate_message_response_field_equals(
+    field: str,
+    expected: Any,
+) -> Callable[[Any, str], list[str]]:
+    """Return a validator that checks a SendMessageResponse field value."""
+    grpc_field = _to_snake_case(field)
+
+    def _validate(response: Any, transport: str) -> list[str]:
+        validate = _TRANSPORT_EQUALITY_VALIDATORS.get(transport)
+        if validate is None:
+            return []
+        f = grpc_field if transport == "grpc" else field
+        return validate(response, f, expected)
 
     return _validate
 

--- a/tests/compatibility/core_operations/test_requirements.py
+++ b/tests/compatibility/core_operations/test_requirements.py
@@ -100,6 +100,10 @@ def _validate_response(
     if requirement.expected_error is not None:
         return validate_expected_error(response, transport, requirement.expected_error)
 
+    # Conditional requirements may allow rejection or validate a successful response.
+    if requirement.allows_error and not response.success:
+        return []
+
     # For streaming responses, just verify at least one event arrives
     if isinstance(response, StreamingResponse):
         if not response.success:

--- a/tests/unit/requirements/test_error_expectations.py
+++ b/tests/unit/requirements/test_error_expectations.py
@@ -1,0 +1,163 @@
+"""Regression tests for requirement error expectations."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from specification.generated import a2a_pb2
+from tck.requirements.base import CONTENT_TYPE_NOT_SUPPORTED_ERROR
+from tck.requirements.core_operations import CORE_OPERATIONS_REQUIREMENTS
+from tests.compatibility.core_operations.test_requirements import _validate_response
+
+
+def _requirement(requirement_id: str) -> Any:
+    """Return a core requirement by ID."""
+    return next(requirement for requirement in CORE_OPERATIONS_REQUIREMENTS if requirement.id == requirement_id)
+
+
+def _response(
+    *,
+    success: bool,
+    error_code: int | str | None = None,
+    raw_response: Any = None,
+) -> SimpleNamespace:
+    """Build the response surface used by the generic requirement validator."""
+    return SimpleNamespace(
+        success=success,
+        error=None if success else "rejected",
+        error_code=error_code,
+        raw_response={} if raw_response is None else raw_response,
+    )
+
+
+@pytest.mark.parametrize(
+    ("transport", "error_code"),
+    [
+        ("jsonrpc", -32005),
+        ("http_json", 415),
+        ("grpc", "INVALID_ARGUMENT"),
+    ],
+)
+def test_core_send_003_requires_content_type_not_supported_error(
+    transport: str,
+    error_code: int | str,
+) -> None:
+    """CORE-SEND-003 must enforce the specific error named by the spec."""
+    requirement = _requirement("CORE-SEND-003")
+
+    assert requirement.expected_error is CONTENT_TYPE_NOT_SUPPORTED_ERROR
+    assert (
+        _validate_response(
+            _response(success=False, error_code=error_code),
+            transport,
+            requirement,
+            {},
+        )
+        == []
+    )
+
+
+def test_core_send_003_rejects_wrong_error_code() -> None:
+    """CORE-SEND-003 must reject a different validation error."""
+    requirement = _requirement("CORE-SEND-003")
+
+    assert _validate_response(
+        _response(success=False, error_code=-32602),
+        "jsonrpc",
+        requirement,
+        {},
+    ) == ["Expected error code -32005 (ContentTypeNotSupportedError), got -32602"]
+
+
+@pytest.mark.parametrize(
+    ("transport", "error_code"),
+    [
+        ("jsonrpc", -32602),
+        ("http_json", 400),
+        ("grpc", "INVALID_ARGUMENT"),
+    ],
+)
+def test_core_multi_002a_allows_rejection_without_exact_code(
+    transport: str,
+    error_code: int | str,
+) -> None:
+    """CORE-MULTI-002a must accept rejection without inventing an exact code."""
+    requirement = _requirement("CORE-MULTI-002a")
+
+    assert requirement.allows_error is True
+    assert requirement.expected_error is None
+    assert (
+        _validate_response(
+            _response(success=False, error_code=error_code),
+            transport,
+            requirement,
+            {},
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    ("transport", "raw_response"),
+    [
+        ("jsonrpc", lambda context_id: {"result": {"task": {"contextId": context_id}}}),
+        ("http_json", lambda context_id: {"message": {"contextId": context_id}}),
+        (
+            "grpc",
+            lambda context_id: a2a_pb2.SendMessageResponse(
+                task=a2a_pb2.Task(context_id=context_id),
+            ),
+        ),
+    ],
+)
+def test_core_multi_002a_accepts_preserved_context_id(
+    transport: str,
+    raw_response: Any,
+) -> None:
+    """CORE-MULTI-002a must allow success when the client context ID is preserved."""
+    requirement = _requirement("CORE-MULTI-002a")
+    context_id = requirement.sample_input["message"]["contextId"]
+
+    assert (
+        _validate_response(
+            _response(success=True, raw_response=raw_response(context_id)),
+            transport,
+            requirement,
+            {},
+        )
+        == []
+    )
+
+
+def test_core_multi_002a_rejects_replaced_context_id() -> None:
+    """CORE-MULTI-002a must fail when success replaces the client context ID."""
+    requirement = _requirement("CORE-MULTI-002a")
+    expected = requirement.sample_input["message"]["contextId"]
+
+    assert _validate_response(
+        _response(
+            success=True,
+            raw_response={"task": {"contextId": "server-generated-replacement"}},
+        ),
+        "http_json",
+        requirement,
+        {},
+    ) == [f"Expected response field 'contextId' to equal '{expected}', got 'server-generated-replacement'"]
+
+
+def test_dispatched_error_requirements_declare_error_expectations() -> None:
+    """Every generic error requirement must opt into an error validation path."""
+    missing_expectation = [
+        requirement.id
+        for requirement in CORE_OPERATIONS_REQUIREMENTS
+        if "error" in requirement.tags
+        and requirement.operation is not None
+        and "multi-operation" not in requirement.tags
+        and requirement.expected_error is None
+        and not getattr(requirement, "allows_error", False)
+    ]
+
+    assert missing_expectation == []


### PR DESCRIPTION
# Description

## Summary

Two generic conformance requirements currently validate the wrong response
outcome: one omits its exact error binding, while the other has conditional
accept-or-reject semantics that the runner cannot represent.

## Changes

- Bind `CORE-SEND-003` to the existing
  `CONTENT_TYPE_NOT_SUPPORTED_ERROR` transport mapping.
- Model `CORE-MULTI-002a` as the conditional requirement defined by the A2A
  spec: an agent may reject the client context ID, or accept it and preserve
  the same value in its Task or Message response.
- Add cross-transport response-field equality validation and a regression guard
  for dispatched error requirements that otherwise fall through to ordinary
  success validation.

## Root cause

The generic requirement runner previously had only two outcome models: an exact
`expected_error` binding or ordinary success. `CORE-SEND-003` omitted its exact
binding, so a conformant error failed. `CORE-MULTI-002a` is conditional and
cannot be represented by assigning one exact error code: the specification also
allows the server to accept and preserve the client-provided `contextId`.

This change keeps exact error validation first, adds a narrowly scoped
`allows_error` outcome for conditional requirements, and still runs normal
content validators when the operation succeeds.

## Scope and risk

`allows_error` defaults to `false` and is appended to `RequirementSpec`, so
existing requirements and positional construction retain their behavior. It is
enabled only for `CORE-MULTI-002a`. The new equality validator follows the
existing JSON-RPC, HTTP+JSON, and gRPC payload-validator dispatch pattern.

## Verification

```bash
make lint
make unit-test
uv run pytest tests/unit/requirements/test_error_expectations.py -q
```

- `make lint`: passed
- `make unit-test`: `265 passed`
- focused exact-error, conditional-outcome, Task/Message, and three-transport
  regressions: `12 passed`

Fixes #202
