### PR TITLE
feat: automate CARD-SIGN-* agent card signing conformance (TASK-29)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,13 @@ dev = [
     "ruff>=0.3",
     "mypy>=1.8",
 ]
+# Agent Card signature verification (CARD-SIGN-* conformance tests).
+# Optional so the base kit stays dependency-minimal; the signing tests
+# skip when this extra is not installed.
+signing = [
+    "jwcrypto>=1.5",
+    "rfc8785>=0.1.4",
+]
 
 [project.scripts]
 run-tck = "run_tck:main"

--- a/tck/requirements/agent_card.py
+++ b/tck/requirements/agent_card.py
@@ -139,7 +139,7 @@ AGENT_CARD_REQUIREMENTS: list[RequirementSpec] = [
         ),
         expected_behavior="Agent Card canonicalized per RFC 8785 before signing",
         spec_url=f"{SPEC_BASE}841-canonicalization-requirements",
-        tags=[AGENT_CARD, SIGNING, JCS, NOT_AUTOMATABLE],
+        tags=[AGENT_CARD, SIGNING, JCS],
     ),
     RequirementSpec(
         id="CARD-SIGN-002",
@@ -152,7 +152,7 @@ AGENT_CARD_REQUIREMENTS: list[RequirementSpec] = [
         ),
         expected_behavior="Signatures field excluded from signing payload",
         spec_url=f"{SPEC_BASE}841-canonicalization-requirements",
-        tags=[AGENT_CARD, SIGNING, NOT_AUTOMATABLE],
+        tags=[AGENT_CARD, SIGNING],
     ),
     RequirementSpec(
         id="CARD-SIGN-003",
@@ -165,8 +165,11 @@ AGENT_CARD_REQUIREMENTS: list[RequirementSpec] = [
         ),
         expected_behavior="Protected header contains alg and kid",
         spec_url=f"{SPEC_BASE}842-signature-format",
-        tags=[AGENT_CARD, SIGNING, JWS, NOT_AUTOMATABLE],
+        tags=[AGENT_CARD, SIGNING, JWS],
     ),
+    # CARD-SIGN-004 stays not-automatable: key expiry/revocation state cannot
+    # be derived from a served Agent Card alone, so a black-box conformance run
+    # has no observable signal to assert against.
     RequirementSpec(
         id="CARD-SIGN-004",
         section="8.4.3",

--- a/tck/validators/card_signature.py
+++ b/tck/validators/card_signature.py
@@ -51,6 +51,10 @@ _TYPE_ENUM = 14
 _OMIT = object()
 
 
+class KeyResolutionError(Exception):
+    """The ``jku`` JWKS fetch or parse failed; recorded on the outcome."""
+
+
 @dataclass
 class VerificationOutcome:
     """Result of verifying a card's ``signatures`` array.
@@ -247,8 +251,11 @@ def _resolve_key(
         return _as_jwk(trusted_keys[kid])
     jku = header.get("jku")
     if jku and fetch_jwks is not None:
-        keyset = jwk.JWKSet.from_json(json.dumps(fetch_jwks(jku)))
-        key = keyset.get_key(kid) if kid else None
+        try:
+            keyset = jwk.JWKSet.from_json(json.dumps(fetch_jwks(jku)))
+            key = keyset.get_key(kid) if kid else None
+        except Exception as exc:  # fetch_jwks is caller-supplied and may raise anything (network, parsing)
+            raise KeyResolutionError(f"jku fetch/parse failed ({exc})") from exc
         if key is not None:
             return key
     return None
@@ -262,7 +269,7 @@ def _resolve_key_safe(
     """Resolve a key, converting any resolution failure into an error string."""
     try:
         return _resolve_key(header, trusted_keys, fetch_jwks), None
-    except (JWException, ValueError, TypeError, KeyError, RecursionError) as exc:
+    except (KeyResolutionError, JWException, ValueError, TypeError, KeyError, RecursionError) as exc:
         return None, f"key resolution failed ({exc})"
 
 
@@ -336,7 +343,7 @@ def verify_card_signatures(
         return VerificationOutcome(errors=["'signatures' is present but is not a JSON array"])
     try:
         payload = canonicalize_for_signing(card, strip_defaults=True)
-    except (ValueError, RecursionError) as exc:
+    except (TypeError, ValueError, RecursionError) as exc:
         return VerificationOutcome(errors=[f"card canonicalization failed ({exc})"])
     outcome = VerificationOutcome()
     checked_any = False

--- a/tck/validators/card_signature.py
+++ b/tck/validators/card_signature.py
@@ -1,0 +1,367 @@
+"""Agent Card signature validation (spec Section 8.4).
+
+Implements the conformance checks behind the ``CARD-SIGN-*`` requirements:
+
+* ``CARD-SIGN-003`` -- the JWS protected header carries non-empty ``alg``
+  and ``kid`` values (:func:`check_signature_headers`).
+* ``CARD-SIGN-001`` / ``CARD-SIGN-002`` -- the signature verifies against the
+  payload canonicalized per Section 8.4.3, proving JCS canonicalization with
+  the ``signatures`` field excluded (:func:`verify_card_signatures`).
+
+Verification reproduces the spec's algorithm: exclude ``signatures``, remove
+properties holding Protocol Buffer default values, JSON-canonicalize with
+RFC 8785, then verify the detached JWS against the resolved public key.
+
+This module requires the ``signing`` optional dependency group
+(``jwcrypto`` + ``rfc8785``).
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import copy
+import json
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import rfc8785
+
+from jwcrypto import jwk, jws
+from jwcrypto.common import JWException
+
+from specification.generated import a2a_pb2
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from google.protobuf.descriptor import Descriptor, FieldDescriptor
+
+
+# Protobuf field-type numbers used for default detection (descriptor.FieldDescriptor.TYPE_*).
+_TYPE_MESSAGE = 11
+_TYPE_STRING = 9
+_TYPE_BYTES = 12
+_TYPE_BOOL = 8
+_TYPE_ENUM = 14
+
+# Sentinel marking a property that must be omitted from the canonical form.
+_OMIT = object()
+
+
+@dataclass
+class VerificationOutcome:
+    """Result of verifying a card's ``signatures`` array.
+
+    Attributes:
+        verified: True if at least one signature verified.
+        inconclusive: True if no signature could be checked because no public
+            key was resolvable (distinct from a verification failure).
+        errors: Human-readable failure or inconclusive reasons.
+    """
+
+    verified: bool = False
+    inconclusive: bool = False
+    errors: list[str] = field(default_factory=list)
+
+
+def _decode_protected(protected_b64: str) -> dict[str, Any]:
+    """Base64url-decode a JWS protected header into a JSON object.
+
+    Raises:
+        ValueError: on undecodable base64, non-JSON content, a non-object
+            header, or JSON nested too deeply to parse (a hostile ``protected``
+            value); callers treat every case as a recorded header error.
+    """
+    padded = protected_b64 + "=" * (-len(protected_b64) % 4)
+    raw = base64.urlsafe_b64decode(padded)
+    try:
+        header = json.loads(raw)
+    except RecursionError as exc:
+        raise ValueError("protected header JSON is nested too deeply") from exc
+    if not isinstance(header, dict):
+        raise ValueError("protected header is not a JSON object")
+    return header
+
+
+def check_signature_headers(card: dict[str, Any]) -> list[str]:
+    """Validate JWS protected headers of every signature (CARD-SIGN-003).
+
+    Args:
+        card: The Agent Card as a JSON object.
+
+    Returns:
+        A list of error strings; empty when every signature's protected header
+        declares non-empty ``alg`` and ``kid`` string values.
+    """
+    if not isinstance(card, dict):
+        return ["agent card is not a JSON object"]
+    errors: list[str] = []
+    signatures = card.get("signatures", [])
+    if not isinstance(signatures, list):
+        return ["'signatures' is present but is not a JSON array"]
+    for index, signature in enumerate(signatures):
+        if not isinstance(signature, dict):
+            errors.append(f"signatures[{index}]: entry is not a JSON object")
+            continue
+        protected_b64 = signature.get("protected")
+        if not isinstance(protected_b64, str) or not protected_b64:
+            errors.append(f"signatures[{index}]: missing required 'protected' header")
+            continue
+        try:
+            header = _decode_protected(protected_b64)
+        except (ValueError, binascii.Error, json.JSONDecodeError) as exc:
+            errors.append(f"signatures[{index}]: protected header is not valid base64url JSON ({exc})")
+            continue
+        # Deliberately no algorithm allowlist: Section 8.4.2 names ES256/RS256 as
+        # examples, not a closed set, and the requirement only mandates presence.
+        if "alg" not in header:
+            errors.append(f"signatures[{index}]: protected header missing required 'alg'")
+        elif not isinstance(header["alg"], str) or not header["alg"]:
+            errors.append(f"signatures[{index}]: 'alg' must be a non-empty string, got {header['alg']!r}")
+        if "kid" not in header:
+            errors.append(f"signatures[{index}]: protected header missing required 'kid'")
+        elif not isinstance(header["kid"], str) or not header["kid"]:
+            errors.append(f"signatures[{index}]: 'kid' must be a non-empty string, got {header['kid']!r}")
+    return errors
+
+
+def _field_default(descriptor: FieldDescriptor) -> object:
+    """Return the JSON-shaped default value for a singular scalar field."""
+    if descriptor.type in (_TYPE_STRING, _TYPE_BYTES):
+        return ""
+    if descriptor.type == _TYPE_BOOL:
+        return False
+    if descriptor.type == _TYPE_ENUM:
+        return descriptor.enum_type.values[0].name
+    return 0
+
+
+def _is_map_field(descriptor: FieldDescriptor) -> bool:
+    """True if the field is a protobuf map (serialized as a JSON object)."""
+    return bool(descriptor.type == _TYPE_MESSAGE and descriptor.message_type.GetOptions().map_entry)
+
+
+def _strip_maybe_message(value: Any, message_type: Descriptor) -> object:
+    """Strip a nested message, passing non-object values through untouched.
+
+    A hostile card may put a scalar where a message is expected; leaving it as-is
+    lets verification fail rather than raising while canonicalizing.
+    """
+    if not isinstance(value, dict):
+        return value
+    return _strip_message(value, message_type)
+
+
+def _strip_repeated(value: Any, descriptor: FieldDescriptor) -> object:
+    if not isinstance(value, list) or not value:
+        return _OMIT
+    if descriptor.type == _TYPE_MESSAGE:
+        return [_strip_maybe_message(item, descriptor.message_type) for item in value]
+    return value
+
+
+def _strip_map(value: Any, descriptor: FieldDescriptor) -> object:
+    if not isinstance(value, dict) or not value:
+        return _OMIT
+    value_field = descriptor.message_type.fields_by_name["value"]
+    if value_field.type == _TYPE_MESSAGE:
+        return {k: _strip_maybe_message(v, value_field.message_type) for k, v in value.items()}
+    return value
+
+
+def _strip_field(value: Any, descriptor: FieldDescriptor) -> object:
+    """Apply default-value removal to one field's value, or return ``_OMIT``."""
+    if _is_map_field(descriptor):
+        return _strip_map(value, descriptor)
+    if descriptor.is_repeated:
+        return _strip_repeated(value, descriptor)
+    if descriptor.type == _TYPE_MESSAGE:
+        if not isinstance(value, dict):
+            return value
+        stripped = _strip_message(value, descriptor.message_type)
+        if not stripped and not descriptor.has_presence:
+            return _OMIT
+        return stripped
+    if not descriptor.has_presence and value == _field_default(descriptor):
+        return _OMIT
+    return value
+
+
+def _strip_message(value: dict[str, Any], descriptor: Descriptor) -> dict[str, Any]:
+    """Recursively remove default-valued properties from a message object.
+
+    Unknown keys (absent from the descriptor) are preserved so that forward-
+    compatible cards are not silently mutated; an unsigned extra field simply
+    causes verification to fail, which is the correct conformance outcome.
+
+    Recursion is bounded by the (non-recursive) ``AgentCard`` schema, so hostile
+    nesting lands in unknown keys instead -- guarded by the ``RecursionError``
+    handling around :func:`canonicalize_for_signing`'s callers.
+    """
+    by_json = {f.json_name: f for f in descriptor.fields}
+    by_name = {f.name: f for f in descriptor.fields}
+    result: dict[str, Any] = {}
+    for key, raw in value.items():
+        descriptor_field = by_json.get(key) or by_name.get(key)
+        if descriptor_field is None:
+            result[key] = raw
+            continue
+        stripped = _strip_field(raw, descriptor_field)
+        if stripped is not _OMIT:
+            result[key] = stripped
+    return result
+
+
+def canonicalize_for_signing(card: dict[str, Any], *, strip_defaults: bool = True) -> bytes:
+    """Produce the JCS canonical signing payload for a card (Section 8.4.1).
+
+    Excludes the ``signatures`` field, optionally removes Protocol Buffer
+    default-valued properties, then canonicalizes with RFC 8785.
+
+    Args:
+        card: The Agent Card as a JSON object.
+        strip_defaults: When True, remove default-valued properties using the
+            ``AgentCard`` protobuf descriptors before canonicalization.
+
+    Returns:
+        The canonical payload bytes that a conformant signature is computed over.
+    """
+    payload = copy.deepcopy(card)
+    payload.pop("signatures", None)
+    if strip_defaults:
+        payload = _strip_message(payload, a2a_pb2.AgentCard.DESCRIPTOR)
+    return rfc8785.dumps(payload)
+
+
+def _resolve_key(
+    header: dict[str, Any],
+    trusted_keys: dict[str, Any] | None,
+    fetch_jwks: Callable[[str], dict[str, Any]] | None,
+) -> jwk.JWK | None:
+    """Resolve the verification key from a trusted store or the ``jku`` JWKS."""
+    kid = header.get("kid")
+    if trusted_keys and kid in trusted_keys:
+        return _as_jwk(trusted_keys[kid])
+    jku = header.get("jku")
+    if jku and fetch_jwks is not None:
+        keyset = jwk.JWKSet.from_json(json.dumps(fetch_jwks(jku)))
+        key = keyset.get_key(kid) if kid else None
+        if key is not None:
+            return key
+    return None
+
+
+def _resolve_key_safe(
+    header: dict[str, Any],
+    trusted_keys: dict[str, Any] | None,
+    fetch_jwks: Callable[[str], dict[str, Any]] | None,
+) -> tuple[jwk.JWK | None, str | None]:
+    """Resolve a key, converting any resolution failure into an error string."""
+    try:
+        return _resolve_key(header, trusted_keys, fetch_jwks), None
+    except (JWException, ValueError, TypeError, KeyError, RecursionError) as exc:
+        return None, f"key resolution failed ({exc})"
+
+
+def _as_jwk(candidate: Any) -> jwk.JWK:
+    if isinstance(candidate, jwk.JWK):
+        return candidate
+    return jwk.JWK.from_json(json.dumps(candidate))
+
+
+def _verify_one(signature: dict[str, Any], key: jwk.JWK, payload: bytes) -> bool:
+    """True if the signature verifies against the canonical payload.
+
+    Any malformed attacker-controlled JWS (bad ``signature`` value, undeserializable
+    token) is treated as a verification failure rather than propagating.
+    """
+    serialized = json.dumps({"protected": signature["protected"], "signature": signature["signature"]})
+    token = jws.JWS()
+    try:
+        token.deserialize(serialized)
+        token.verify(key, detached_payload=payload)
+    except (JWException, ValueError, TypeError):
+        return False
+    return True
+
+
+def _entry_error(signature: Any, index: int) -> str | None:
+    """Return an error string if a ``signatures`` entry is structurally invalid."""
+    if not isinstance(signature, dict):
+        return f"signatures[{index}]: entry is not a JSON object"
+    for member in ("protected", "signature"):
+        value = signature.get(member)
+        if not isinstance(value, str) or not value:
+            return f"signatures[{index}]: '{member}' must be a non-empty string"
+    return None
+
+
+def verify_card_signatures(
+    card: dict[str, Any],
+    *,
+    trusted_keys: dict[str, Any] | None = None,
+    fetch_jwks: Callable[[str], dict[str, Any]] | None = None,
+) -> VerificationOutcome:
+    """Verify a card's signatures per Section 8.4.3 (CARD-SIGN-001/002).
+
+    A signature is accepted only when it verifies against the spec's single
+    canonical payload: ``signatures`` excluded and proto-default properties
+    removed (Section 8.4.2 step 1). Accepting a non-canonical form would let a
+    non-conformant signer pass, so verification is intentionally strict; a card
+    that a conformant signer produced always matches this form. (The descriptor
+    strip cannot model the spec's ``REQUIRED``-field carve-out, so an unusual
+    card could yield a false *negative* -- the safe direction for a kit.)
+
+    Args:
+        card: The Agent Card as a JSON object.
+        trusted_keys: Optional mapping of ``kid`` to a JWK (dict or
+            :class:`jwcrypto.jwk.JWK`); consulted before any network lookup.
+        fetch_jwks: Optional callable mapping a ``jku`` URL to a JWKS object.
+            The injection point for the network boundary; ``None`` (the default)
+            keeps verification fully offline. A caller that supplies one is
+            responsible for its own SSRF guards, since ``jku`` is attacker-
+            controlled card content.
+
+    Returns:
+        A :class:`VerificationOutcome`. ``inconclusive`` is set only when no
+        signature could be checked because no key was resolvable.
+    """
+    if not isinstance(card, dict):
+        return VerificationOutcome(errors=["agent card is not a JSON object"])
+    signatures = card.get("signatures", [])
+    if not isinstance(signatures, list):
+        return VerificationOutcome(errors=["'signatures' is present but is not a JSON array"])
+    try:
+        payload = canonicalize_for_signing(card, strip_defaults=True)
+    except (ValueError, RecursionError) as exc:
+        return VerificationOutcome(errors=[f"card canonicalization failed ({exc})"])
+    outcome = VerificationOutcome()
+    checked_any = False
+    for index, signature in enumerate(signatures):
+        entry_error = _entry_error(signature, index)
+        if entry_error is not None:
+            outcome.errors.append(entry_error)
+            continue
+        try:
+            header = _decode_protected(signature["protected"])
+        except (ValueError, binascii.Error, json.JSONDecodeError) as exc:
+            outcome.errors.append(f"signatures[{index}]: undecodable protected header ({exc})")
+            continue
+        key, resolve_error = _resolve_key_safe(header, trusted_keys, fetch_jwks)
+        if resolve_error is not None:
+            outcome.errors.append(f"signatures[{index}]: {resolve_error}")
+            continue
+        if key is None:
+            outcome.errors.append(f"signatures[{index}]: no verification key resolvable for kid={header.get('kid')!r}")
+            continue
+        checked_any = True
+        if _verify_one(signature, key, payload):
+            outcome.verified = True
+            return outcome
+        outcome.errors.append(f"signatures[{index}]: signature did not verify")
+    if not checked_any and not outcome.verified:
+        outcome.inconclusive = True
+    return outcome

--- a/tests/compatibility/agent_card/test_agent_card_signing.py
+++ b/tests/compatibility/agent_card/test_agent_card_signing.py
@@ -1,0 +1,123 @@
+"""Agent card signing conformance tests (A2A spec Section 8.4).
+
+Fulfils backlog TASK-29 by automating the CARD-SIGN-* requirements that were
+previously declared but untested.
+
+Requirements tested:
+    CARD-SIGN-001 (JCS canonicalization), CARD-SIGN-002 (signatures excluded),
+    CARD-SIGN-003 (protected header parameters).
+
+Signing is OPTIONAL (spec Section 8.4: cards **MAY** be signed), so each test
+skips when the card carries no ``signatures`` array.  Verification requires the
+``signing`` optional dependency group; the module skips when it is absent.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+
+pytest.importorskip("jwcrypto")
+pytest.importorskip("rfc8785")
+
+from tck.requirements.registry import get_requirement_by_id
+from tck.validators.card_signature import (
+    check_signature_headers,
+    verify_card_signatures,
+)
+from tests.compatibility.markers import core, must
+
+
+if TYPE_CHECKING:
+    from tck.requirements.base import RequirementSpec
+
+
+CARD_SIGN_001 = get_requirement_by_id("CARD-SIGN-001")
+CARD_SIGN_002 = get_requirement_by_id("CARD-SIGN-002")
+CARD_SIGN_003 = get_requirement_by_id("CARD-SIGN-003")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fail_msg(req: RequirementSpec, detail: str) -> str:
+    return f"{req.id} [{req.title}]: {detail} (see {req.spec_url})"
+
+
+def _record(
+    collector: Any,
+    req: RequirementSpec,
+    passed: bool,
+    errors: list[str] | None = None,
+) -> None:
+    collector.record(
+        requirement_id=req.id,
+        transport="agent_card",
+        level=req.level.value,
+        passed=passed,
+        errors=errors or [],
+    )
+
+
+def _skip_if_unsigned(card: dict[str, Any]) -> None:
+    if not card.get("signatures"):
+        pytest.skip("Agent card carries no signatures; signing is OPTIONAL (spec 8.4)")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@must
+@core
+class TestAgentCardSignatureHeaders:
+    """CARD-SIGN-003: JWS protected header includes alg and kid."""
+
+    def test_protected_headers_well_formed(
+        self,
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+    ) -> None:
+        """Every signature's protected header declares alg and kid."""
+        req = CARD_SIGN_003
+        _skip_if_unsigned(agent_card)
+        errors = check_signature_headers(agent_card)
+        _record(collector=compatibility_collector, req=req, passed=not errors, errors=errors)
+        assert not errors, _fail_msg(req, "; ".join(errors))
+
+
+@must
+@core
+class TestAgentCardSignatureVerification:
+    """CARD-SIGN-001 / CARD-SIGN-002: signature verifies over the JCS payload."""
+
+    def test_signature_verifies(
+        self,
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+    ) -> None:
+        """At least one signature verifies over the canonical JCS payload."""
+        _skip_if_unsigned(agent_card)
+        # Verification stays offline: no jku fetcher is wired in, so a card whose
+        # key is not in a trusted store is inconclusive rather than triggering a
+        # network fetch of attacker-controlled `jku` content (SSRF surface).
+        outcome = verify_card_signatures(agent_card)
+        if outcome.inconclusive:
+            pytest.skip(
+                "No verification key resolvable offline (signature key not in a trusted store); cannot assert signature validity"
+            )
+        # A passing verification demonstrates both JCS canonicalization
+        # (CARD-SIGN-001) and signatures-field exclusion (CARD-SIGN-002).
+        for req in (CARD_SIGN_001, CARD_SIGN_002):
+            _record(
+                collector=compatibility_collector,
+                req=req,
+                passed=outcome.verified,
+                errors=outcome.errors,
+            )
+        assert outcome.verified, _fail_msg(CARD_SIGN_001, "; ".join(outcome.errors))

--- a/tests/unit/validators/test_card_signature.py
+++ b/tests/unit/validators/test_card_signature.py
@@ -310,6 +310,26 @@ class TestHostileInput:
         assert not outcome.verified
         assert any("canonicalization failed" in error for error in outcome.errors)
 
+    def test_nan_valued_card_reports_error(self, key: jwk.JWK) -> None:
+        """A card with a JCS-invalid number (NaN) is rejected, not a crash."""
+        signed = _sign(_base_card(), key, "key-1")
+        signed["x-nan"] = float("nan")
+        outcome = verify_card_signatures(signed, trusted_keys={"key-1": key})
+        assert not outcome.verified
+        assert any("canonicalization failed" in error for error in outcome.errors)
+
+    def test_raising_jwks_fetcher_is_recorded_not_raised(self, key: jwk.JWK) -> None:
+        """An arbitrary error from the injected fetcher is recorded, not propagated."""
+
+        def _broken_fetcher(url: str) -> dict[str, Any]:
+            raise RuntimeError(f"connection refused: {url}")
+
+        signed = _sign(_base_card(), key, "key-1", jku="https://a.example/jwks.json")
+        outcome = verify_card_signatures(signed, fetch_jwks=_broken_fetcher)
+        assert not outcome.verified
+        assert outcome.inconclusive
+        assert any("key resolution failed" in error for error in outcome.errors)
+
 
 # ---------------------------------------------------------------------------
 # Canonicalization

--- a/tests/unit/validators/test_card_signature.py
+++ b/tests/unit/validators/test_card_signature.py
@@ -1,0 +1,340 @@
+"""Tests for the Agent Card signature validator (CARD-SIGN-*)."""
+
+from __future__ import annotations
+
+import json
+
+from typing import Any
+
+import pytest
+
+
+pytest.importorskip("jwcrypto")
+pytest.importorskip("rfc8785")
+
+from jwcrypto import jwk, jws
+
+from tck.validators.card_signature import (
+    canonicalize_for_signing,
+    check_signature_headers,
+    verify_card_signatures,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _base_card() -> dict[str, Any]:
+    """Return a minimal spec-shaped Agent Card with a default-valued field."""
+    return {
+        "name": "GeoRoute",
+        "description": "Route planner",
+        "version": "1.2.0",
+        "supportedInterfaces": [{"url": "https://a.example/a2a", "protocolBinding": "JSONRPC", "protocolVersion": "1.0"}],
+        "capabilities": {"streaming": False, "pushNotifications": True},
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [],
+    }
+
+
+def _sign(card: dict[str, Any], key: jwk.JWK, kid: str, *, jku: str | None = None) -> dict[str, Any]:
+    """Return a spec-conformant signed copy of ``card`` (spec Section 8.4.2)."""
+    payload = canonicalize_for_signing(card, strip_defaults=True)
+    header: dict[str, Any] = {"alg": "ES256", "typ": "JOSE", "kid": kid}
+    if jku is not None:
+        header["jku"] = jku
+    token = jws.JWS(payload)
+    token.add_signature(key, alg="ES256", protected=json.dumps(header))
+    flat = json.loads(token.serialize())
+    return {**card, "signatures": [{"protected": flat["protected"], "signature": flat["signature"]}]}
+
+
+def _sign_with_header(card: dict[str, Any], key: jwk.JWK, header: dict[str, Any]) -> dict[str, Any]:
+    """Sign ``card`` with an arbitrary protected ``header`` for negative tests."""
+    payload = canonicalize_for_signing(card, strip_defaults=True)
+    token = jws.JWS(payload)
+    token.add_signature(key, alg="ES256", protected=json.dumps(header))
+    flat = json.loads(token.serialize())
+    return {**card, "signatures": [{"protected": flat["protected"], "signature": flat["signature"]}]}
+
+
+@pytest.fixture
+def key() -> jwk.JWK:
+    """Generate an ES256 signing key with a fixed key id."""
+    return jwk.JWK.generate(kty="EC", crv="P-256", kid="key-1")
+
+
+@pytest.fixture
+def public_jwks(key: jwk.JWK) -> dict[str, Any]:
+    """Return a JWKS document carrying the public half of ``key``."""
+    return {"keys": [key.export_public(as_dict=True)]}
+
+
+# ---------------------------------------------------------------------------
+# CARD-SIGN-003 -- protected header
+# ---------------------------------------------------------------------------
+
+
+class TestSignatureHeaders:
+    """CARD-SIGN-003: the JWS protected header carries alg and kid."""
+
+    def test_valid_header_passes(self, key: jwk.JWK) -> None:
+        """A conformant signature reports no header errors."""
+        signed = _sign(_base_card(), key, "key-1")
+        assert check_signature_headers(signed) == []
+
+    def test_missing_kid_reported(self, key: jwk.JWK) -> None:
+        """A protected header without kid is flagged."""
+        signed = _sign_with_header(_base_card(), key, {"alg": "ES256", "typ": "JOSE"})
+        assert any("kid" in error for error in check_signature_headers(signed))
+
+    def test_missing_alg_reported(self, key: jwk.JWK) -> None:
+        """A protected header without alg is flagged."""
+        signed = _sign_with_header(_base_card(), key, {"typ": "JOSE", "kid": "key-1"})
+        assert any("alg" in error for error in check_signature_headers(signed))
+
+    def test_non_string_alg_reported(self) -> None:
+        """A non-string alg value is flagged as malformed."""
+        import base64
+
+        protected = base64.urlsafe_b64encode(json.dumps({"alg": 123, "kid": "key-1"}).encode()).decode().rstrip("=")
+        card = {**_base_card(), "signatures": [{"protected": protected, "signature": "AA"}]}
+        assert any("non-empty string" in error for error in check_signature_headers(card))
+
+    def test_empty_kid_reported(self) -> None:
+        """An empty kid value is flagged as malformed."""
+        import base64
+
+        protected = base64.urlsafe_b64encode(json.dumps({"alg": "ES256", "kid": ""}).encode()).decode().rstrip("=")
+        card = {**_base_card(), "signatures": [{"protected": protected, "signature": "AA"}]}
+        assert any("non-empty string" in error for error in check_signature_headers(card))
+
+    def test_unlisted_algorithm_accepted(self) -> None:
+        """An algorithm outside the spec's examples (e.g. EdDSA) is not flagged."""
+        import base64
+
+        protected = base64.urlsafe_b64encode(json.dumps({"alg": "EdDSA", "kid": "key-1"}).encode()).decode().rstrip("=")
+        card = {**_base_card(), "signatures": [{"protected": protected, "signature": "AA"}]}
+        assert check_signature_headers(card) == []
+
+    def test_unsigned_card_has_no_header_errors(self) -> None:
+        """An unsigned card produces no header errors (nothing to check)."""
+        assert check_signature_headers(_base_card()) == []
+
+
+# ---------------------------------------------------------------------------
+# CARD-SIGN-001 / 002 -- verification
+# ---------------------------------------------------------------------------
+
+
+class TestVerification:
+    """CARD-SIGN-001/002: signature verifies over the canonical payload."""
+
+    def test_verifies_with_trusted_key(self, key: jwk.JWK) -> None:
+        """A trusted-key lookup verifies a conformant signature."""
+        signed = _sign(_base_card(), key, "key-1")
+        outcome = verify_card_signatures(signed, trusted_keys={"key-1": key})
+        assert outcome.verified
+        assert not outcome.inconclusive
+
+    def test_verifies_via_jku_fetch(self, key: jwk.JWK, public_jwks: dict[str, Any]) -> None:
+        """A jku JWKS fetch resolves the key and verifies the signature."""
+        signed = _sign(_base_card(), key, "key-1", jku="https://a.example/jwks.json")
+        outcome = verify_card_signatures(signed, fetch_jwks=lambda _url: public_jwks)
+        assert outcome.verified
+
+    def test_verifies_card_with_explicit_default_field(self, key: jwk.JWK) -> None:
+        """Verification succeeds even when the card serializes default values."""
+        signed = _sign(_base_card(), key, "key-1")
+        outcome = verify_card_signatures(signed, trusted_keys={"key-1": key})
+        assert outcome.verified
+
+    def test_tampered_card_fails(self, key: jwk.JWK) -> None:
+        """Mutating a signed field fails verification (not inconclusive)."""
+        signed = _sign(_base_card(), key, "key-1")
+        signed["name"] = "Tampered"
+        outcome = verify_card_signatures(signed, trusted_keys={"key-1": key})
+        assert not outcome.verified
+        assert not outcome.inconclusive
+        assert any("did not verify" in error for error in outcome.errors)
+
+    def test_signatures_not_excluded_fails(self, key: jwk.JWK) -> None:
+        """A signature computed without excluding signatures fails (CARD-SIGN-002)."""
+        import rfc8785
+
+        polluted = {**_base_card(), "signatures": [{"protected": "x", "signature": "y"}]}
+        payload = rfc8785.dumps(polluted)
+        token = jws.JWS(payload)
+        token.add_signature(key, alg="ES256", protected=json.dumps({"alg": "ES256", "typ": "JOSE", "kid": "key-1"}))
+        flat = json.loads(token.serialize())
+        signed = {**_base_card(), "signatures": [{"protected": flat["protected"], "signature": flat["signature"]}]}
+        outcome = verify_card_signatures(signed, trusted_keys={"key-1": key})
+        assert not outcome.verified
+
+    def test_wrong_key_fails(self, key: jwk.JWK) -> None:
+        """A different key under the same kid fails verification."""
+        signed = _sign(_base_card(), key, "key-1")
+        other = jwk.JWK.generate(kty="EC", crv="P-256", kid="key-1")
+        outcome = verify_card_signatures(signed, trusted_keys={"key-1": other})
+        assert not outcome.verified
+
+    def test_no_key_is_inconclusive(self, key: jwk.JWK) -> None:
+        """A signed card with no resolvable key is inconclusive, not failed."""
+        signed = _sign(_base_card(), key, "key-1")
+        outcome = verify_card_signatures(signed)
+        assert not outcome.verified
+        assert outcome.inconclusive
+
+    def test_unsigned_card_is_inconclusive(self) -> None:
+        """An unsigned card has nothing to verify and is inconclusive."""
+        outcome = verify_card_signatures(_base_card())
+        assert not outcome.verified
+        assert outcome.inconclusive
+
+
+# ---------------------------------------------------------------------------
+# Hostile input -- a conformance kit fetches arbitrary third-party cards, so
+# malformed structures must produce recorded errors, never exceptions.
+# ---------------------------------------------------------------------------
+
+
+class TestHostileInput:
+    """Malformed cards report failures rather than crashing the run."""
+
+    def test_signatures_not_a_list_headers(self) -> None:
+        """A non-array signatures value is reported, not iterated blindly."""
+        card = {**_base_card(), "signatures": 5}
+        errors = check_signature_headers(card)
+        assert errors and "not a JSON array" in errors[0]
+
+    def test_signatures_not_a_list_verify(self) -> None:
+        """Verification of a non-array signatures value fails cleanly."""
+        card = {**_base_card(), "signatures": 5}
+        outcome = verify_card_signatures(card)
+        assert not outcome.verified
+        assert any("not a JSON array" in error for error in outcome.errors)
+
+    def test_non_dict_entry_headers(self) -> None:
+        """Non-object signature entries are each flagged, not dereferenced."""
+        card = {**_base_card(), "signatures": ["not-an-object", 123]}
+        errors = check_signature_headers(card)
+        assert errors == [
+            "signatures[0]: entry is not a JSON object",
+            "signatures[1]: entry is not a JSON object",
+        ]
+
+    def test_non_dict_entry_verify(self) -> None:
+        """A non-object signature entry fails verification without raising."""
+        card = {**_base_card(), "signatures": [123]}
+        outcome = verify_card_signatures(card)
+        assert not outcome.verified
+        assert any("not a JSON object" in error for error in outcome.errors)
+
+    def test_non_string_signature_member(self) -> None:
+        """A non-string 'signature' member is flagged as malformed."""
+        card = {**_base_card(), "signatures": [{"protected": "abc", "signature": 42}]}
+        outcome = verify_card_signatures(card)
+        assert not outcome.verified
+        assert any("non-empty string" in error for error in outcome.errors)
+
+    def test_undeserializable_signature_value(self, key: jwk.JWK) -> None:
+        """A garbage signature value fails verification without raising."""
+        signed = _sign(_base_card(), key, "key-1")
+        signed["signatures"][0]["signature"] = "!!!not-base64!!!"
+        outcome = verify_card_signatures(signed, trusted_keys={"key-1": key})
+        assert not outcome.verified
+        assert any("did not verify" in error for error in outcome.errors)
+
+    def test_non_dict_card_root_headers(self) -> None:
+        """A card root that is not a JSON object is reported, not dereferenced."""
+        for root in ([], "err", 123, None):
+            errors = check_signature_headers(root)  # type: ignore[arg-type]
+            assert errors == ["agent card is not a JSON object"]
+
+    def test_non_dict_card_root_verify(self) -> None:
+        """Verifying a non-object card root fails cleanly."""
+        for root in ([], "err", 123, None):
+            outcome = verify_card_signatures(root)  # type: ignore[arg-type]
+            assert not outcome.verified
+            assert outcome.errors == ["agent card is not a JSON object"]
+
+    def test_repeated_message_field_with_scalar_items(self, key: jwk.JWK) -> None:
+        """A repeated-message field holding scalars canonicalizes without raising."""
+        card = {**_base_card(), "skills": ["not-an-object"], "signatures": [{"protected": "a", "signature": "b"}]}
+        outcome = verify_card_signatures(card, trusted_keys={"key-1": key})
+        assert not outcome.verified
+
+    def test_map_field_with_scalar_value(self, key: jwk.JWK) -> None:
+        """A map<string,message> field holding a scalar value does not raise."""
+        card = {
+            **_base_card(),
+            "securitySchemes": {"scheme": "not-an-object"},
+            "signatures": [{"protected": "a", "signature": "b"}],
+        }
+        outcome = verify_card_signatures(card, trusted_keys={"key-1": key})
+        assert not outcome.verified
+
+    def test_deeply_nested_protected_header_headers(self) -> None:
+        """A deeply-nested JSON protected header is reported, not a stack overflow."""
+        import base64
+
+        nested = ("[" * 20000 + "]" * 20000).encode()
+        protected = base64.urlsafe_b64encode(nested).decode().rstrip("=")
+        card = {**_base_card(), "signatures": [{"protected": protected, "signature": "AA"}]}
+        errors = check_signature_headers(card)
+        assert any("nested too deeply" in error for error in errors)
+
+    def test_deeply_nested_protected_header_verify(self, key: jwk.JWK) -> None:
+        """Verification of a deeply-nested protected header fails without raising."""
+        import base64
+
+        nested = ("[" * 20000 + "]" * 20000).encode()
+        protected = base64.urlsafe_b64encode(nested).decode().rstrip("=")
+        card = {**_base_card(), "signatures": [{"protected": protected, "signature": "AA"}]}
+        outcome = verify_card_signatures(card, trusted_keys={"key-1": key})
+        assert not outcome.verified
+        assert any("nested too deeply" in error for error in outcome.errors)
+
+    def test_deeply_nested_card_reports_error(self, key: jwk.JWK) -> None:
+        """A pathologically nested card is rejected, not a stack overflow."""
+        deep: dict[str, Any] = {}
+        cursor = deep
+        for _ in range(5000):
+            cursor["ext"] = {}
+            cursor = cursor["ext"]
+        card = {**_base_card(), "x-deep": deep, "signatures": [{"protected": "abc", "signature": "def"}]}
+        outcome = verify_card_signatures(card, trusted_keys={"key-1": key})
+        assert not outcome.verified
+        assert any("canonicalization failed" in error for error in outcome.errors)
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalization:
+    """canonicalize_for_signing reproduces the spec's signing payload."""
+
+    def test_excludes_signatures_field(self, key: jwk.JWK) -> None:
+        """The signatures field is excluded from the canonical payload."""
+        signed = _sign(_base_card(), key, "key-1")
+        assert b"signatures" not in canonicalize_for_signing(signed, strip_defaults=True)
+
+    def test_strips_empty_repeated_field(self) -> None:
+        """An empty repeated field is removed; a non-empty one is retained."""
+        canonical = canonicalize_for_signing(_base_card(), strip_defaults=True)
+        assert b"skills" not in canonical
+        assert b"supportedInterfaces" in canonical
+
+    def test_retains_explicit_presence_default(self) -> None:
+        """A proto3 optional field set to its default is retained."""
+        assert b"streaming" in canonicalize_for_signing(_base_card(), strip_defaults=True)
+
+    def test_preserves_unknown_keys(self) -> None:
+        """Keys absent from the descriptor are preserved, not dropped."""
+        card = {**_base_card(), "x-vendor-extension": {"foo": "bar"}}
+        assert b"x-vendor-extension" in canonicalize_for_signing(card, strip_defaults=True)


### PR DESCRIPTION
# Implement CARD-SIGN-* agent card signing conformance tests (TASK-29)

Tracking: backlog TASK-29, issue #187

## What

Automates the `CARD-SIGN-*` agent-card signing requirements (spec §8.4), which are declared in
the registry but tagged `not-automatable` with no validators and came back **NOT TESTED** in the
April conformance run (TASK-29).

- **CARD-SIGN-001 / CARD-SIGN-002** — reproduce the §8.4.3 verification algorithm (exclude
  `signatures`, remove proto-default-valued properties, JCS-canonicalize per RFC 8785, verify the
  detached JWS against the key resolved from `kid`/`jku`). A passing verification demonstrates
  conformant JCS canonicalization (001) with `signatures` excluded (002).
- **CARD-SIGN-003** — decode each `signatures[].protected`; assert `alg` and `kid` are present,
  non-empty strings. Deliberately no algorithm allowlist: §8.4.2 names `ES256`/`RS256` as
  examples, not a closed set, so algorithm policy stays out of scope (per the scoping discussion
  on #187).
- **CARD-SIGN-004** (expired/revoked keys) stays `not-automatable` with a rationale — key
  lifecycle state isn't observable from a served card.

Tests **skip** when the card carries no `signatures[]` (signing is `MAY`, §8.4), matching the
kit's existing `agent_card` test conventions and TASK-29's own note.

## Relationship to #194 and #196

- **#194** (reference JCS canonicalization vectors for 001/002) is complementary: it provides
  standalone byte-level fixtures, this PR provides the live-card validator that flips the
  requirements from `not-automatable` to tested. Per @chopmob-cloud's offer on #187, happy to
  fold the #194 vectors in here as fixtures for `canonicalize_for_signing`, or rebase on it if it
  lands first — either order works.
- **#196** (CARD-SIGN-003 structural header tests) overlaps this PR's 003 validator and also
  edits `tck/requirements/agent_card.py`, so one of the two will need a rebase. This PR
  additionally covers 001/002 with actual JWS verification; if maintainers prefer to land #196
  first for 003, I'll rebase and drop the overlapping piece.

## Design notes for reviewers

- **Canonicalization removes proto-default values before JCS**, per §8.4.2 step 1 / §8.4.3
  step 3, driven by the bundled `AgentCard` descriptors (`specification/generated/a2a_pb2.py`).
  proto3 `optional` (presence) fields set to their default are retained; no-presence defaults and
  empty repeated fields are removed. Unknown keys are preserved.
- **Verification is offline.** Keys resolve from a trusted `kid`→JWK store. `jku` fetching
  is an injectable callable on the library API, but the compatibility test wires in **no**
  fetcher, so running the kit against a third-party SUT never fetches attacker-controlled
  `jku` content — there is no SSRF surface in the shipped tests. A card whose key isn't
  resolvable offline is reported inconclusive (→ skip), not a failure, since signing is
  `MAY`. A caller who opts into `jku` fetching supplies (and guards) their own resolver.
- **Single canonical form.** Signatures are verified only against the spec's canonical
  payload (§8.4.2 step 1: `signatures` excluded, proto defaults removed). Accepting a
  non-canonical form would let a non-conformant signer pass, so the check is strict; a
  conformant signer always matches this form.
- **Hostile-input hardened.** The validators run against arbitrary served cards, so a
  non-array `signatures`, non-object entries, non-string `protected`/`signature` members,
  undeserializable JWS values, unresolvable keys, and pathologically nested cards all
  produce recorded conformance errors rather than uncaught exceptions.
- **New optional dependency group** `signing = ["jwcrypto", "rfc8785"]`. The validator and tests
  `importorskip` it, so the base kit gains no required dependencies and existing CI is
  unaffected. **Open question (see #187):** to exercise these tests in CI, the CI job needs
  `uv sync --extra signing` (otherwise they skip). Happy to wire that in, or promote the deps to
  core, whichever you prefer.
- `uv.lock` intentionally **not** included — adding the optional extra to the lock triggered an
  unrelated lockfile format-revision rewrite under a newer uv (911-line diff). Left out to keep
  the diff focused; `uv lock` regenerates it cleanly, and CI's plain `uv sync` is unaffected.

## Due diligence

- The TASK-29 description's per-ID summaries (`present/valid/verifiable/algorithm`) predate the
  current registry; tests here align to the **current** `CARD-SIGN-001..004` definitions.
  Flagging the drift so the backlog note can be reconciled.

## Tests

- 26 unit tests (`tests/unit/validators/test_card_signature.py`): conformant verify; tampered →
  fail; `signatures` not excluded → fail; wrong key → fail; missing/malformed `alg`/`kid`;
  unlisted-but-valid algorithm accepted; no key → inconclusive; unsigned → no errors;
  default-stripping and unknown-key preservation; and hostile-input cases (non-array/non-object
  entries, non-string members, undeserializable signatures, deep nesting).
  Run with `uv run pytest tests/unit/validators/test_card_signature.py`.
- 2 compatibility tests (`tests/compatibility/agent_card/test_agent_card_signing.py`) wired to
  the `agent_card` fixture, validated end-to-end against a locally-served signed card.
- `make lint` and `make unit-test` green with and without the `signing` extra (without it, the
  new tests skip).
