### PR TITLE
test(error): assert the specific spec-mandated error, not just any error

### DIFF
--- a/tck/requirements/core_operations.py
+++ b/tck/requirements/core_operations.py
@@ -9,11 +9,14 @@ from __future__ import annotations
 
 from tck.requirements.base import (
     CANCEL_TASK_BINDING,
+    EXTENSION_SUPPORT_REQUIRED_ERROR,
     GET_TASK_BINDING,
     LIST_TASKS_BINDING,
+    PUSH_NOTIFICATION_NOT_SUPPORTED_ERROR,
     SEND_MESSAGE_BINDING,
     SEND_STREAMING_MESSAGE_BINDING,
     SPEC_BASE,
+    TASK_NOT_CANCELABLE_ERROR,
     TASK_NOT_FOUND_ERROR,
     UNSUPPORTED_OPERATION_ERROR,
     OperationType,
@@ -356,9 +359,9 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
         binding=CANCEL_TASK_BINDING,
         proto_request_type="CancelTaskRequest",
         expected_behavior="TaskNotCancelableError returned",
+        expected_error=TASK_NOT_CANCELABLE_ERROR,
         spec_url=f"{SPEC_BASE}315-cancel-task",
         tags=[CORE, CANCEL_TASK, ERROR, MULTI_OPERATION],
-
     ),
     RequirementSpec(
         id="CORE-CANCEL-003",
@@ -469,6 +472,7 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
             "PushNotificationNotSupportedError."
         ),
         expected_behavior="PushNotificationNotSupportedError returned",
+        expected_error=PUSH_NOTIFICATION_NOT_SUPPORTED_ERROR,
         spec_url=f"{SPEC_BASE}334-capability-validation",
         tags=[CORE, CAPABILITY, PUSH_NOTIFICATION],
     ),
@@ -483,6 +487,7 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
             "UnsupportedOperationError."
         ),
         expected_behavior="UnsupportedOperationError returned",
+        expected_error=UNSUPPORTED_OPERATION_ERROR,
         spec_url=f"{SPEC_BASE}334-capability-validation",
         tags=[CORE, CAPABILITY, STREAMING],
     ),
@@ -496,6 +501,7 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
             "GetExtendedAgentCard MUST return UnsupportedOperationError."
         ),
         expected_behavior="UnsupportedOperationError returned",
+        expected_error=UNSUPPORTED_OPERATION_ERROR,
         spec_url=f"{SPEC_BASE}334-capability-validation",
         tags=[CORE, CAPABILITY, AGENT_CARD],
     ),
@@ -510,6 +516,7 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
             "ExtensionSupportRequiredError."
         ),
         expected_behavior="ExtensionSupportRequiredError returned",
+        expected_error=EXTENSION_SUPPORT_REQUIRED_ERROR,
         spec_url=f"{SPEC_BASE}334-capability-validation",
         tags=[CORE, CAPABILITY, EXTENSION],
     ),

--- a/tck/requirements/streaming.py
+++ b/tck/requirements/streaming.py
@@ -10,6 +10,7 @@ from tck.requirements.base import (
     SPEC_BASE,
     SUBSCRIBE_TO_TASK_BINDING,
     TASK_NOT_FOUND_ERROR,
+    UNSUPPORTED_OPERATION_ERROR,
     OperationType,
     RequirementLevel,
     RequirementSpec,
@@ -126,9 +127,9 @@ STREAMING_REQUIREMENTS: list[RequirementSpec] = [
         binding=SUBSCRIBE_TO_TASK_BINDING,
         proto_request_type="SubscribeToTaskRequest",
         expected_behavior="UnsupportedOperationError returned for terminal task",
+        expected_error=UNSUPPORTED_OPERATION_ERROR,
         spec_url=f"{SPEC_BASE}316-subscribe-to-task",
         tags=[STREAMING, SUBSCRIBE, ERROR, MULTI_OPERATION],
-
     ),
     RequirementSpec(
         id="STREAM-SUB-004",

--- a/tck/requirements/versioning.py
+++ b/tck/requirements/versioning.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from tck.requirements.base import (
     SPEC_BASE,
+    VERSION_NOT_SUPPORTED_ERROR,
     RequirementLevel,
     RequirementSpec,
 )
@@ -57,6 +58,7 @@ VERSIONING_REQUIREMENTS: list[RequirementSpec] = [
             "return a VersionNotSupportedError."
         ),
         expected_behavior="VersionNotSupportedError returned",
+        expected_error=VERSION_NOT_SUPPORTED_ERROR,
         spec_url=f"{SPEC_BASE}362-server-responsibilities",
         tags=[VERSIONING, SERVER, ERROR],
     ),

--- a/tests/compatibility/_test_helpers.py
+++ b/tests/compatibility/_test_helpers.py
@@ -15,8 +15,20 @@ import pytest
 
 
 if TYPE_CHECKING:
-    from tck.requirements.base import RequirementSpec
+    from tck.requirements.base import ErrorBinding, RequirementSpec
     from tck.transport.base import BaseTransportClient
+
+
+def expected_error_of(req: RequirementSpec) -> ErrorBinding:
+    """Return a requirement's declared ``expected_error``, asserting it is set.
+
+    The registry invariant (``test_expected_error_declared``) guarantees that
+    any requirement whose text mandates a specific error declares it here, so a
+    missing binding is a registry bug, not a runtime condition.
+    """
+    if req.expected_error is None:
+        raise AssertionError(f"{req.id} does not declare an expected_error")
+    return req.expected_error
 
 
 def fail_msg(req: RequirementSpec, transport: str, detail: str) -> str:

--- a/tests/compatibility/core_operations/test_error_handling.py
+++ b/tests/compatibility/core_operations/test_error_handling.py
@@ -28,7 +28,12 @@ from tck.validators.error_binding import validate_expected_error
 from tck.validators.error_info import validate_error_info
 from tck.validators.http_json.error_validator import validate_http_json_error
 from tck.validators.jsonrpc.error_validator import validate_jsonrpc_error
-from tests.compatibility._test_helpers import assert_and_record, get_client, record
+from tests.compatibility._test_helpers import (
+    assert_and_record,
+    expected_error_of,
+    get_client,
+    record,
+)
 from tests.compatibility.markers import core, grpc, http_json, jsonrpc, must
 
 
@@ -229,8 +234,7 @@ class TestCapabilityPushNotifications:
             task_id="t",
             config={"url": "https://example.com"},
         )
-        passed = not response.success
-        errors = [] if passed else ["Expected error for unsupported push notifications"]
+        errors = validate_expected_error(response, transport, expected_error_of(req))
         assert_and_record(compatibility_collector, req, transport, errors)
 
     def test_push_not_supported_rest(
@@ -251,8 +255,7 @@ class TestCapabilityPushNotifications:
             task_id="t",
             config={"url": "https://example.com"},
         )
-        passed = not response.success
-        errors = [] if passed else ["Expected error for unsupported push notifications"]
+        errors = validate_expected_error(response, transport, expected_error_of(req))
         assert_and_record(compatibility_collector, req, transport, errors)
 
 
@@ -286,8 +289,8 @@ class TestCapabilityStreaming:
             client.base_url, "SendStreamingMessage", {"message": msg}
         )
         body = response.json()
-        passed = "error" in body
-        errors = [] if passed else ["Expected error for unsupported streaming"]
+        result = validate_jsonrpc_error(body, expected_error_of(req).name)
+        errors = [] if result.valid else [result.message]
         assert_and_record(compatibility_collector, req, transport, errors)
 
 
@@ -378,8 +381,7 @@ class TestCapabilityExtendedCard:
             pytest.skip("Agent supports extended agent card")
         client = get_client(transport_clients, transport, compatibility_collector=compatibility_collector, req=req)
         response = client.get_extended_agent_card()
-        passed = not response.success
-        errors = [] if passed else ["Expected error for unsupported extended card"]
+        errors = validate_expected_error(response, transport, expected_error_of(req))
         assert_and_record(compatibility_collector, req, transport, errors)
 
 
@@ -490,8 +492,8 @@ class TestVersionErrors:
             headers={A2A_VERSION_HEADER: "99.0"},
         )
         body = response.json()
-        passed = "error" in body
-        errors = [] if passed else ["Expected VersionNotSupportedError for A2A-Version: 99.0"]
+        result = validate_jsonrpc_error(body, expected_error_of(req).name)
+        errors = [] if result.valid else [result.message]
         assert_and_record(compatibility_collector, req, transport, errors)
 
     def test_unsupported_version_returns_error_rest(
@@ -516,8 +518,8 @@ class TestVersionErrors:
             json_body={"message": msg},
             headers={A2A_VERSION_HEADER: "99.0"},
         )
-        passed = response.status_code >= _HTTP_ERROR_STATUS
-        errors = [] if passed else [f"Expected error for unsupported version, got {response.status_code}"]
+        result = validate_http_json_error(response, expected_error_of(req).name)
+        errors = [] if result.valid else [result.message]
         assert_and_record(compatibility_collector, req, transport, errors)
 
     def test_empty_version_treated_as_default_jsonrpc(

--- a/tests/compatibility/core_operations/test_error_handling.py
+++ b/tests/compatibility/core_operations/test_error_handling.py
@@ -330,7 +330,7 @@ class TestCapabilityExtensionRequired:
         }
         response = _jsonrpc_call(client.base_url, "SendMessage", {"message": msg})
         body = response.json()
-        result = validate_jsonrpc_error(body, "ExtensionSupportRequiredError")
+        result = validate_jsonrpc_error(body, expected_error_of(req).name)
         errors = [] if result.valid else [result.message]
         assert_and_record(compatibility_collector, req, transport, errors)
 
@@ -355,7 +355,7 @@ class TestCapabilityExtensionRequired:
         response = _rest_call(
             client.base_url, "POST", "/message:send", json_body={"message": msg},
         )
-        result = validate_http_json_error(response, "ExtensionSupportRequiredError")
+        result = validate_http_json_error(response, expected_error_of(req).name)
         errors = [] if result.valid else [result.message]
         assert_and_record(compatibility_collector, req, transport, errors)
 

--- a/tests/compatibility/core_operations/test_task_lifecycle.py
+++ b/tests/compatibility/core_operations/test_task_lifecycle.py
@@ -452,13 +452,11 @@ class TestSubscribeLifecycle:
         # Some servers open the stream and deliver the error on iteration; the
         # error code is not observable from the stream, so any iteration error
         # is accepted and only a successfully-yielded event is a failure.
-        try:
-            collect_events_with_timeout(sub_response.events)[0]
+        events, _ = collect_events_with_timeout(sub_response.events, stop_after_first=True)
+        if events:
             errors.append(
                 "SubscribeToTask on a terminal task should return an error, "
                 "but yielded an event"
             )
-        except Exception:
-            pass
 
         assert_and_record(compatibility_collector, req, transport, errors)

--- a/tests/compatibility/core_operations/test_task_lifecycle.py
+++ b/tests/compatibility/core_operations/test_task_lifecycle.py
@@ -26,10 +26,12 @@ import pytest
 from tck.requirements.base import TERMINAL_STATES, tck_id
 from tck.requirements.registry import get_requirement_by_id
 from tck.transport import ALL_TRANSPORTS
+from tck.validators.error_binding import validate_expected_error
 from tests.compatibility._task_helpers import create_completed_task, create_working_task
 from tests.compatibility._test_helpers import (
     assert_and_record,
     collect_events_with_timeout,
+    expected_error_of,
     get_client,
     record,
 )
@@ -231,12 +233,7 @@ class TestCancelTask:
 
         response = client.cancel_task(id=info.task_id)
 
-        errors: list[str] = []
-        if response.success:
-            errors.append(
-                "CancelTask on a terminal task should return an error, "
-                "but succeeded"
-            )
+        errors = validate_expected_error(response, transport, expected_error_of(req))
 
         assert_and_record(compatibility_collector, req, transport, errors)
 
@@ -444,18 +441,24 @@ class TestSubscribeLifecycle:
             pytest.skip("Task did not reach a terminal state; cannot test subscribe-after-terminal")
 
         sub_response = client.subscribe_to_task(id=info.task_id)
-
         errors: list[str] = []
-        if sub_response.success:
-            # Some servers may return success but deliver an error on iteration
-            try:
-                collect_events_with_timeout(sub_response.events)[0]
-                errors.append(
-                    "SubscribeToTask on a terminal task should return an error, "
-                    "but succeeded"
-                )
-            except Exception:
-                pass  # Error during iteration is acceptable
-        # else: server returned error immediately — correct behavior
+
+        if not sub_response.success:
+            # Immediate error: must be the specific UnsupportedOperationError.
+            errors = validate_expected_error(sub_response, transport, expected_error_of(req))
+            assert_and_record(compatibility_collector, req, transport, errors)
+            return
+
+        # Some servers open the stream and deliver the error on iteration; the
+        # error code is not observable from the stream, so any iteration error
+        # is accepted and only a successfully-yielded event is a failure.
+        try:
+            collect_events_with_timeout(sub_response.events)[0]
+            errors.append(
+                "SubscribeToTask on a terminal task should return an error, "
+                "but yielded an event"
+            )
+        except Exception:
+            pass
 
         assert_and_record(compatibility_collector, req, transport, errors)

--- a/tests/unit/requirements/test_expected_error_declared.py
+++ b/tests/unit/requirements/test_expected_error_declared.py
@@ -1,0 +1,34 @@
+"""Registry invariant: a requirement that mandates a specific error declares it.
+
+When a requirement's description says the server ``MUST return <Name>Error``,
+that named error is the conformance target.  If the ``RequirementSpec`` does
+not declare it via ``expected_error``, tests fall back to accepting *any*
+error and a server returning the wrong code passes a MUST it should fail.
+This test pins the specific error to the requirement so both the generic
+runner and the dedicated tests can assert the exact code.
+"""
+
+from __future__ import annotations
+
+import re
+
+from tck.requirements.registry import ALL_REQUIREMENTS
+
+
+_MUST_RETURN_ERROR = re.compile(r"MUST return (?:a |an )?(\w*Error)\b")
+
+
+def test_named_error_requirements_declare_expected_error() -> None:
+    """Every 'MUST return <Name>Error' requirement declares that error."""
+    violations = []
+    for r in ALL_REQUIREMENTS:
+        match = _MUST_RETURN_ERROR.search(r.description)
+        if match is None:
+            continue
+        want = match.group(1)
+        have = r.expected_error.name if r.expected_error else None
+        if have != want:
+            violations.append(f"{r.id}: description mandates {want}, expected_error={have}")
+    assert not violations, "Requirements missing their mandated expected_error:\n" + "\n".join(
+        violations
+    )


### PR DESCRIPTION

Fixes #206.

Six MUST requirements name a specific error in their description, but
their dedicated tests accepted any error, so a server returning the wrong
error passed a MUST it should fail. See the issue for the full analysis
and table.

## Changes

- Declare `expected_error` on 7 requirements (`core_operations.py`,
  `streaming.py`, `versioning.py`): the 6 under-asserting ones plus
  `CORE-CAP-004`, which asserted the code but never declared it. The
  registry is now the single source of truth.
- Route the dedicated tests through the declared error via the existing
  validators. New narrowing accessor `expected_error_of(req)` in
  `tests/compatibility/_test_helpers.py`; `CORE-CAP-004`'s tests use it
  too instead of a hardcoded error name.
- `STREAM-SUB-003` keeps its lenient branch for the case where the server
  opens the stream and only errors on iteration (the code is not
  observable from the stream); the immediate-error path asserts the
  specific code.
- Regression guard `tests/unit/requirements/test_expected_error_declared.py`:
  fails if any `MUST return <Name>Error` requirement omits its
  `expected_error`.

## Known limitations

- On `http_json`, four of these errors share HTTP status 400, so that
  transport asserts status 400 only — stronger than the old any-error
  check, not the full specific-code assertion of the jsonrpc path.
- The guard regex is scoped to the literal `MUST return a/an <Name>Error`
  phrasing; differently-worded mandates (e.g. `CORE-SEND-003`, tracked in
  #202) are out of its reach.

## Verification

- `make lint` clean; full unit suite green (254), including the guard.
- Compatibility tests collect cleanly; the assertion changes were
  verified statically (executing them needs a live SUT). The declared
  codes were checked against the §3.3.2 error table across all three
  transport bindings.
