### PR TITLE
fix(codegen): migrate a2a-python SUT to the 1.x API and enqueue the initial Task

### DIFF
--- a/codegen/a2a-python/pyproject.toml.j2
+++ b/codegen/a2a-python/pyproject.toml.j2
@@ -5,7 +5,7 @@ name = "a2a-tck-sut"
 version = "1.0.0"
 requires-python = ">=3.11"
 dependencies = [
-    "a2a-sdk[http-server,grpc,sqlite]>={{ a2a_python_sdk_version }}",
+    "a2a-sdk[http-server,fastapi,grpc,sqlite]>={{ a2a_python_sdk_version }}",
     "packaging",
     "starlette>=1.1.0",
     "uvicorn",

--- a/codegen/a2a-python/pyproject.toml.j2
+++ b/codegen/a2a-python/pyproject.toml.j2
@@ -6,8 +6,8 @@ version = "1.0.0"
 requires-python = ">=3.11"
 dependencies = [
     "a2a-sdk[http-server,fastapi,grpc,sqlite]>={{ a2a_python_sdk_version }}",
+    "fastapi",
     "packaging",
-    "starlette>=1.1.0",
     "uvicorn",
 ]
 

--- a/codegen/a2a-python/sut_agent.py.j2
+++ b/codegen/a2a-python/sut_agent.py.j2
@@ -17,6 +17,7 @@ from fastapi import FastAPI
 
 import a2a.types.a2a_pb2_grpc as a2a_grpc
 
+from a2a.helpers import new_task
 from a2a.server.agent_execution.agent_executor import AgentExecutor
 from a2a.server.agent_execution.context import RequestContext
 from a2a.server.events.event_queue import EventQueue
@@ -35,6 +36,7 @@ from a2a.types import (
     AgentProvider,
     AgentSkill,
     Part,
+    TaskState,
 )
 from a2a.utils.errors import (
     A2AError,
@@ -63,8 +65,27 @@ class TckAgentExecutor(AgentExecutor):
             return
 
         updater = TaskUpdater(event_queue, task_id, context_id)
+
+        async def ensure_task() -> None:
+            """Enqueue the initial Task before any status update.
+
+            The SDK rejects a TaskStatusUpdateEvent that arrives before the
+            task exists. Artifact events create the task on demand, so this is
+            only emitted for handlers that publish a status update.
+            """
+            if context.current_task is None:
+                await event_queue.enqueue_event(
+                    new_task(
+                        task_id,
+                        context_id,
+                        TaskState.TASK_STATE_SUBMITTED,
+                        history=[context.message] if context.message else [],
+                    )
+                )
+
         message = context.message
         if message is None:
+            await ensure_task()
             await updater.complete(
                 updater.new_agent_message([Part(text='No message provided')])
             )
@@ -74,6 +95,9 @@ class TckAgentExecutor(AgentExecutor):
         {% for handler in handlers %}
 
         if message_id.startswith('{{ handler.prefix }}'):
+            {% if handler.needs_task %}
+            await ensure_task()
+            {% endif %}
             {{ handler.python_code | indent(12) }}
             {% if not handler.raises %}
             return
@@ -81,6 +105,7 @@ class TckAgentExecutor(AgentExecutor):
         {% endfor %}
 
         # Default: complete the task with an echo response
+        await ensure_task()
         await updater.complete(
             updater.new_agent_message(
                 [Part(text='Unhandled messageId prefix: ' + message_id)]

--- a/codegen/a2a-python/sut_agent.py.j2
+++ b/codegen/a2a-python/sut_agent.py.j2
@@ -13,21 +13,19 @@ import uvicorn
 from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Value
 
-from starlette.applications import Starlette
+from fastapi import FastAPI
 
 import a2a.types.a2a_pb2_grpc as a2a_grpc
 
 from a2a.server.agent_execution.agent_executor import AgentExecutor
 from a2a.server.agent_execution.context import RequestContext
-from a2a.server.apps import (
-    A2ARESTFastAPIApplication,
-    A2AStarletteApplication,
-)
 from a2a.server.events.event_queue import EventQueue
-from a2a.server.request_handlers.default_request_handler import (
-    DefaultRequestHandler,
-)
+from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.request_handlers.grpc_handler import GrpcHandler
+from a2a.server.routes.agent_card_routes import create_agent_card_routes
+from a2a.server.routes.fastapi_routes import add_a2a_routes_to_fastapi
+from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
+from a2a.server.routes.rest_routes import create_rest_routes
 from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.server.tasks.task_updater import TaskUpdater
 from a2a.types import (
@@ -157,24 +155,18 @@ async def main() -> None:
     request_handler = DefaultRequestHandler(
         agent_executor=TckAgentExecutor(),
         task_store=task_store,
-    )
-
-    main_app = Starlette()
-
-    # JSON-RPC
-    jsonrpc_server = A2AStarletteApplication(
         agent_card=agent_card,
-        http_handler=request_handler,
     )
-    jsonrpc_server.add_routes_to_app(main_app)
 
-    # REST / HTTP+JSON
-    rest_server = A2ARESTFastAPIApplication(
-        agent_card=agent_card,
-        http_handler=request_handler,
+    main_app = FastAPI()
+    add_a2a_routes_to_fastapi(
+        main_app,
+        agent_card_routes=create_agent_card_routes(agent_card),
+        jsonrpc_routes=create_jsonrpc_routes(request_handler, rpc_url='/'),
+        rest_routes=create_rest_routes(
+            request_handler, path_prefix=REST_URL
+        ),
     )
-    rest_app = rest_server.build(rpc_url=REST_URL)
-    main_app.mount('', rest_app)
 
     config = uvicorn.Config(
         main_app, host='0.0.0.0', port=http_port, log_level='info'
@@ -184,7 +176,7 @@ async def main() -> None:
     # gRPC
     grpc_server = grpc.aio.server()
     grpc_server.add_insecure_port(f'[::]:{grpc_port}')
-    servicer = GrpcHandler(agent_card, request_handler)
+    servicer = GrpcHandler(request_handler)
     a2a_grpc.add_A2AServiceServicer_to_server(servicer, grpc_server)
 
     logger.info(

--- a/codegen/python_emitter.py
+++ b/codegen/python_emitter.py
@@ -34,7 +34,7 @@ from codegen.model import (
 
 _TEMPLATES_DIR = Path(__file__).parent / "a2a-python"
 
-_DEFAULT_A2A_PYTHON_SDK_VERSION = "0.3.0"
+_DEFAULT_A2A_PYTHON_SDK_VERSION = "1.1.1"
 _DEFAULT_A2A_PYTHON_SDK_PATH = "../../../a2a-python"
 
 _STREAMING_TIMEOUT_S = 2

--- a/codegen/python_emitter.py
+++ b/codegen/python_emitter.py
@@ -99,6 +99,22 @@ class _Handler:
     prefix: str
     python_code: str
     raises: bool = False
+    needs_task: bool = False
+
+
+def _needs_task(scenario: Scenario) -> bool:
+    """Whether the handler emits a task status update.
+
+    The SDK rejects a ``TaskStatusUpdateEvent`` that arrives before the task
+    exists, so such handlers must enqueue the initial ``Task`` first. Artifact
+    events create the task on demand and so do not need it, and a handler that
+    only returns a ``Message`` must NOT create one, since mixing a Message into
+    task mode is itself an error.
+    """
+    return any(
+        isinstance(action, (CompleteTask, UpdateTaskStatus))
+        for action in scenario.actions
+    )
 
 
 def _build_handlers(scenarios: list[Scenario]) -> list[_Handler]:
@@ -113,7 +129,14 @@ def _build_handlers(scenarios: list[Scenario]) -> list[_Handler]:
         trigger = scenario.trigger
         if isinstance(trigger, (MessageTrigger, StreamingMessageTrigger)):
             code, raises = _render_actions(scenario)
-            handlers.append(_Handler(prefix=trigger.prefix, python_code=code, raises=raises))
+            handlers.append(
+                _Handler(
+                    prefix=trigger.prefix,
+                    python_code=code,
+                    raises=raises,
+                    needs_task=_needs_task(scenario),
+                )
+            )
     handlers.sort(key=lambda h: len(h.prefix), reverse=True)
     return handlers
 


### PR DESCRIPTION
Fixes #209.

Two commits: the import migration the issue reports, and a task-lifecycle fix that the migration turns out to require.

## 1. Import migration (`6448b12`)

`make codegen-a2a-python-sut` produced a SUT that failed at import, as reported. Migrating to the 1.x route-factory API surfaced three further call sites that had also drifted. Each was verified against the installed `a2a-sdk` 1.1.1 package rather than the SDK's main branch, since the two differ:

- `a2a.server.apps` (`A2AStarletteApplication`, `A2ARESTFastAPIApplication`) is gone. Routes are now built with `create_agent_card_routes` / `create_jsonrpc_routes` / `create_rest_routes` and mounted via `add_a2a_routes_to_fastapi`.
- `DefaultRequestHandler` is re-exported from `a2a.server.request_handlers`; the `default_request_handler` submodule now defines `LegacyRequestHandler` and `DefaultRequestHandlerV2`.
- `DefaultRequestHandlerV2.__init__` requires `agent_card`.
- `GrpcHandler.__init__` no longer takes an agent card.

The generated project gains the `fastapi` extra, because `add_a2a_routes_to_fastapi` raises `ImportError` without it, and the default SDK version is bumped to a release containing this API.

## 2. Task lifecycle (`89723b2`)

With the imports fixed the SUT boots, but most conformance scenarios still fail at runtime:

```
InvalidAgentResponseError: Agent should enqueue Task before TaskStatusUpdateEvent event
```

`ActiveTask._handle_task_modification_event` rejects a `TaskStatusUpdateEvent` when no task exists yet, and no generated handler enqueued the initial `Task`. Measured against real scenarios: `tck-stream-artifact-text` (starts with `start_work()`) and the default branch (`complete()`) both failed; `tck-artifact-file-url` passed only incidentally, because artifact events create the task on demand.

`submit()` is not the fix, since it publishes a `TaskStatusUpdateEvent` itself and hits the same guard. The task has to be enqueued as a `Task`.

The emitter derives `needs_task` from the scenario action model (`CompleteTask` / `UpdateTaskStatus`), and the template emits an `ensure_task()` guard only for those handlers. Handlers that only return a `Message` are deliberately excluded: creating a task for them would put the executor in task mode and make the following Message an error ("Received Message object in task mode"). `tck-message-response` is that case, and the generated output was checked to confirm it does not call `ensure_task()`.

This is what the "confirm `./run_tck.py` runs successfully against it" step in the issue needs in order to pass.

## Verification

Isolated Python 3.12 environment, `a2a-sdk` 1.1.1.

- Pre-fix reproduction from a clean clone: the reported `ModuleNotFoundError`.
- `ruff check .` clean; `pytest tests/unit` 253 passed.
- Regenerated SUT boots and serves all three transports: JSON-RPC (`SendMessage` then `GetTask` round-trip returning the same task id), REST (`GET /a2a/rest/tasks`), and gRPC (real stub call, not a port check).
- Error paths return structured errors rather than 500s or leaked tracebacks: malformed JSON body gives `-32700`, unknown task gives `-32001` on JSON-RPC and 404 on REST.
- Real scenario handlers: 1 of 3 sampled passed before the lifecycle commit, 3 of 3 after.
- Developer workflow end to end: with a sibling `a2a-python` checkout at `v1.1.1`, `uv sync` in the generated project succeeds and the SUT passes the same checks from its own resolved venv.

## One pre-existing note, not changed here

The generated `pyproject.toml` carries `[tool.uv.sources] a2a-sdk = { path = "../../../a2a-python" }`, from the existing `_DEFAULT_A2A_PYTHON_SDK_PATH`. Without a sibling `a2a-python` checkout, `uv sync` in the generated project fails with `Distribution not found`. Because that path source wins over the version constraint, the version bump only binds when `A2A_PYTHON_SDK_PATH` is overridden or the source block is dropped; in the default workflow the sibling checkout's version governs. Flagging it rather than changing it, since it looks deliberate for SDK development. Happy to adjust if you would rather the generated project resolve from PyPI by default.
