### PR TITLE
fix(sut): update a2a-python reference SUT for the current SDK routing API

### DIFF
--- a/codegen/a2a-python/sut_agent.py.j2
+++ b/codegen/a2a-python/sut_agent.py.j2
@@ -17,17 +17,17 @@ from starlette.applications import Starlette
 
 import a2a.types.a2a_pb2_grpc as a2a_grpc
 
+from a2a.helpers.proto_helpers import new_task_from_user_message
 from a2a.server.agent_execution.agent_executor import AgentExecutor
 from a2a.server.agent_execution.context import RequestContext
-from a2a.server.apps import (
-    A2ARESTFastAPIApplication,
-    A2AStarletteApplication,
-)
 from a2a.server.events.event_queue import EventQueue
-from a2a.server.request_handlers.default_request_handler import (
-    DefaultRequestHandler,
-)
+from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.request_handlers.grpc_handler import GrpcHandler
+from a2a.server.routes import (
+    create_agent_card_routes,
+    create_jsonrpc_routes,
+    create_rest_routes,
+)
 from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.server.tasks.task_updater import TaskUpdater
 from a2a.types import (
@@ -38,11 +38,7 @@ from a2a.types import (
     AgentSkill,
     Part,
 )
-from a2a.utils.errors import (
-    A2AError,
-    TaskNotCancelableError,
-    UnsupportedOperationError,
-)
+from a2a.utils.errors import A2AError
 
 REST_URL = '/a2a/rest'
 
@@ -71,6 +67,9 @@ class TckAgentExecutor(AgentExecutor):
                 updater.new_agent_message([Part(text='No message provided')])
             )
             return
+
+        if context.current_task is None:
+            await event_queue.enqueue_event(new_task_from_user_message(message))
 
         message_id = message.message_id
         {% for handler in handlers %}
@@ -157,24 +156,26 @@ async def main() -> None:
     request_handler = DefaultRequestHandler(
         agent_executor=TckAgentExecutor(),
         task_store=task_store,
-    )
-
-    main_app = Starlette()
-
-    # JSON-RPC
-    jsonrpc_server = A2AStarletteApplication(
         agent_card=agent_card,
-        http_handler=request_handler,
     )
-    jsonrpc_server.add_routes_to_app(main_app)
 
+    # JSON-RPC (mounted at root, matching the interface URL declared above)
+    jsonrpc_routes = create_jsonrpc_routes(
+        request_handler=request_handler,
+        rpc_url='/',
+    )
     # REST / HTTP+JSON
-    rest_server = A2ARESTFastAPIApplication(
-        agent_card=agent_card,
-        http_handler=request_handler,
+    rest_routes = create_rest_routes(
+        request_handler=request_handler,
+        path_prefix=REST_URL,
     )
-    rest_app = rest_server.build(rpc_url=REST_URL)
-    main_app.mount('', rest_app)
+    # Agent card discovery (/.well-known/agent-card.json)
+    agent_card_routes = create_agent_card_routes(agent_card=agent_card)
+
+    # NOTE: agent_card_routes must precede rest_routes — REST exposes a
+    # catch-all Mount('/{tenant}', ...) that would otherwise swallow
+    # /.well-known/agent-card.json before it's tried.
+    main_app = Starlette(routes=[*jsonrpc_routes, *agent_card_routes, *rest_routes])
 
     config = uvicorn.Config(
         main_app, host='0.0.0.0', port=http_port, log_level='info'
@@ -184,7 +185,7 @@ async def main() -> None:
     # gRPC
     grpc_server = grpc.aio.server()
     grpc_server.add_insecure_port(f'[::]:{grpc_port}')
-    servicer = GrpcHandler(agent_card, request_handler)
+    servicer = GrpcHandler(request_handler)
     a2a_grpc.add_A2AServiceServicer_to_server(servicer, grpc_server)
 
     logger.info(

--- a/sut/a2a-python/sut_agent.py
+++ b/sut/a2a-python/sut_agent.py
@@ -17,17 +17,17 @@ from starlette.applications import Starlette
 
 import a2a.types.a2a_pb2_grpc as a2a_grpc
 
+from a2a.helpers.proto_helpers import new_task_from_user_message
 from a2a.server.agent_execution.agent_executor import AgentExecutor
 from a2a.server.agent_execution.context import RequestContext
-from a2a.server.apps import (
-    A2ARESTFastAPIApplication,
-    A2AStarletteApplication,
-)
 from a2a.server.events.event_queue import EventQueue
-from a2a.server.request_handlers.default_request_handler import (
-    DefaultRequestHandler,
-)
+from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.request_handlers.grpc_handler import GrpcHandler
+from a2a.server.routes import (
+    create_agent_card_routes,
+    create_jsonrpc_routes,
+    create_rest_routes,
+)
 from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.server.tasks.task_updater import TaskUpdater
 from a2a.types import (
@@ -38,11 +38,7 @@ from a2a.types import (
     AgentSkill,
     Part,
 )
-from a2a.utils.errors import (
-    A2AError,
-    TaskNotCancelableError,
-    UnsupportedOperationError,
-)
+from a2a.utils.errors import A2AError
 
 REST_URL = '/a2a/rest'
 
@@ -71,6 +67,9 @@ class TckAgentExecutor(AgentExecutor):
                 updater.new_agent_message([Part(text='No message provided')])
             )
             return
+
+        if context.current_task is None:
+            await event_queue.enqueue_event(new_task_from_user_message(message))
 
         message_id = message.message_id
 
@@ -231,24 +230,26 @@ async def main() -> None:
     request_handler = DefaultRequestHandler(
         agent_executor=TckAgentExecutor(),
         task_store=task_store,
-    )
-
-    main_app = Starlette()
-
-    # JSON-RPC
-    jsonrpc_server = A2AStarletteApplication(
         agent_card=agent_card,
-        http_handler=request_handler,
     )
-    jsonrpc_server.add_routes_to_app(main_app)
 
+    # JSON-RPC (mounted at root, matching the interface URL declared above)
+    jsonrpc_routes = create_jsonrpc_routes(
+        request_handler=request_handler,
+        rpc_url='/',
+    )
     # REST / HTTP+JSON
-    rest_server = A2ARESTFastAPIApplication(
-        agent_card=agent_card,
-        http_handler=request_handler,
+    rest_routes = create_rest_routes(
+        request_handler=request_handler,
+        path_prefix=REST_URL,
     )
-    rest_app = rest_server.build(rpc_url=REST_URL)
-    main_app.mount('', rest_app)
+    # Agent card discovery (/.well-known/agent-card.json)
+    agent_card_routes = create_agent_card_routes(agent_card=agent_card)
+
+    # NOTE: agent_card_routes must precede rest_routes — REST exposes a
+    # catch-all Mount('/{tenant}', ...) that would otherwise swallow
+    # /.well-known/agent-card.json before it's tried.
+    main_app = Starlette(routes=[*jsonrpc_routes, *agent_card_routes, *rest_routes])
 
     config = uvicorn.Config(
         main_app, host='0.0.0.0', port=http_port, log_level='info'
@@ -258,7 +259,7 @@ async def main() -> None:
     # gRPC
     grpc_server = grpc.aio.server()
     grpc_server.add_insecure_port(f'[::]:{grpc_port}')
-    servicer = GrpcHandler(agent_card, request_handler)
+    servicer = GrpcHandler(request_handler)
     a2a_grpc.add_A2AServiceServicer_to_server(servicer, grpc_server)
 
     logger.info(


### PR DESCRIPTION
## Summary

Fixes #221 — the generated reference SUT for the `a2a-python` SDK (`sut/a2a-python/sut_agent.py`, produced from `codegen/a2a-python/sut_agent.py.j2`) can't start against the SDK version this repo itself declares as its dependency floor (`sut/a2a-python/pyproject.toml`: `a2a-sdk>=0.3.0`):

```
ModuleNotFoundError: No module named 'a2a.server.apps'
```

`a2a.server.apps` (`A2AStarletteApplication` / `A2ARESTFastAPIApplication`) was removed from `a2a-python` in favor of `a2a.server.routes`. Ported the SUT to `create_jsonrpc_routes` / `create_rest_routes` / `create_agent_card_routes`.

Two more bugs surfaced once the app was reassembled and actually run end-to-end against the TCK:

1. **Route order matters.** REST exposes a catch-all `Mount('/{tenant}', ...)` that swallows `/.well-known/agent-card.json` if registered first — agent card discovery broke silently. Fixed by listing `agent_card_routes` before `rest_routes`.
2. **`DefaultRequestHandler` now requires the task to be explicitly enqueued.** Added `event_queue.enqueue_event(new_task_from_user_message(message))` when `context.current_task is None` — without it, every task-lifecycle MUST requirement failed by construction, not because of anything the SUT was actually doing wrong.

Patched **both** `codegen/a2a-python/sut_agent.py.j2` and the generated `sut/a2a-python/sut_agent.py` — regenerating from an unpatched template would silently revert the fix, so the template needed the same treatment as the fixture it produces.

## Test plan

- [x] `ruff check sut/a2a-python/sut_agent.py`: all checks passed
- [x] The patched SUT boots and serves all three transports (JSON-RPC, REST, gRPC) — verified by running the full TCK MUST-level suite against it end-to-end multiple times this session (used as the reference SUT for #218/#219/#220's verification), most recently: 188 passed, 47 skipped, 0 failed, `overall_compatibility: 68.7%` (the remainder being requirements this fixture doesn't yet implement handlers for, not fixture crashes)
- [x] Confirmed the pre-fix state reproduces the exact `ModuleNotFoundError` above against current `a2a-sdk`