### PR TITLE
test: verify blocking vs non-blocking sendMessage behaviour (#85)

### DIFF
--- a/scenarios/core_operations.feature
+++ b/scenarios/core_operations.feature
@@ -14,14 +14,26 @@ Feature: Core Operations
   # ---------------------------------------------------------------------------
 
   # Default behavior: complete the task with a message.
-  # Used by: CORE-SEND-001, CORE-SEND-002 (setup), CORE-EXECUTION-MODE-001,
-  # CORE-EXECUTION-MODE-002, CORE-MULTI-001/001a/002/002a/003,
+  # Used by: CORE-SEND-001, CORE-SEND-002 (setup),
+  # CORE-MULTI-001/001a/002/002a/003,
   # CORE-GET-001 (setup), CORE-CANCEL-002 (setup), CORE-MULTI-005/006 (setup),
   # STREAM-SUB-002/003 (setup),
   # CORE-HIST-001/002/003/004 (setup — history tests use completed task).
   Scenario: Complete the task
     When a message is received with prefix "tck-complete-task"
     Then complete the task with the message "Hello from TCK"
+
+  # Used by: CORE-EXECUTION-MODE-001, CORE-EXECUTION-MODE-002.
+  # The task stays in a non-terminal (working) state for a bounded delay
+  # before completing.  A blocking send must wait for the terminal state,
+  # while a non-blocking send must return while the task is still working,
+  # so the two produce observably different responses.  A server that
+  # ignores the returnImmediately flag cannot satisfy both.
+  Scenario: Work before completing the task
+    When a message is received with prefix "tck-delayed-complete"
+    Then update the task status to "working"
+    And wait for 1x streaming timeout
+    And complete the task with the message "Done after delay"
 
   # CORE-SEND-003: ContentTypeNotSupportedError is detected by the SDK framework
   # based on the agent card's supported input content types. No executor scenario needed.

--- a/sut/a2a-jakarta/src/main/java/org/a2aproject/jakarta/sdk/sut/TckAgentExecutorProducer.java
+++ b/sut/a2a-jakarta/src/main/java/org/a2aproject/jakarta/sdk/sut/TckAgentExecutorProducer.java
@@ -75,6 +75,13 @@ public class TckAgentExecutorProducer {
                     return;
                 }
 
+                if (messageId.startsWith("tck-delayed-complete")) {
+                    emitter.startWork();
+                    try { Thread.sleep(2000); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+                    emitter.complete(A2A.toAgentMessage("Done after delay"));
+                    return;
+                }
+
                 if (messageId.startsWith("tck-message-response")) {
                     emitter.sendMessage(List.of(new TextPart("Direct message response")));
                     return;

--- a/sut/a2a-python/sut_agent.py
+++ b/sut/a2a-python/sut_agent.py
@@ -109,6 +109,12 @@ class TckAgentExecutor(AgentExecutor):
             await updater.complete()
             return
 
+        if message_id.startswith('tck-delayed-complete'):
+            await updater.start_work()
+            await asyncio.sleep(2)
+            await updater.complete(updater.new_agent_message([Part(text="Done after delay")]))
+            return
+
         if message_id.startswith('tck-message-response'):
             await event_queue.enqueue_event(updater.new_agent_message([Part(text="Direct message response")]))
             return

--- a/tck/requirements/core_operations.py
+++ b/tck/requirements/core_operations.py
@@ -399,12 +399,14 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
         proto_response_type="SendMessageResponse",
         expected_behavior="Response delayed until terminal or interrupted state",
         spec_url=f"{SPEC_BASE}322-sendmessageconfiguration",
-        tags=[CORE, EXECUTION_MODE],
+        # Covered by the dedicated behavioural test in test_execution_mode.py
+        # (MULTI_OPERATION excludes it from the schema-only generic runner).
+        tags=[CORE, EXECUTION_MODE, MULTI_OPERATION],
         sample_input={
             "message": {
                 "role": "ROLE_USER",
                 "parts": [{"text": "Blocking request"}],
-                "messageId": tck_id("complete-task"),
+                "messageId": tck_id("delayed-complete"),
             },
             "configuration": {"returnImmediately": False},
         },
@@ -424,12 +426,14 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
         proto_response_type="SendMessageResponse",
         expected_behavior="Response returned immediately with in-progress state",
         spec_url=f"{SPEC_BASE}322-sendmessageconfiguration",
-        tags=[CORE, EXECUTION_MODE],
+        # Covered by the dedicated behavioural test in test_execution_mode.py
+        # (MULTI_OPERATION excludes it from the schema-only generic runner).
+        tags=[CORE, EXECUTION_MODE, MULTI_OPERATION],
         sample_input={
             "message": {
                 "role": "ROLE_USER",
                 "parts": [{"text": "Non-blocking request"}],
-                "messageId": tck_id("complete-task"),
+                "messageId": tck_id("delayed-complete"),
             },
             "configuration": {"returnImmediately": True},
         },

--- a/tests/compatibility/_test_helpers.py
+++ b/tests/compatibility/_test_helpers.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from tck.requirements.base import TERMINAL_STATES
+
 
 if TYPE_CHECKING:
     from tck.requirements.base import ErrorBinding, RequirementSpec
@@ -29,6 +31,48 @@ def expected_error_of(req: RequirementSpec) -> ErrorBinding:
     if req.expected_error is None:
         raise AssertionError(f"{req.id} does not declare an expected_error")
     return req.expected_error
+
+
+_GRPC_TERMINAL_STATES = frozenset(s.grpc_value for s in TERMINAL_STATES)
+
+_JSON_TERMINAL_STATES = frozenset(s.json_value for s in TERMINAL_STATES)
+
+
+def is_terminal_status(response: Any, transport: str) -> bool:
+    """Return True if *response* carries a task in a terminal state.
+
+    Handles both the ``SendMessageResponse`` payload oneof (gRPC) or
+    ``result`` envelope (JSON-RPC) and a bare ``Task`` returned by
+    GetTask/CancelTask.
+    """
+    raw = response.raw_response
+    if transport == "grpc":
+        # SendMessageResponse has a "payload" oneof; Task proto does not.
+        try:
+            payload = raw.WhichOneof("payload")
+            if payload == "task":
+                return raw.task.status.state in _GRPC_TERMINAL_STATES
+        except (ValueError, AttributeError):
+            pass
+        # Task proto returned directly (GetTask, CancelTask)
+        if hasattr(raw, "status"):
+            return raw.status.state in _GRPC_TERMINAL_STATES
+        return False
+
+    # JSON-RPC or HTTP+JSON
+    if not isinstance(raw, dict):
+        return False
+    if transport == "jsonrpc":
+        result = raw.get("result", {})
+        task = result.get("task", result) if isinstance(result, dict) else {}
+    else:
+        task = raw.get("task", raw)
+
+    if isinstance(task, dict):
+        status = task.get("status", {})
+        state = status.get("state", "") if isinstance(status, dict) else ""
+        return state in _JSON_TERMINAL_STATES
+    return False
 
 
 def fail_msg(req: RequirementSpec, transport: str, detail: str) -> str:

--- a/tests/compatibility/core_operations/test_execution_mode.py
+++ b/tests/compatibility/core_operations/test_execution_mode.py
@@ -1,0 +1,128 @@
+"""Execution-mode (blocking vs non-blocking) behaviour tests.
+
+The generic requirement runner only checks that a ``SendMessage`` response is
+well-formed, so a server that ignores the ``returnImmediately`` configuration
+flag still passes it.  These tests drive the ``tck-delayed-complete`` SUT
+scenario, which holds the task in a non-terminal ``working`` state for a bounded
+delay before completing, so blocking and non-blocking sends produce observably
+different responses.
+
+Requirements tested:
+    CORE-EXECUTION-MODE-001: blocking send waits for a terminal/interrupted state
+    CORE-EXECUTION-MODE-002: non-blocking send returns before the task completes
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from tck.requirements.base import tck_id
+from tck.requirements.registry import get_requirement_by_id
+from tck.transport import ALL_TRANSPORTS
+from tests.compatibility._test_helpers import (
+    assert_and_record,
+    get_client,
+    is_terminal_status,
+)
+from tests.compatibility.markers import must
+
+
+if TYPE_CHECKING:
+    from tck.transport.base import BaseTransportClient
+
+
+# ---------------------------------------------------------------------------
+# Requirement lookups
+# ---------------------------------------------------------------------------
+
+CORE_EXECUTION_MODE_001 = get_requirement_by_id("CORE-EXECUTION-MODE-001")
+CORE_EXECUTION_MODE_002 = get_requirement_by_id("CORE-EXECUTION-MODE-002")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _delayed_message() -> dict[str, Any]:
+    """Build a message that routes to the delayed-complete SUT scenario."""
+    return {
+        "role": "ROLE_USER",
+        "parts": [{"text": "Execution-mode probe"}],
+        "messageId": tck_id("delayed-complete"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@must
+@pytest.mark.parametrize("transport", ALL_TRANSPORTS)
+class TestExecutionMode:
+    """Tests for blocking vs non-blocking SendMessage behaviour."""
+
+    def test_blocking_waits_for_terminal_state(
+        self,
+        transport: str,
+        transport_clients: dict[str, BaseTransportClient],
+        compatibility_collector: Any,
+    ) -> None:
+        """CORE-EXECUTION-MODE-001: a blocking send waits for a terminal state.
+
+        With ``returnImmediately`` false the server must not return until the
+        task reaches a terminal (or interrupted) state.  A server that ignores
+        the flag returns while the task is still ``working`` and fails here.
+        """
+        req = CORE_EXECUTION_MODE_001
+        client = get_client(transport_clients, transport, compatibility_collector=compatibility_collector, req=req)
+
+        response = client.send_message(
+            message=_delayed_message(),
+            configuration={"returnImmediately": False},
+        )
+
+        errors: list[str] = []
+        if not response.success:
+            errors.append(f"Blocking send_message failed: {response.error}")
+        elif not is_terminal_status(response, transport):
+            errors.append(
+                "Blocking send_message (returnImmediately=false) returned before "
+                "the task reached a terminal state"
+            )
+
+        assert_and_record(compatibility_collector, req, transport, errors)
+
+    def test_non_blocking_returns_before_completion(
+        self,
+        transport: str,
+        transport_clients: dict[str, BaseTransportClient],
+        compatibility_collector: Any,
+    ) -> None:
+        """CORE-EXECUTION-MODE-002: a non-blocking send returns immediately.
+
+        With ``returnImmediately`` true the server must return while the task
+        is still in progress.  A server that ignores the flag blocks until the
+        task is terminal and fails here.
+        """
+        req = CORE_EXECUTION_MODE_002
+        client = get_client(transport_clients, transport, compatibility_collector=compatibility_collector, req=req)
+
+        response = client.send_message(
+            message=_delayed_message(),
+            configuration={"returnImmediately": True},
+        )
+
+        errors: list[str] = []
+        if not response.success:
+            errors.append(f"Non-blocking send_message failed: {response.error}")
+        elif is_terminal_status(response, transport):
+            errors.append(
+                "Non-blocking send_message (returnImmediately=true) did not return "
+                "until the task reached a terminal state"
+            )
+
+        assert_and_record(compatibility_collector, req, transport, errors)


### PR DESCRIPTION
## What

Adds behavioural conformance coverage for the `returnImmediately` (blocking vs
non-blocking) execution mode of `SendMessage`, closing #85.

## Why

CORE-EXECUTION-MODE-001 and -002 already existed but were only exercised by the
generic requirement runner, which dispatches the sample input and checks that the
response is a well-formed `SendMessageResponse`. Both requirements used the
`tck-complete-task` scenario, which completes the task immediately, so a server
that ignores `returnImmediately` returns `completed` either way and passes. This
is exactly the gap #85 describes: before a2a-java#327 the Java SDK ignored blocking
and still passed the TCK.

## How

- New SUT scenario `tck-delayed-complete` (`scenarios/core_operations.feature`):
  the task goes to `working`, waits one streaming-timeout unit (2s in the generated
  Python SUT), then completes. The task is therefore briefly non-terminal, so a
  blocking send and a non-blocking send produce observably different responses.
  The Python and Jakarta SUTs are regenerated to add the handler.
- CORE-EXECUTION-MODE-001/002 are tagged `MULTI_OPERATION` so the schema-only
  generic runner skips them, matching how the other behavioural requirements
  (CORE-GET-001, CORE-CANCEL-001, CORE-MULTI-005, ...) are handled, and their
  sample input is repointed at the delayed scenario.
- New dedicated test `tests/compatibility/core_operations/test_execution_mode.py`:
  - blocking (`returnImmediately=false`) must return a task in a terminal state.
    A server that ignores the flag returns while still `working` and fails.
  - non-blocking (`returnImmediately=true`) must return before the task completes.
    A server that always blocks returns `completed` and fails.
  - a shared `is_terminal_status` helper is added to `_test_helpers.py`.

The distinguishing signal is the SUT scenario state (working vs completed), driven
by a deterministic server-side delay, so there is no timing-based flakiness.

## Validation

Clean `python:3.12-slim` container, base main:

- `make lint unit-test`: ruff clean, 253 unit tests pass.
- Against the a2a-python reference SUT: both tests pass on grpc, jsonrpc and
  http_json (6 passed). Blocking returns after ~2s in `completed`; non-blocking
  returns in ~0s in `working`.
- Teeth: patching the SDK handler to ignore `returnImmediately` makes the blocking
  test fail on all three transports; forcing it to always block makes the
  non-blocking test fail on all three. Restoring the handler returns to all green.

Closes #85.