### PR TITLE
fix: probe-and-route CARD-EXT precondition; fail on wrong error (#188)

### DIFF
--- a/tck/requirements/agent_card.py
+++ b/tck/requirements/agent_card.py
@@ -10,7 +10,6 @@ from tck.requirements.base import (
     EXTENDED_AGENT_CARD_NOT_CONFIGURED_ERROR,
     GET_EXTENDED_AGENT_CARD_BINDING,
     SPEC_BASE,
-    OperationType,
     RequirementLevel,
     RequirementSpec,
 )
@@ -100,7 +99,10 @@ AGENT_CARD_REQUIREMENTS: list[RequirementSpec] = [
             "The client MUST authenticate the GetExtendedAgentCard request "
             "using one of the schemes declared in the public AgentCard."
         ),
-        operation=OperationType.GET_EXTENDED_AGENT_CARD,
+        # No ``operation``: the extended-card precondition is not observable
+        # from the card, so this is driven by a dedicated probe-and-skip test
+        # (TestExtendedCardRequiresAuth) instead of the generic requirement
+        # runner, which would false-fail when no extended card is configured.
         binding=GET_EXTENDED_AGENT_CARD_BINDING,
         proto_request_type="GetExtendedAgentCardRequest",
         proto_response_type="AgentCard",

--- a/tck/validators/extended_card.py
+++ b/tck/validators/extended_card.py
@@ -15,6 +15,7 @@ from tck.requirements.base import EXTENDED_AGENT_CARD_NOT_CONFIGURED_ERROR
 
 
 _AUTH_CHALLENGE_STATUS = frozenset({401, 403})
+_AUTH_CHALLENGE_GRPC = frozenset({"UNAUTHENTICATED", "PERMISSION_DENIED"})
 
 
 class ExtendedCardProbe(Enum):
@@ -31,8 +32,9 @@ def classify_extended_card_probe(response: Any, transport: str) -> ExtendedCardP
 
     Returns:
         ``CONFIGURED`` when the call succeeds (a card was returned);
-        ``AUTH_REQUIRED`` on an HTTP 401/403 auth challenge (the card exists
-        but the request was not authorized); ``NOT_CONFIGURED`` when the
+        ``AUTH_REQUIRED`` on an auth challenge — HTTP 401/403, or the gRPC
+        ``UNAUTHENTICATED``/``PERMISSION_DENIED`` statuses (gRPC responses
+        carry no HTTP status code); ``NOT_CONFIGURED`` when the
         transport returns ``ExtendedAgentCardNotConfiguredError`` (the
         precondition holds); ``WRONG_ERROR`` for any other error — a
         conformance violation, since a server that declares support must
@@ -40,7 +42,7 @@ def classify_extended_card_probe(response: Any, transport: str) -> ExtendedCardP
     """
     if response.success:
         return ExtendedCardProbe.CONFIGURED
-    if response.status_code in _AUTH_CHALLENGE_STATUS:
+    if response.status_code in _AUTH_CHALLENGE_STATUS or response.error_code in _AUTH_CHALLENGE_GRPC:
         return ExtendedCardProbe.AUTH_REQUIRED
     expected = EXTENDED_AGENT_CARD_NOT_CONFIGURED_ERROR.expected_code(transport)
     if expected is not None and response.error_code == expected:

--- a/tck/validators/extended_card.py
+++ b/tck/validators/extended_card.py
@@ -9,9 +9,13 @@ endpoint and route on the response rather than asserting a fixed outcome.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING
 
 from tck.requirements.base import EXTENDED_AGENT_CARD_NOT_CONFIGURED_ERROR
+
+
+if TYPE_CHECKING:
+    from tck.transport.base import TransportResponse
 
 
 _AUTH_CHALLENGE_STATUS = frozenset({401, 403})
@@ -27,7 +31,7 @@ class ExtendedCardProbe(Enum):
     WRONG_ERROR = "wrong_error"
 
 
-def classify_extended_card_probe(response: Any, transport: str) -> ExtendedCardProbe:
+def classify_extended_card_probe(response: TransportResponse, transport: str) -> ExtendedCardProbe:
     """Classify a GetExtendedAgentCard probe response.
 
     Returns:

--- a/tck/validators/extended_card.py
+++ b/tck/validators/extended_card.py
@@ -1,0 +1,48 @@
+"""Classify a GetExtendedAgentCard probe response for CARD-EXT routing.
+
+The extended-card precondition — a server that declares ``extendedAgentCard``
+support but has not configured a card — is not observable from the public
+Agent Card (A2A §3.1.11).  CARD-EXT-001 and CARD-EXT-002 therefore probe the
+endpoint and route on the response rather than asserting a fixed outcome.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from tck.requirements.base import EXTENDED_AGENT_CARD_NOT_CONFIGURED_ERROR
+
+
+_AUTH_CHALLENGE_STATUS = frozenset({401, 403})
+
+
+class ExtendedCardProbe(Enum):
+    """Outcome of probing the GetExtendedAgentCard endpoint."""
+
+    CONFIGURED = "configured"
+    NOT_CONFIGURED = "not_configured"
+    AUTH_REQUIRED = "auth_required"
+    WRONG_ERROR = "wrong_error"
+
+
+def classify_extended_card_probe(response: Any, transport: str) -> ExtendedCardProbe:
+    """Classify a GetExtendedAgentCard probe response.
+
+    Returns:
+        ``CONFIGURED`` when the call succeeds (a card was returned);
+        ``AUTH_REQUIRED`` on an HTTP 401/403 auth challenge (the card exists
+        but the request was not authorized); ``NOT_CONFIGURED`` when the
+        transport returns ``ExtendedAgentCardNotConfiguredError`` (the
+        precondition holds); ``WRONG_ERROR`` for any other error — a
+        conformance violation, since a server that declares support must
+        serve the card, challenge for auth, or return the specified error.
+    """
+    if response.success:
+        return ExtendedCardProbe.CONFIGURED
+    if response.status_code in _AUTH_CHALLENGE_STATUS:
+        return ExtendedCardProbe.AUTH_REQUIRED
+    expected = EXTENDED_AGENT_CARD_NOT_CONFIGURED_ERROR.expected_code(transport)
+    if expected is not None and response.error_code == expected:
+        return ExtendedCardProbe.NOT_CONFIGURED
+    return ExtendedCardProbe.WRONG_ERROR

--- a/tests/compatibility/core_operations/test_error_handling.py
+++ b/tests/compatibility/core_operations/test_error_handling.py
@@ -397,7 +397,8 @@ class TestExtendedCardNotConfigured:
     The precondition (server declares support but has not configured a card)
     is not observable from the agent card, so the test probes the
     GetExtendedAgentCard endpoint and routes on the response.  A successful
-    response or an HTTP 401/403 auth challenge means the card IS configured,
+    response or an auth challenge (HTTP 401/403, or the gRPC
+    UNAUTHENTICATED/PERMISSION_DENIED statuses) means the card IS configured,
     so the test is skipped.  The expected ExtendedAgentCardNotConfiguredError
     passes.  Any *other* error is a conformance violation — the server
     declared support but returned neither the card, an auth challenge, nor

--- a/tests/compatibility/core_operations/test_error_handling.py
+++ b/tests/compatibility/core_operations/test_error_handling.py
@@ -6,7 +6,7 @@ the error responses conform to the A2A specification.
 Requirements tested:
     CORE-ERR-001, CORE-ERR-002,
     CORE-CAP-001, CORE-CAP-002, CORE-CAP-003, CORE-CAP-004,
-    CARD-EXT-002,
+    CARD-EXT-001, CARD-EXT-002,
     VER-SERVER-002, VER-SERVER-003,
     JSONRPC-ERR-001, JSONRPC-ERR-002, JSONRPC-ERR-003,
     HTTP_JSON-ERR-001, HTTP_JSON-ERR-002,
@@ -24,8 +24,11 @@ import pytest
 from tck.requirements.base import EXTENDED_AGENT_CARD_NOT_CONFIGURED_ERROR, tck_id
 from tck.requirements.registry import get_requirement_by_id
 from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER
-from tck.validators.error_binding import validate_expected_error
 from tck.validators.error_info import validate_error_info
+from tck.validators.extended_card import (
+    ExtendedCardProbe,
+    classify_extended_card_probe,
+)
 from tck.validators.http_json.error_validator import validate_http_json_error
 from tck.validators.jsonrpc.error_validator import validate_jsonrpc_error
 from tests.compatibility._test_helpers import (
@@ -51,6 +54,7 @@ CORE_CAP_001 = get_requirement_by_id("CORE-CAP-001")
 CORE_CAP_002 = get_requirement_by_id("CORE-CAP-002")
 CORE_CAP_003 = get_requirement_by_id("CORE-CAP-003")
 CORE_CAP_004 = get_requirement_by_id("CORE-CAP-004")
+CARD_EXT_001 = get_requirement_by_id("CARD-EXT-001")
 CARD_EXT_002 = get_requirement_by_id("CARD-EXT-002")
 VER_SERVER_002 = get_requirement_by_id("VER-SERVER-002")
 VER_SERVER_003 = get_requirement_by_id("VER-SERVER-003")
@@ -390,17 +394,14 @@ class TestCapabilityExtendedCard:
 class TestExtendedCardNotConfigured:
     """CARD-EXT-002: Extended card not configured returns ExtendedAgentCardNotConfiguredError.
 
-    This test probes the GetExtendedAgentCard endpoint to determine whether
-    the test precondition holds (the server declares support but has not
-    configured an extended card).  When the server returns a successful
-    response or a non-matching error (e.g. an authentication error) the card
-    IS configured and the test is skipped.
-
-    By design this test can only pass or skip — it never fails.  The
-    precondition (card not configured) is not observable from the agent card
-    alone, so we infer it from the response: if the server returns the
-    expected ExtendedAgentCardNotConfiguredError the test passes; any other
-    outcome means the precondition does not hold and the test is skipped.
+    The precondition (server declares support but has not configured a card)
+    is not observable from the agent card, so the test probes the
+    GetExtendedAgentCard endpoint and routes on the response.  A successful
+    response or an HTTP 401/403 auth challenge means the card IS configured,
+    so the test is skipped.  The expected ExtendedAgentCardNotConfiguredError
+    passes.  Any *other* error is a conformance violation — the server
+    declared support but returned neither the card, an auth challenge, nor
+    the specified error — and fails rather than silently skipping.
     """
 
     @staticmethod
@@ -417,16 +418,19 @@ class TestExtendedCardNotConfigured:
             pytest.skip("Agent does not declare extendedAgentCard capability")
         client = get_client(transport_clients, transport, compatibility_collector=compatibility_collector, req=req)
         response = client.get_extended_agent_card()
-        if response.success:
+        probe = classify_extended_card_probe(response, transport)
+        if probe in (ExtendedCardProbe.CONFIGURED, ExtendedCardProbe.AUTH_REQUIRED):
             record(collector=compatibility_collector, req=req, transport=transport, passed=False, skipped=True)
-            pytest.skip("Extended card is configured (returned successfully); test does not apply")
-        errors = validate_expected_error(response, transport, EXTENDED_AGENT_CARD_NOT_CONFIGURED_ERROR)
-        if errors:
-            record(collector=compatibility_collector, req=req, transport=transport, passed=False, skipped=True)
-            pytest.skip(
-                "Extended card appears configured (server returned a different error); "
-                "test does not apply"
-            )
+            pytest.skip("Extended card is configured (test precondition does not hold)")
+        errors = (
+            []
+            if probe is ExtendedCardProbe.NOT_CONFIGURED
+            else [
+                "Server declares extendedAgentCard support but returned "
+                f"{response.error_code!r} instead of "
+                f"{EXTENDED_AGENT_CARD_NOT_CONFIGURED_ERROR.name}"
+            ]
+        )
         assert_and_record(compatibility_collector, req, transport, errors)
 
     @jsonrpc
@@ -457,6 +461,78 @@ class TestExtendedCardNotConfigured:
         compatibility_collector: Any,
     ) -> None:
         """CARD-EXT-002: Not-configured extended card returns correct error (gRPC)."""
+        self._run("grpc", transport_clients, agent_card, compatibility_collector)
+
+
+@must
+@core
+class TestExtendedCardRequiresAuth:
+    """CARD-EXT-001: An authenticated GetExtendedAgentCard request returns the extended card.
+
+    Like CARD-EXT-002, the precondition is not observable from the public
+    card, so the endpoint is probed and the result routed.  A configured card
+    returned to the TCK's authenticated client passes.  When no card is
+    configured, or the transport returns an auth challenge (the TCK's own
+    credentials were not accepted), the precondition does not hold and the
+    test is skipped.  Any other error is a conformance violation and fails.
+    """
+
+    @staticmethod
+    def _run(
+        transport: str,
+        transport_clients: dict[str, BaseTransportClient],
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+    ) -> None:
+        req = CARD_EXT_001
+        caps = agent_card.get("capabilities", {})
+        if not caps.get("extendedAgentCard"):
+            record(collector=compatibility_collector, req=req, transport=transport, passed=False, skipped=True)
+            pytest.skip("Agent does not declare extendedAgentCard capability")
+        client = get_client(transport_clients, transport, compatibility_collector=compatibility_collector, req=req)
+        response = client.get_extended_agent_card()
+        probe = classify_extended_card_probe(response, transport)
+        if probe in (ExtendedCardProbe.NOT_CONFIGURED, ExtendedCardProbe.AUTH_REQUIRED):
+            record(collector=compatibility_collector, req=req, transport=transport, passed=False, skipped=True)
+            pytest.skip("No authenticated extended card available (test precondition does not hold)")
+        errors = (
+            []
+            if probe is ExtendedCardProbe.CONFIGURED
+            else [
+                "Authenticated GetExtendedAgentCard returned "
+                f"{response.error_code!r}; expected the extended card"
+            ]
+        )
+        assert_and_record(compatibility_collector, req, transport, errors)
+
+    @jsonrpc
+    def test_extended_card_requires_auth_jsonrpc(
+        self,
+        transport_clients: dict[str, BaseTransportClient],
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+    ) -> None:
+        """CARD-EXT-001: Authenticated request returns extended card (JSON-RPC)."""
+        self._run("jsonrpc", transport_clients, agent_card, compatibility_collector)
+
+    @http_json
+    def test_extended_card_requires_auth_http_json(
+        self,
+        transport_clients: dict[str, BaseTransportClient],
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+    ) -> None:
+        """CARD-EXT-001: Authenticated request returns extended card (HTTP+JSON)."""
+        self._run("http_json", transport_clients, agent_card, compatibility_collector)
+
+    @grpc
+    def test_extended_card_requires_auth_grpc(
+        self,
+        transport_clients: dict[str, BaseTransportClient],
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+    ) -> None:
+        """CARD-EXT-001: Authenticated request returns extended card (gRPC)."""
         self._run("grpc", transport_clients, agent_card, compatibility_collector)
 
 

--- a/tests/compatibility/core_operations/test_error_handling.py
+++ b/tests/compatibility/core_operations/test_error_handling.py
@@ -24,6 +24,7 @@ import pytest
 from tck.requirements.base import EXTENDED_AGENT_CARD_NOT_CONFIGURED_ERROR, tck_id
 from tck.requirements.registry import get_requirement_by_id
 from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER
+from tck.validators.error_binding import validate_expected_error
 from tck.validators.error_info import validate_error_info
 from tck.validators.extended_card import (
     ExtendedCardProbe,

--- a/tests/unit/validators/test_extended_card.py
+++ b/tests/unit/validators/test_extended_card.py
@@ -69,6 +69,22 @@ class TestClassifyExtendedCardProbe:
             is ExtendedCardProbe.AUTH_REQUIRED
         )
 
+    def test_grpc_not_configured_status(self) -> None:
+        """A gRPC FAILED_PRECONDITION maps to the not-configured precondition."""
+        response = _resp("grpc", error_code="FAILED_PRECONDITION")
+        assert classify_extended_card_probe(response, "grpc") is ExtendedCardProbe.NOT_CONFIGURED
+
+    @pytest.mark.parametrize("code", ["UNAUTHENTICATED", "PERMISSION_DENIED"])
+    def test_grpc_auth_status_is_auth_required(self, code: str) -> None:
+        """The gRPC auth statuses are auth challenges; gRPC has no HTTP status code."""
+        response = _resp("grpc", error_code=code)
+        assert classify_extended_card_probe(response, "grpc") is ExtendedCardProbe.AUTH_REQUIRED
+
+    def test_grpc_other_status_is_wrong_error(self) -> None:
+        """Any other gRPC status is a conformance violation."""
+        response = _resp("grpc", error_code="INTERNAL")
+        assert classify_extended_card_probe(response, "grpc") is ExtendedCardProbe.WRONG_ERROR
+
     @pytest.mark.parametrize("code", [-32601, -32603, -32004])
     def test_other_jsonrpc_error_is_wrong_error(self, code: int) -> None:
         """Any other A2A/JSON-RPC error is a conformance violation."""

--- a/tests/unit/validators/test_extended_card.py
+++ b/tests/unit/validators/test_extended_card.py
@@ -1,0 +1,87 @@
+"""Tests for the extended-card probe classifier."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from tck.validators.extended_card import (
+    ExtendedCardProbe,
+    classify_extended_card_probe,
+)
+
+
+@dataclass
+class _FakeResponse:
+    """Minimal stand-in for a TransportResponse probe result."""
+
+    transport: str
+    success: bool
+    error_code: int | str | None = None
+    status_code: int | None = None
+    raw_response: Any = None
+
+
+def _resp(
+    transport: str,
+    *,
+    success: bool = False,
+    error_code: int | str | None = None,
+    status_code: int | None = None,
+) -> _FakeResponse:
+    return _FakeResponse(
+        transport=transport,
+        success=success,
+        error_code=error_code,
+        status_code=status_code,
+    )
+
+
+class TestClassifyExtendedCardProbe:
+    """CARD-EXT precondition routing (A2A §3.1.11)."""
+
+    def test_success_is_configured(self) -> None:
+        """A successful response means the extended card is configured."""
+        response = _resp("jsonrpc", success=True)
+        assert classify_extended_card_probe(response, "jsonrpc") is ExtendedCardProbe.CONFIGURED
+
+    def test_jsonrpc_not_configured_code(self) -> None:
+        """JSON-RPC -32007 maps to the not-configured precondition."""
+        response = _resp("jsonrpc", error_code=-32007)
+        assert classify_extended_card_probe(response, "jsonrpc") is ExtendedCardProbe.NOT_CONFIGURED
+
+    def test_http_json_not_configured_status(self) -> None:
+        """HTTP 400 maps to the not-configured precondition on http_json."""
+        response = _resp("http_json", error_code=400, status_code=400)
+        assert (
+            classify_extended_card_probe(response, "http_json")
+            is ExtendedCardProbe.NOT_CONFIGURED
+        )
+
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_auth_challenge_is_auth_required(self, status: int) -> None:
+        """An HTTP 401/403 auth challenge means the card exists but needs auth."""
+        response = _resp("jsonrpc", error_code=-32600, status_code=status)
+        assert (
+            classify_extended_card_probe(response, "jsonrpc")
+            is ExtendedCardProbe.AUTH_REQUIRED
+        )
+
+    @pytest.mark.parametrize("code", [-32601, -32603, -32004])
+    def test_other_jsonrpc_error_is_wrong_error(self, code: int) -> None:
+        """Any other A2A/JSON-RPC error is a conformance violation."""
+        response = _resp("jsonrpc", error_code=code)
+        assert (
+            classify_extended_card_probe(response, "jsonrpc")
+            is ExtendedCardProbe.WRONG_ERROR
+        )
+
+    def test_http_json_server_error_is_wrong_error(self) -> None:
+        """An HTTP 500 on http_json is a conformance violation, not a skip."""
+        response = _resp("http_json", error_code=500, status_code=500)
+        assert (
+            classify_extended_card_probe(response, "http_json")
+            is ExtendedCardProbe.WRONG_ERROR
+        )


### PR DESCRIPTION

Fixes #188.

The extended-card precondition — a server that declares `extendedAgentCard`
support but has not configured a card — is not observable from the public
Agent Card, so neither CARD-EXT test can assert a fixed outcome. This PR
routes both tests through a probe of the GetExtendedAgentCard endpoint.

## Changes

- New pure classifier `tck/validators/extended_card.py::classify_extended_card_probe`
  returning `CONFIGURED` / `NOT_CONFIGURED` / `AUTH_REQUIRED` / `WRONG_ERROR`.
  Not-configured is `ExtendedAgentCardNotConfiguredError` per transport
  (`-32007` / HTTP 400 / `FAILED_PRECONDITION`); auth challenges are HTTP
  401/403 or the gRPC `UNAUTHENTICATED`/`PERMISSION_DENIED` statuses (gRPC
  responses carry no HTTP status code).
- `TestExtendedCardNotConfigured` (CARD-EXT-002) now **fails** on
  `WRONG_ERROR` instead of skipping. Previously a server returning a
  wrong-but-present error code skipped, so a MUST violation went unreported.
- CARD-EXT-001 leaves the generic success-runner (its `operation=` is
  removed): with it, a conformant server in the not-configured state
  false-failed. It gets a dedicated `TestExtendedCardRequiresAuth`
  probe-and-skip test instead, mirroring how #186 handled CARD-EXT-002.
- 13 unit tests for the classifier across all three transports.

## Design note: gRPC `PERMISSION_DENIED` routes to skip, not fail

`UNAUTHENTICATED` is unambiguously an auth challenge. `PERMISSION_DENIED`
is also treated as one, which means a non-conformant server that wrongly
returns `PERMISSION_DENIED` for a not-configured card is skipped rather
than failed. The classifier cannot distinguish "authenticated but not
authorized to see this card" (legitimate) from a misused status code, so
the skip is deliberate: a false skip is recoverable by the operator, a
false MUST failure is not. All other unexpected statuses
(`INTERNAL`, `UNIMPLEMENTED`, …) fail.

## Known limitations

- On `http_json`, several A2A errors share HTTP status 400, so the
  not-configured check is status-level only (pre-existing validator
  behavior; distinguishing them would require asserting the error body).
- CARD-EXT-001's requirement text is a client-side MUST; the harness can
  verify its own authenticated client is served a card, but cannot verify
  an unauthenticated request is rejected. The test docstring states this.
- A probe that fails at the transport level (no status, no error code)
  classifies as `WRONG_ERROR` and fails. This is the strict reading: a
  server that declares support must produce the card, a challenge, or the
  specified error.

## Verification

- `make lint` clean; full unit suite green (266).
- Compatibility tests collect cleanly. The classifier is covered by unit
  tests across all three transports; the compatibility-test routing was
  verified statically (executing it needs a live SUT).
