### PR TITLE
fix(conftest): recover req/transport from crashed-frame locals in safety net

### DIFF
--- a/tests/compatibility/conftest.py
+++ b/tests/compatibility/conftest.py
@@ -247,6 +247,45 @@ def _extract_requirement_and_transport(
     return requirement_id, transport
 
 
+def _extract_from_crashed_frame(
+    item: pytest.Item, call: pytest.CallInfo[None]
+) -> tuple[str | None, str | None]:
+    """Recover ``(requirement_id, transport)`` from the crashed frame's locals.
+
+    Fallback for when ``_extract_requirement_and_transport`` comes up empty.
+    That happens whenever a test's *class* docstring documents the
+    requirement ID but the individual *method* docstring doesn't (a common
+    pattern in this suite — see e.g. ``TestCapabilityStreaming``), or the
+    transport is a hardcoded local rather than a parametrize/marker (as in
+    tests that need a raw client for a specific transport, like
+    ``test_streaming_not_supported_jsonrpc``). Every compatibility test
+    assigns ``req = <REQUIREMENT_CONST>`` before doing any I/O that could
+    raise, so the crashed frame's own locals are ground truth for what the
+    test was actually checking — the same object it would have passed to
+    ``record()``/``assert_and_record()`` had it gotten that far.
+    """
+    excinfo = call.excinfo
+    if excinfo is None:
+        return None, None
+    func = getattr(item, "function", None)
+    func_code = getattr(func, "__code__", None)
+    if func_code is None:
+        return None, None
+
+    tb = excinfo.tb
+    while tb is not None:
+        frame = tb.tb_frame
+        if frame.f_code is func_code:
+            req = frame.f_locals.get("req")
+            transport = frame.f_locals.get("transport")
+            requirement_id = getattr(req, "id", None)
+            if not isinstance(transport, str):
+                transport = None
+            return requirement_id, transport
+        tb = tb.tb_next
+    return None, None
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(
     item: pytest.Item, call: pytest.CallInfo[None]
@@ -270,6 +309,13 @@ def pytest_runtest_makereport(
         return
     if report.passed:
         return
+    if report.skipped:
+        # A bare pytest.skip() with no prior record() is a deliberate,
+        # untracked skip (e.g. "this check doesn't apply here") — not a
+        # crash. Auto-recording it as a FAIL would misrepresent it; leave it
+        # to surface as NOT TESTED via the registry gap-fill, same as before
+        # the crashed-frame fallback below existed.
+        return
 
     before = item.stash.get(_record_count_key, None)
     if before is None:
@@ -279,6 +325,10 @@ def pytest_runtest_makereport(
         return
 
     requirement_id, transport = _extract_requirement_and_transport(item)
+    if requirement_id is None or transport is None:
+        frame_requirement_id, frame_transport = _extract_from_crashed_frame(item, call)
+        requirement_id = requirement_id or frame_requirement_id
+        transport = transport or frame_transport
     if requirement_id is None or transport is None:
         return
 

--- a/tests/unit/reporting/test_safety_net_hook.py
+++ b/tests/unit/reporting/test_safety_net_hook.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+import sys
+
+from types import SimpleNamespace, TracebackType
 from unittest.mock import MagicMock
 
 import pytest
 
 # The helper lives in a conftest, so import it via its module path.
-from tests.compatibility.conftest import _extract_requirement_and_transport
+from tests.compatibility.conftest import (
+    _extract_from_crashed_frame,
+    _extract_requirement_and_transport,
+)
 
 
 def _make_item(
@@ -103,3 +108,76 @@ class TestExtractRequirementAndTransport:
         req_id, transport = _extract_requirement_and_transport(item)
         assert req_id == "CORE-GET-001"
         assert transport == "http_json"
+
+
+def _crash_with_locals(req: object, transport: object) -> None:
+    """Assign req/transport as real locals, then raise.
+
+    Mirrors the shape of a compatibility test that crashes before its own
+    record() call.
+    """
+    raise ValueError("simulated crash before record()")
+
+
+def _get_traceback(**kwargs: object) -> TracebackType:
+    """Run _crash_with_locals and return the traceback of the raised exception."""
+    try:
+        _crash_with_locals(**kwargs)
+    except ValueError:
+        return sys.exc_info()[2]
+    raise AssertionError("expected _crash_with_locals to raise")
+
+
+class TestExtractFromCrashedFrame:
+    """_extract_from_crashed_frame recovers metadata the docstring path misses."""
+
+    def test_recovers_req_id_and_transport_from_locals(self) -> None:
+        """A req local with an .id attribute and a string transport local are both found."""
+        req = SimpleNamespace(id="CORE-CAP-002")
+        tb = _get_traceback(req=req, transport="jsonrpc")
+        item = SimpleNamespace(function=_crash_with_locals)
+        call = SimpleNamespace(excinfo=SimpleNamespace(tb=tb))
+
+        req_id, transport = _extract_from_crashed_frame(item, call)
+        assert req_id == "CORE-CAP-002"
+        assert transport == "jsonrpc"
+
+    def test_no_req_local_returns_none_id(self) -> None:
+        """Missing req local yields a None requirement ID, not a crash."""
+        tb = _get_traceback(req=None, transport="jsonrpc")
+        item = SimpleNamespace(function=_crash_with_locals)
+        call = SimpleNamespace(excinfo=SimpleNamespace(tb=tb))
+
+        req_id, transport = _extract_from_crashed_frame(item, call)
+        assert req_id is None
+        assert transport == "jsonrpc"
+
+    def test_non_string_transport_local_returns_none(self) -> None:
+        """A transport local that isn't a string (e.g. left at its default None) is ignored."""
+        req = SimpleNamespace(id="CORE-CAP-002")
+        tb = _get_traceback(req=req, transport=None)
+        item = SimpleNamespace(function=_crash_with_locals)
+        call = SimpleNamespace(excinfo=SimpleNamespace(tb=tb))
+
+        req_id, transport = _extract_from_crashed_frame(item, call)
+        assert req_id == "CORE-CAP-002"
+        assert transport is None
+
+    def test_no_excinfo_returns_none_none(self) -> None:
+        """A call with no exception info (shouldn't normally happen) is a no-op."""
+        item = SimpleNamespace(function=_crash_with_locals)
+        call = SimpleNamespace(excinfo=None)
+
+        req_id, transport = _extract_from_crashed_frame(item, call)
+        assert req_id is None
+        assert transport is None
+
+    def test_no_function_returns_none_none(self) -> None:
+        """An item with no function attribute is a no-op."""
+        tb = _get_traceback(req=SimpleNamespace(id="X-Y-001"), transport="grpc")
+        item = SimpleNamespace(function=None)
+        call = SimpleNamespace(excinfo=SimpleNamespace(tb=tb))
+
+        req_id, transport = _extract_from_crashed_frame(item, call)
+        assert req_id is None
+        assert transport is None


### PR DESCRIPTION
## Summary

Fixes #215 — the existing `pytest_runtest_makereport` safety net (which auto-records a `FAIL` when a test crashes before calling `record()`) can only find the requirement ID and transport via `_extract_requirement_and_transport()`, which reads the test *method's* docstring plus parametrize/marker metadata. That lookup fails for a real, reproducible subset of tests:

- The requirement ID is documented on the **class** docstring, not the method's — e.g. `TestCapabilityStreaming` has `"""CORE-CAP-002: Streaming operations return error when not supported."""` at class level, while `test_streaming_not_supported_jsonrpc`'s own docstring is plain prose with no ID in it.
- The transport is a hardcoded local (`transport = "jsonrpc"`) rather than a `parametrize`/marker, which several tests need when they require a raw client for one specific transport.

When both lookups come up empty, the safety net silently gives up — which is exactly this issue's repro: a server that processes `SendStreamingMessage` despite declaring `capabilities.streaming: false` makes `test_streaming_not_supported_jsonrpc` crash with `JSONDecodeError` (parsing an SSE stream as JSON) before its own `assert_and_record()` call, and `CORE-CAP-002` disappears from the report as `NOT TESTED` instead of surfacing as `FAIL`.

## Fix

Every compatibility test assigns `req = <REQUIREMENT_CONST>` (and usually `transport = "..."`) before doing any I/O that could raise — it's the exact object the test would have passed to `record()`/`assert_and_record()` had it reached that call. Added `_extract_from_crashed_frame()`, which walks the exception traceback for the frame belonging to the test function itself and reads `req`/`transport` directly out of its locals, as a fallback when the docstring/marker path returns `(None, None)`. This needs no change to any test's docstring and generalizes to any test with this shape — confirmed empirically below on a *second*, different test in the same file that turned out to share the exact same crash pattern.

**Guard against a hazard this introduces:** the fallback also widens the net to `pytest.skip()` outcomes with no prior `record()` call — several tests call bare `pytest.skip()` without recording first (a legitimate, deliberate skip, e.g. "server doesn't enforce this header"). Before this fix, those were invisible to the old lookup too (same docstring/marker gap), so nothing mistook them for failures; my fallback would have started auto-recording them as `FAIL`. Added `report.skipped` as an explicit short-circuit before the fallback runs, so bare skips stay invisible (falling back to `NOT TESTED` via the registry gap-fill) exactly as before.

## Test plan

- [x] Unit: `tests/unit/reporting/test_safety_net_hook.py` — 5 new tests for `_extract_from_crashed_frame` (recovers both locals; missing `req`; non-string `transport`; no `excinfo`; no `function`), all pass alongside the 6 existing tests for the docstring/marker path
- [x] `tests/unit/` (full unit suite, 259 tests): all pass
- [x] `ruff check` on both changed files: all checks passed
- [x] **Empirical, against a live local reference SUT mutated to violate `CORE-CAP-002`** (streaming processed despite an undeclared capability — the exact scenario from this issue): before this fix, `compatibility.json` shows `"CORE-CAP-002": {"status": "NOT TESTED", "errors": []}`. After this fix, the same run shows `"status": "FAIL"` with the actual `JSONDecodeError` traceback captured as the error — and a *second*, previously-unnoticed test in the same file (`test_unsupported_operation_error`) that shares the identical crash shape also flips from silently missing to correctly reported, which is exactly the "not a one-off" structural claim in the issue body.
- [x] Full compatibility suite (188 passed, 47 skipped, 0 failed) against an unmutated reference SUT to confirm no regression: no bare-skip test was misrecorded as a `FAIL`.