### PR TITLE
fix: read streamed error body before close so _extract_error survives non-2xx (#225)

### DIFF
--- a/tck/transport/http_json_client.py
+++ b/tck/transport/http_json_client.py
@@ -6,6 +6,7 @@ using RESTful URLs, standard HTTP verbs, and SSE for streaming.
 
 from __future__ import annotations
 
+import contextlib
 import json
 
 from dataclasses import dataclass
@@ -47,7 +48,10 @@ def _extract_error(response: httpx.Response) -> str:
             error = body["error"]
             message = error.get("message", "")
             return f"[{response.status_code}] {message}" if message else f"[{response.status_code}]"
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError, httpx.StreamError):
+        # httpx.StreamError (e.g. ResponseNotRead) is raised when the body of a
+        # streamed response has not been read; fall through to .text below,
+        # which the caller is expected to have made readable via response.read().
         pass
     return f"[{response.status_code}] {response.text}"
 
@@ -184,6 +188,11 @@ class HttpJsonClient(BaseTransportClient):
             response = self._client.send(request, stream=True)
             resp_headers = dict(response.headers)
             if response.status_code >= _HTTP_ERROR_MIN:
+                # Read the body before closing so callers reaching ``.error`` ->
+                # ``_extract_error`` can access ``.json()``/``.text`` instead of
+                # hitting httpx.ResponseNotRead on this streamed response.
+                with contextlib.suppress(httpx.StreamError):
+                    response.read()
                 response.close()
                 return HttpJsonStreamingResponse(
                     transport=self.transport,

--- a/tests/unit/transport/__init__.py
+++ b/tests/unit/transport/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the TCK transport clients."""

--- a/tests/unit/transport/test_http_json_client.py
+++ b/tests/unit/transport/test_http_json_client.py
@@ -1,0 +1,98 @@
+"""Regression tests for the HTTP+JSON transport client (issue #225).
+
+A conformant server may answer a streamed ``message:stream`` request with a
+non-2xx status and a JSON error body.  ``_request_streaming`` opens the response
+with ``stream=True`` and, on an error status, must make the body readable before
+closing it; otherwise ``_extract_error`` (reached via ``.error``) calls
+``.json()``/``.text`` on an unread streamed response and raises
+``httpx.ResponseNotRead`` (a ``StreamError``/``RuntimeError`` subclass) that the
+harness does not expect, crashing HTTP_JSON-SSE-001 instead of skipping.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Iterator
+
+import httpx
+import pytest
+
+from tck.transport.http_json_client import HttpJsonClient, _extract_error
+
+
+_ERROR_MESSAGE = "task not found"
+_ERROR_BODY = json.dumps({"error": {"code": 404, "message": _ERROR_MESSAGE}}).encode()
+_STATUS_BAD_REQUEST = 400
+
+
+class _ErrorHandler(BaseHTTPRequestHandler):
+    """Returns 400 with an AIP-193 JSON error body to any streamed POST."""
+
+    def do_POST(self) -> None:
+        # Drain the request body before responding; leaving it unread makes some
+        # platforms (notably Windows) reset the connection, which would surface
+        # as a spurious httpx.ReadError rather than the 400 under test.
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length:
+            self.rfile.read(content_length)
+        self.send_response(_STATUS_BAD_REQUEST)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(_ERROR_BODY)))
+        self.end_headers()
+        self.wfile.write(_ERROR_BODY)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+
+@pytest.fixture
+def error_server() -> Iterator[str]:
+    """A stdlib HTTP server that answers every POST with a 400 JSON error."""
+    server = HTTPServer(("127.0.0.1", 0), _ErrorHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_streaming_error_does_not_crash_and_returns_message(error_server: str) -> None:
+    """Streaming to a server that returns 400 must yield the error string, not raise.
+
+    This is the exact scenario from issue #225: without reading the streamed
+    body before close, ``.error`` raised ``httpx.ResponseNotRead``.
+    """
+    client = HttpJsonClient(error_server)
+    try:
+        response = client.send_streaming_message(message={"role": "user", "parts": []})
+        assert response.success is False
+        assert response.status_code == _STATUS_BAD_REQUEST
+        # ``.error`` routes through ``_extract_error`` on the closed streamed
+        # response; it must return the server's error string, not raise.
+        error = response.error
+        assert error is not None
+        assert "[400]" in error
+        assert _ERROR_MESSAGE in error
+    finally:
+        client.close()
+
+
+def test_extract_error_on_read_streamed_response(error_server: str) -> None:
+    """Suite-level path: ``_extract_error`` on a read+closed streamed response returns a string."""
+    with httpx.Client(base_url=error_server) as raw:
+        request = raw.build_request("POST", "/message:stream", json={})
+        response = raw.send(request, stream=True)
+        try:
+            assert response.status_code == _STATUS_BAD_REQUEST
+            response.read()  # what _request_streaming now does before close()
+        finally:
+            response.close()
+        result = _extract_error(response)
+    assert isinstance(result, str)
+    assert "[400]" in result
+    assert _ERROR_MESSAGE in result


### PR DESCRIPTION
## Summary

Fixes #225. `HttpJsonClient._request_streaming` opened the response with
`stream=True` and, on a status >= 400, called `response.close()` without reading
the body. Any caller that then reaches `.error` routes through `_extract_error`,
which calls `.json()`/`.text` on the unread streamed response and raises
`httpx.ResponseNotRead`. Its MRO is `ResponseNotRead -> StreamError ->
RuntimeError`, so the existing `except (json.JSONDecodeError, ValueError)` clause
does not catch it, and the exception escapes.

The result: any conformant server that returns a non-2xx to a streaming request
(exactly what `CORE-CAP-002` requires when `capabilities.streaming` is unset)
crashes the harness in `HTTP_JSON-SSE-001` instead of letting it skip. In the
same run, `CORE-CAP-002` passes, so the server is marked correct for the very
behaviour that crashes the suite.

## Root cause and the in-tree precedent

The sibling `tck/transport/jsonrpc_client.py` already handles the same situation
on the same httpx streaming API correctly: it calls `response.read()` before
touching `.json()`/`.text`. The HTTP+JSON client is the odd one out.

## Fix

Two small, aligned changes in `tck/transport/http_json_client.py`:

1. In `_request_streaming`, read the body before closing on the error branch,
   guarded by `httpx.StreamError`, mirroring `jsonrpc_client`.
2. Harden `_extract_error` by widening its `except` to include
   `httpx.StreamError` (the common base of `ResponseNotRead`, `StreamConsumed`
   and `StreamClosed`) as belt-and-braces, since `_extract_error` is reachable
   from other paths too.

The success path is unchanged. `httpx.StreamError` is a narrow, deliberate catch
that does not swallow `KeyboardInterrupt`/`SystemExit`.

## Test

Adds `tests/unit/transport/test_http_json_client.py` (new `tests/unit/transport`
package; the repo previously exercised the clients only via the live
compatibility harness). A stdlib `http.server` returns 400 with an AIP-193 JSON
error body to a streamed POST, reproducing the exact issue scenario:

- `test_streaming_error_does_not_crash_and_returns_message` drives the real
  client path (`send_streaming_message(...).error`) and asserts it returns the
  server's error string containing `[400]` and the message, rather than raising.
- `test_extract_error_on_read_streamed_response` covers the `_extract_error`
  path directly on a read-then-closed streamed response.

The test handler drains the request body before responding so the server does
not reset the connection on platforms (notably Windows) that would otherwise
surface a spurious `httpx.ReadError`.

## Validation

- Reproduced the original crash on pristine `main` (`5996b79`, httpx 0.28.1):
  `httpx.ResponseNotRead` from `_extract_error`.
- With the fix, the same scenario returns `[400] <message>` and the suite skips
  cleanly.
- New tests: 2 passed, stable across repeated runs on Linux and Windows.
- Existing unit suite: green (no regression).

Environment: `a2a-tck` main `5996b79`, httpx 0.28.1, Python 3.11/3.12.
