### PR TITLE
fix: bind expected_error on CORE-SEND-003 and CORE-MULTI-002a (#202)

### DIFF
--- a/tck/requirements/core_operations.py
+++ b/tck/requirements/core_operations.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 from tck.requirements.base import (
     CANCEL_TASK_BINDING,
+    CONTENT_TYPE_NOT_SUPPORTED_ERROR,
     GET_TASK_BINDING,
+    INVALID_PARAMS_ERROR,
     LIST_TASKS_BINDING,
     SEND_MESSAGE_BINDING,
     SEND_STREAMING_MESSAGE_BINDING,
@@ -105,6 +107,7 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
         binding=SEND_MESSAGE_BINDING,
         proto_request_type="SendMessageRequest",
         expected_behavior="ContentTypeNotSupportedError returned",
+        expected_error=CONTENT_TYPE_NOT_SUPPORTED_ERROR,
         spec_url=f"{SPEC_BASE}311-send-message",
         tags=[CORE, SEND_MESSAGE, ERROR],
         sample_input={
@@ -594,6 +597,7 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
         operation=OperationType.SEND_MESSAGE,
         binding=SEND_MESSAGE_BINDING,
         expected_behavior="Error returned when client contextId not accepted",
+        expected_error=INVALID_PARAMS_ERROR,
         spec_url=f"{SPEC_BASE}341-context-identifier-semantics",
         tags=[CORE, MULTI_TURN, CONTEXT, ERROR],
         sample_input={


### PR DESCRIPTION
## Problem (#202)

`CORE-SEND-003` and `CORE-MULTI-002a` assert MUST-level **error** responses, but neither sets `expected_error`. The parametrized runner in `tests/compatibility/core_operations/test_requirements.py` only validates the expected error when `requirement.expected_error is not None`; otherwise it falls through to the success path and reports `Operation failed: ...` for any error response. Both tests therefore demanded `response.success` — the exact inverse of the MUST they cite — and **no SUT could pass them**, regardless of how correct its error handling was.

## Fix

- **CORE-SEND-003** (SendMessage with an unsupported media type, spec §3.1.1) → `expected_error=CONTENT_TYPE_NOT_SUPPORTED_ERROR` (-32005).
- **CORE-MULTI-002a** (unacceptable client-provided contextId, spec §3.4.1) → `expected_error=INVALID_PARAMS_ERROR` (-32602). The spec mandates "reject the request with an error" without naming an A2A reserved error; the context id is a client-supplied parameter, so JSON-RPC Invalid params is the defensible binding.

## Verification

- Requirements registry resolves both bindings (`get_requirement_by_id`).
- Repo unit suite: **253/253 passed**.
- End-to-end against a live A2A broker that returns -32005 for unsupported media and -32602 for an unknown contextId: both runner tests now pass (**2 passed**, previously 2 failed).

Note for reviewers: implementations that reject an unacceptable contextId with a *different* error code than -32602 will newly fail CORE-MULTI-002a — that is the intended effect of the binding, but it is a behavior change for SUTs that previously "passed by skipping". Happy to adjust the binding choice if maintainers prefer a different mapping for §3.4.1.

Closes #202