### PR TITLE
fix(jsonrpc): send a valid JSON body in the wrong-Content-Type test

### DIFF
--- a/tests/compatibility/jsonrpc/test_error_codes.py
+++ b/tests/compatibility/jsonrpc/test_error_codes.py
@@ -9,6 +9,8 @@ Requirements tested:
 
 from __future__ import annotations
 
+import json
+
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -218,7 +220,12 @@ class TestJsonRpcErrorCodeMappings:
         }
         response = httpx.post(
             client.base_url,
-            content=str(payload).encode(),
+            # json.dumps, not str(): a bare str(dict) is Python repr (single
+            # quotes), not valid JSON — that made the body itself unparseable
+            # independent of the deliberately-wrong Content-Type header below,
+            # so a server correctly returned ParseError (-32700) for reasons
+            # unrelated to what this test means to exercise (GH-216).
+            content=json.dumps(payload).encode(),
             headers={"Content-Type": "text/plain", A2A_VERSION_HEADER: A2A_VERSION},
         )
 


### PR DESCRIPTION
## Summary

Fixes (partially) #216 — `test_content_type_not_supported_error` built its request body with `str(payload).encode()` on a Python `dict`. `str(dict)` produces Python repr (single-quoted keys: `{'jsonrpc': '2.0', ...}`), which is not valid JSON. `json.loads(str(payload))` raises `JSONDecodeError: Expecting property name enclosed in double quotes`.

That means the request body was unparseable independent of the deliberately-wrong `Content-Type: text/plain` header this test means to exercise. A server that correctly parses JSON has no way to single out `ContentTypeNotSupportedError` for this specific request — the body itself is malformed, so a generic `ParseError` (-32700) is the more defensible response, for reasons that have nothing to do with what the test is meant to check. This matches the issue's reproduction exactly (`AssertionError: ... expected ContentTypeNotSupportedError (-32005), got ParseError (-32700)`).

## Fix

Switched to `json.dumps(payload).encode()`, so the envelope is valid JSON and only the `Content-Type` header is wrong — matching the test's own stated intent ("Raw call needed: deliberately wrong Content-Type header").

## What this PR deliberately does NOT touch

The issue raised a second, separate concern: whether `ContentTypeNotSupportedError` — spec'd (`specification.md:561`, `:1188`) against a message `Part`'s `media_type`, not the HTTP transport envelope — is even the right error to expect for a wrong Content-Type *header* at all. I flagged that in the issue as a question for a maintainer ("Happy to send a PR for either interpretation if a maintainer can confirm which one was intended") and haven't gotten a response yet, so this PR doesn't guess at an answer. It only fixes the unambiguous bug: the test body must be valid JSON regardless of which interpretation is correct. Once there's a maintainer steer on the semantic-target question, I'm happy to follow up.

## Test plan

- [x] Ran the test in isolation against a live local reference SUT: previously it hit `pytest.skip("Server returned non-JSON response...")` via a try/except around the malformed body's own parse failure being conflated with the server's response; now the *request* body parses cleanly and the test correctly observes the server's actual behavior (in this SUT's case, it ignores the wrong Content-Type entirely and processes the request — the test correctly `pytest.skip()`s with "Server did not return an error for wrong Content-Type", a legitimate skip, not a masked crash).
- [x] Ran the full `test_error_codes.py` + `test_error_handling.py` modules together against the same reference SUT: 24 passed, 8 skipped, 0 failed.
- [x] `ruff check` on the changed lines: clean (two pre-existing `ISC004` findings elsewhere in this file, unrelated to this change, left untouched).