### PR TITLE
fix(reporting): don't crash HTMLFormatter when agent_card has no version

### DIFF
--- a/tck/reporting/html_formatter.py
+++ b/tck/reporting/html_formatter.py
@@ -80,7 +80,7 @@ class HTMLFormatter:
             "</table>\n"
             f"<p>Timestamp: {escape(report.timestamp)}</p>\n"
             f'<p>SUT URL: <a href="{escape(self._sut_url)}">{escape(self._sut_url)}</a></p>\n'
-            f"<p>SUT Version: {escape(report.agent_card['version'])}</p>\n"
+            f"<p>SUT Version: {escape(str(report.agent_card.get('version','?')))}</p>\n"
             "</div>\n"
         )
 

--- a/tests/unit/reporting/test_html_formatter.py
+++ b/tests/unit/reporting/test_html_formatter.py
@@ -85,6 +85,20 @@ class TestExecutiveSummary:
         html = formatter.format(report)
         assert "http://localhost:9999" in html
 
+    def test_missing_version_does_not_crash(
+        self, collector: CompatibilityCollector, formatter: HTMLFormatter
+    ) -> None:
+        """A report with no agent_card (e.g. an unreachable SUT) doesn't raise KeyError.
+
+        Regression test: CompatibilityAggregator defaults agent_card to {}
+        when none is available, and report.agent_card['version'] used to
+        raise KeyError formatting that report instead of rendering it.
+        """
+        report = CompatibilityAggregator(collector, agent_card={}).aggregate()
+        html = formatter.format(report)
+        assert "SUT Version: ?" in html
+
+
 class TestPerRequirementTable:
     """Per-requirement table contents."""
 


### PR DESCRIPTION
## Summary

Fixes #223 — `HTMLFormatter._render_executive_summary()` accessed `report.agent_card['version']` directly. `CompatibilityAggregator` defaults `agent_card` to `{}` whenever none is available (e.g. the `agent_card` fixture never resolved because the SUT was unreachable), so formatting the report in exactly that case raised `KeyError: 'version'` — the run where a human-readable HTML report matters most is the one where report generation itself crashed.

## Fix

`report.agent_card.get('version', '?')` instead of `report.agent_card['version']`, plus a regression test (`TestExecutiveSummary::test_missing_version_does_not_crash`) that aggregates a report with `agent_card={}` and asserts the formatter renders `SUT Version: ?` instead of raising.

## Test plan

- [x] `tests/unit/reporting/test_html_formatter.py` (25 tests, including the new one): all pass
- [x] `ruff check` on both changed files: all checks passed
- [x] Confirmed the pre-fix code reproduces `KeyError: 'version'` on the exact repro in the issue