### PR TITLE
fix(reporting): don't count NOT TESTED requirements as compatible

### DIFF
--- a/tck/reporting/aggregator.py
+++ b/tck/reporting/aggregator.py
@@ -65,6 +65,16 @@ class CompatibilityAggregator:
     where it was tested.  Compatibility for a given level is the percentage
     of requirements at that level which pass.  When no requirements exist
     for a level the compatibility is 100.0 (nothing to fail).
+
+    A requirement that was registered but never exercised (``NOT TESTED`` —
+    e.g. the SUT never responded, or crashed before the test ran) counts
+    against compatibility the same as a failure would: it is *not* excluded
+    from the denominator.  Only ``SKIPPED`` requirements (legitimately
+    inapplicable to this SUT, e.g. an optional capability it doesn't
+    implement) are excluded.  Otherwise an unreachable SUT that answers zero
+    requests can report 100% compatibility on the handful of requirements
+    that happened to produce a result before every other one silently
+    dropped out of the denominator as "not tested".
     """
 
     def __init__(
@@ -197,7 +207,7 @@ class CompatibilityAggregator:
             if level is None
             else [r for r in per_requirement.values() if r.level == level]
         )
-        reqs = [r for r in reqs if r.status not in ("SKIPPED", "NOT TESTED")]
+        reqs = [r for r in reqs if r.status != "SKIPPED"]
         if not reqs:
             return 100.0
         passing = sum(1 for r in reqs if r.status == "PASS")

--- a/tests/unit/reporting/test_aggregator.py
+++ b/tests/unit/reporting/test_aggregator.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from tck.reporting.aggregator import CompatibilityAggregator
 from tck.reporting.collector import CompatibilityCollector
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 FULL = 100.0
@@ -19,6 +24,21 @@ ZERO = 0.0
 def collector() -> CompatibilityCollector:
     """Return a fresh CompatibilityCollector."""
     return CompatibilityCollector()
+
+
+@pytest.fixture(autouse=True)
+def _empty_registry() -> Iterator[None]:
+    """Keep aggregator tests hermetic against the real ~129-requirement registry.
+
+    Since GH-214, NOT TESTED requirements count against compatibility, so any
+    test that doesn't explicitly care about untested-registry behavior must
+    not have the real ALL_REQUIREMENTS registry silently mixed into its
+    counts. Tests that do care (``TestUntestedRequirements``) patch their own
+    fake registry inside a nested ``with``, which overrides this one for the
+    duration of that block.
+    """
+    with patch("tck.requirements.registry.ALL_REQUIREMENTS", []):
+        yield
 
 
 class TestEmptyCollector:
@@ -277,8 +297,13 @@ class TestUntestedRequirements:
         assert untested.transports == {}
         assert untested.description == "Description for R-UNTESTED"
 
-    def test_untested_excluded_from_compatibility(self, collector: CompatibilityCollector) -> None:
-        """NOT TESTED requirements do not affect compatibility percentages."""
+    def test_untested_counts_against_compatibility(self, collector: CompatibilityCollector) -> None:
+        """NOT TESTED requirements count against compatibility, like a failure.
+
+        Regression test for GH-214: a requirement that was registered but
+        never exercised must not be silently excluded from the denominator —
+        otherwise a SUT that answers almost nothing can still report 100%.
+        """
         fake_registry = [
             self._make_spec("R1", "MUST"),
             self._make_spec("R-UNTESTED", "MUST"),
@@ -288,8 +313,27 @@ class TestUntestedRequirements:
         with patch("tck.requirements.registry.ALL_REQUIREMENTS", fake_registry):
             report = CompatibilityAggregator(collector).aggregate()
 
-        assert report.must_compatibility == FULL
-        assert report.overall_compatibility == FULL
+        assert report.must_compatibility == HALF
+        assert report.overall_compatibility == HALF
+
+    def test_unreachable_sut_does_not_report_full_compatibility(
+        self, collector: CompatibilityCollector
+    ) -> None:
+        """A SUT that never responds must not report vacuous 100% compatibility.
+
+        Reproduces the exact shape of GH-214's repro: a handful of
+        requirements happen to pass (e.g. a health check answered before the
+        rest of the run timed out) while the vast majority never ran.
+        """
+        fake_registry = [self._make_spec(f"R{i}", "MUST") for i in range(129)]
+        for i in range(4):
+            collector.record(requirement_id=f"R{i}", transport="http", passed=True, level="MUST")
+
+        with patch("tck.requirements.registry.ALL_REQUIREMENTS", fake_registry):
+            report = CompatibilityAggregator(collector).aggregate()
+
+        assert report.must_compatibility != FULL
+        assert report.must_compatibility == pytest.approx(4 / 129 * 100.0)
 
     def test_tested_requirement_not_overwritten(self, collector: CompatibilityCollector) -> None:
         """A requirement that was tested keeps its actual result."""

--- a/tests/unit/reporting/test_console_formatter.py
+++ b/tests/unit/reporting/test_console_formatter.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
 import pytest
 
 from tck.reporting.aggregator import CompatibilityAggregator
@@ -9,10 +12,26 @@ from tck.reporting.collector import CompatibilityCollector
 from tck.reporting.console_formatter import ConsoleFormatter
 
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
 @pytest.fixture
 def collector() -> CompatibilityCollector:
     """Return a fresh CompatibilityCollector."""
     return CompatibilityCollector()
+
+
+@pytest.fixture(autouse=True)
+def _empty_registry() -> Iterator[None]:
+    """Keep formatter tests hermetic against the real ~129-requirement registry.
+
+    Since GH-214, NOT TESTED requirements count against compatibility, so an
+    unpatched test would get diluted by every real requirement the collector
+    didn't record a result for.
+    """
+    with patch("tck.requirements.registry.ALL_REQUIREMENTS", []):
+        yield
 
 
 @pytest.fixture

--- a/tests/unit/reporting/test_html_formatter.py
+++ b/tests/unit/reporting/test_html_formatter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -12,6 +13,7 @@ from tck.reporting.html_formatter import HTMLFormatter
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 
@@ -19,6 +21,18 @@ if TYPE_CHECKING:
 def collector() -> CompatibilityCollector:
     """Return a fresh CompatibilityCollector."""
     return CompatibilityCollector()
+
+
+@pytest.fixture(autouse=True)
+def _empty_registry() -> Iterator[None]:
+    """Keep formatter tests hermetic against the real ~129-requirement registry.
+
+    Since GH-214, NOT TESTED requirements count against compatibility, so an
+    unpatched test would get diluted by every real requirement the collector
+    didn't record a result for.
+    """
+    with patch("tck.requirements.registry.ALL_REQUIREMENTS", []):
+        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes #214 — `CompatibilityAggregator._compute_compatibility()` excluded both `SKIPPED` and `NOT TESTED` requirements from its denominator. `SKIPPED` is correct to exclude (the requirement legitimately doesn't apply to this SUT — e.g. an optional capability it doesn't implement). `NOT TESTED` means something different: the requirement was never exercised at all, whether because the SUT was unreachable, the run crashed early, or (see #215) a test errored before calling `record()`.

Excluding `NOT TESTED` from the denominator let a SUT that answers almost nothing report near-100% compatibility on the small number of requirements that happened to produce a result before everything else silently dropped out of the calculation.

## Change

One-line functional change in `tck/reporting/aggregator.py`: `NOT TESTED` requirements now count against compatibility the same as a `FAIL` would; only `SKIPPED` is excluded from the denominator. Updated the class docstring to document this explicitly.

The rest of the diff makes the existing unit tests in `tests/unit/reporting/` hermetic against the real ~129-requirement registry. Several tests didn't patch `tck.requirements.registry.ALL_REQUIREMENTS`, so `_add_untested_requirements()` was silently merging the live global registry into their `per_requirement` results. This was invisible before (since `NOT TESTED` didn't affect the percentage), but became visible once the fix landed — those tests started failing because the real registry's untested entries now count. I added an `autouse` fixture (`_empty_registry`) to `test_aggregator.py`, `test_console_formatter.py`, and `test_html_formatter.py` that patches the registry to `[]` by default; the tests in `TestUntestedRequirements` that specifically exercise registry-merge behavior already patch their own fake registry inside a nested `with`, which overrides the outer patch for the duration of that block.

Also updated `test_untested_excluded_from_compatibility` (renamed `test_untested_counts_against_compatibility`) since it was asserting the exact behavior this issue reports as a bug, and added `test_unreachable_sut_does_not_report_full_compatibility`, which reproduces the numeric shape of the issue's own repro (4 passed / 125 not tested → ~3.1%, not 100%).

## Test plan

- [x] `tests/unit/reporting/` (87 tests): all pass
- [x] `tests/unit/` (full unit suite, 259 tests): all pass
- [x] `ruff check` on all changed files: all checks passed
- [x] Empirically verified against a live local reference SUT: a single-test isolated run (1/129 requirements exercised) that used to report inflated compatibility now correctly reports a low number reflecting actual coverage