### PR TITLE
Add RFC 8785 canonicalization conformance vectors (a2a-jcs-v01, Layer A)

### DIFF
--- a/conformance-vectors/a2a-jcs-v01/MANIFEST.json
+++ b/conformance-vectors/a2a-jcs-v01/MANIFEST.json
@@ -1,0 +1,254 @@
+{
+  "corpus": "a2a-jcs-v01",
+  "suite": "a2a-agent-card-canonicalization-conformance",
+  "specRef": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "scope": "Layer A only (RFC 8785 canonicalization + a2a signatures-exclusion); field-presence vectors (spec section 8.4.1 rule 1) are deliberately excluded pending resolution of a2aproject/A2A#2122's rule-1 question.",
+  "oracles": [
+    "rfc8785 (PyPI, 0.1.4)",
+    "gowebpki/jcs (Go, v1.0.1)"
+  ],
+  "counts": {
+    "accept": 47,
+    "reject": 10,
+    "total": 57
+  },
+  "groups": [
+    "a2-signatures-exclusion",
+    "a3-object-key-ordering",
+    "a4-string-serialization",
+    "a5-number-serialization",
+    "a6-arrays-nesting-literals"
+  ],
+  "vectors": [
+    {
+      "path": "a2-signatures-exclusion/A2-001.json",
+      "sha256": "dc15ec0f7dea5c98cb6e23a1f0ad36f69b8b945c269e71846b4f1cbfcb1b279c"
+    },
+    {
+      "path": "a2-signatures-exclusion/A2-002.json",
+      "sha256": "70707b61ffbf80bb4a983de21af9677cc0611be1ad05184e538bcfdbabafe2d5"
+    },
+    {
+      "path": "a2-signatures-exclusion/A2-REJECT-003.json",
+      "sha256": "faf5bec55b05269aac80fd41b3e6e4daa4f2f241074869315f36823bfb9ec7c3"
+    },
+    {
+      "path": "a2-signatures-exclusion/A2-REJECT-004.json",
+      "sha256": "e71201b74da090f2ac07b944726298c8ee765268f819cb58be5924bf9d50aa47"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-001.json",
+      "sha256": "5a03287ce73d20825bf76995142fbebf6d229f83526d1b0b16bebdb0117015a9"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-002.json",
+      "sha256": "51a2d698a9daa2e975760827415ca05e954bb2dfda14c95f09a8f354e71e66c0"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-003.json",
+      "sha256": "b406598175653952c2a3b669fb79cb5574e5afad25118a2cc9ea7e40a6e92efc"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-004.json",
+      "sha256": "9cf8781a9c9a9df3399532c8dde237c470c4d29a1e4229bf0326885e40315c83"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-005.json",
+      "sha256": "b6f278ef5d0ba6fa69132818bff97872b8fccf04a3a8ad9c83115cc85b63727d"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-006.json",
+      "sha256": "2481521ac7bf127de9dc85fde0f14a4c53d1691dab65df99b9dd9c2193b6e2a1"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-007.json",
+      "sha256": "cf59dbf5e7cca5dcad839759400968067a832dc6ed6e0e9dcfbc036a142a295e"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-008.json",
+      "sha256": "6aa786180ef7a85d5ea67415d4f5ae4d0e702dcead0d510117c2b3b8721927df"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-009.json",
+      "sha256": "ea433756b1f0797dfe6ba6ce8e40885e9359b9ac4b5d18c477625118b20528ea"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-010.json",
+      "sha256": "253eb0fd52ec577e32a673cd7a067ea09d253deed351b58f1eaee9f62fa8bf7b"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-REJECT-011.json",
+      "sha256": "cf2cdefed7e898f37c866d4c32ed6d9af70d1ce4b244e455470ebb94922b0e17"
+    },
+    {
+      "path": "a3-object-key-ordering/A3-REJECT-012.json",
+      "sha256": "fc79882a79e13cc8d7547098760612a7a61ed3e48dd3eeadfbdfa595eef2075f"
+    },
+    {
+      "path": "a4-string-serialization/A4-001.json",
+      "sha256": "42435ce2469a64617fff54f2b87a963285285ae006dbcbea53e5b055cbf2c8ff"
+    },
+    {
+      "path": "a4-string-serialization/A4-002.json",
+      "sha256": "d3addd71274174b61aa60aebb1e0565b832befdac871c979b30dc23fdc247cb3"
+    },
+    {
+      "path": "a4-string-serialization/A4-003.json",
+      "sha256": "01364d7bc81cb7efcb90bb94b6bd3502ad31ac7af8fc48f1d451953475840802"
+    },
+    {
+      "path": "a4-string-serialization/A4-004.json",
+      "sha256": "19d6c11df3db73610b1d227d6ff1d33a4406ac06848faf4960c5a73040d06a0e"
+    },
+    {
+      "path": "a4-string-serialization/A4-005.json",
+      "sha256": "794942353846a99990a8809a017489d7b6646d395bb8a249f9a4e7dcbc73eea4"
+    },
+    {
+      "path": "a4-string-serialization/A4-006.json",
+      "sha256": "f2fd4fc9ccd7b37d154aeadf9fb61aec3c8fc7b87acff5adff9c95a761fdf30f"
+    },
+    {
+      "path": "a4-string-serialization/A4-007.json",
+      "sha256": "e859bde2ccccf90098f67acfc1fcab828ad082ee69177888c026a5f0ad244eb5"
+    },
+    {
+      "path": "a4-string-serialization/A4-008.json",
+      "sha256": "b91282d1835e9e24fa72b2e52780841c46377a405c2fcd93fc9002005b1732b0"
+    },
+    {
+      "path": "a4-string-serialization/A4-009.json",
+      "sha256": "2efe4cc3a7ddd5a421d772b1c8cfcc27741589d35c575c91bb7453c60def78af"
+    },
+    {
+      "path": "a4-string-serialization/A4-010.json",
+      "sha256": "ffa7ab4f25b4261290e218f1d003faf1e4653571b108414883f0d6219deaef7e"
+    },
+    {
+      "path": "a4-string-serialization/A4-011.json",
+      "sha256": "35a9601abaa0c7bf2a9c96ada53af6a35a45683327030bc85425596e128376e1"
+    },
+    {
+      "path": "a4-string-serialization/A4-012.json",
+      "sha256": "a776b6bad02bd42a5682f4ded793da13dbc9f2d8e7b907513c140c9dd81951cd"
+    },
+    {
+      "path": "a4-string-serialization/A4-REJECT-013.json",
+      "sha256": "eae05e171d6c69c3bd18931b12c14271c73eaa78a8b4322d7e77ae7b1ae5fc37"
+    },
+    {
+      "path": "a4-string-serialization/A4-REJECT-014.json",
+      "sha256": "00e854bc0dc6a17718e7489874fbe6111e517a29d3236ba325811627f3694878"
+    },
+    {
+      "path": "a4-string-serialization/A4-REJECT-015.json",
+      "sha256": "caebeb1e17f8b5343143c78e0e1f46ad08e0af92f69df6b6b99a0f86836b4bc4"
+    },
+    {
+      "path": "a5-number-serialization/A5-001.json",
+      "sha256": "3fd76250f640c0b5cde9e3b377c69562ccdabf521e52ffe00ce6f845ab61459d"
+    },
+    {
+      "path": "a5-number-serialization/A5-002.json",
+      "sha256": "2e1f65f43c7106e1ff9112e923e09eac52cb272cfc831ee880b4bf0c21907e36"
+    },
+    {
+      "path": "a5-number-serialization/A5-003.json",
+      "sha256": "bf1fe9df5213009047e87e68b7f7713b8b45288300569653e477346b6a129e69"
+    },
+    {
+      "path": "a5-number-serialization/A5-004.json",
+      "sha256": "93ade06748a17e2da121ccf2aec0b01412a9b1db6fbe092f9009f259d8e9c860"
+    },
+    {
+      "path": "a5-number-serialization/A5-005.json",
+      "sha256": "ed2227144b764074538e954f8ba41be1be0e91b37f40d50657ffe046c0e6d201"
+    },
+    {
+      "path": "a5-number-serialization/A5-006.json",
+      "sha256": "9743c1b0d28d05230afb177dca712b3b43fe121a0717184ab5b6fb138af69257"
+    },
+    {
+      "path": "a5-number-serialization/A5-007.json",
+      "sha256": "a16a1e04a559e54c6b97335b73418ed81240914fab9efc12d1c3501920c2e385"
+    },
+    {
+      "path": "a5-number-serialization/A5-008.json",
+      "sha256": "4bca7750bbad5b8709ea3f5730aa22ae76ede6e4e9b1e9e123f83d6cf8e6b995"
+    },
+    {
+      "path": "a5-number-serialization/A5-009.json",
+      "sha256": "a6581ef2e7516f37b2ee9dde0d834dc343adbe3dd97547e0e07e0eba513704cb"
+    },
+    {
+      "path": "a5-number-serialization/A5-010.json",
+      "sha256": "330205c2d7368bda95452cf4275412fd8bb3a7c10e0aa4e98087b02e1fd18ec5"
+    },
+    {
+      "path": "a5-number-serialization/A5-011.json",
+      "sha256": "c1517860e8baab8427bf3d804c7419d7fc2c93d9caa3def38fd18707359d5527"
+    },
+    {
+      "path": "a5-number-serialization/A5-012.json",
+      "sha256": "c9b06bb6da03e94273c96e46bfe998d1a965dc723d3f0bb3f2e5c02246e65b3a"
+    },
+    {
+      "path": "a5-number-serialization/A5-013.json",
+      "sha256": "7639b7d7afeb9d711934d443c0eafdd16fc41e75fc7b87e7ef13219daa40dd4c"
+    },
+    {
+      "path": "a5-number-serialization/A5-014.json",
+      "sha256": "69fa3aeb0c559942c52482dd884d932a5ed054d81c01d0d0d1ce292150fa6d90"
+    },
+    {
+      "path": "a5-number-serialization/A5-015.json",
+      "sha256": "03ff8bf1a88b92f188af50179a0b2199e42b5ccef17aa84b8cb28083de29ac1a"
+    },
+    {
+      "path": "a5-number-serialization/A5-REJECT-016.json",
+      "sha256": "787ba4711aa90490526470f381da062b8cb450f10e52dbba384f27f151387da8"
+    },
+    {
+      "path": "a5-number-serialization/A5-REJECT-017.json",
+      "sha256": "547d8d2d0cc7557b01f18a8541c93b05b6730cb17bb3e1320019dc80122daa9b"
+    },
+    {
+      "path": "a5-number-serialization/A5-REJECT-018.json",
+      "sha256": "97533a28720c36a5045c24350171e73d0667a7850da4967da3e7e8bd328d7026"
+    },
+    {
+      "path": "a6-arrays-nesting-literals/A6-001.json",
+      "sha256": "fe95eb701df0a6f8252a2c24f2fbf2c01fc132123aa67b8851a0002a8febba8d"
+    },
+    {
+      "path": "a6-arrays-nesting-literals/A6-002.json",
+      "sha256": "05659c09f6c0b1ec3324790634928a336b55fa04431fd74ce133bc500c1e34f9"
+    },
+    {
+      "path": "a6-arrays-nesting-literals/A6-003.json",
+      "sha256": "652f8b567937b3463689c7361c98ccc75e43e43267828148dbb587c3004f887b"
+    },
+    {
+      "path": "a6-arrays-nesting-literals/A6-004.json",
+      "sha256": "e34ccf4bbb90fe690f052d88f251071c5537ac5797c5e68eefe63149d824baa9"
+    },
+    {
+      "path": "a6-arrays-nesting-literals/A6-005.json",
+      "sha256": "307951b8c139bb632a6fbb249c880fcd3d7c2c43ba43ed51d734ad4639a35f4d"
+    },
+    {
+      "path": "a6-arrays-nesting-literals/A6-006.json",
+      "sha256": "8e6f0bdaa7113f325d77f7eab308edcfc15834a9ee7b5db2ce8f88804f9b2172"
+    },
+    {
+      "path": "a6-arrays-nesting-literals/A6-007.json",
+      "sha256": "892589ed9d22344473270c56984ca80f282aa8eda3ebfd571582b28e6e044ea7"
+    },
+    {
+      "path": "a6-arrays-nesting-literals/A6-008.json",
+      "sha256": "b43026c697e087b2fb62f11d21e6fe624fa1289c2778ff2efac155cf2b6250f9"
+    }
+  ],
+  "corpusDigest": "2ec93667b1436537a7f46cf882bae37977dc10face4bb27a2120e2d7aa824da4"
+}

--- a/conformance-vectors/a2a-jcs-v01/README.md
+++ b/conformance-vectors/a2a-jcs-v01/README.md
@@ -1,0 +1,95 @@
+# a2a-jcs-v01: RFC 8785 canonicalization conformance vectors for a2a Agent Card signing
+
+This corpus is an offer to a2aproject/a2a-tck#227. It gives the CARD-SIGN requirements a
+language-neutral conformance corpus. That project currently tags those requirements
+not-automatable.
+
+The corpus exists because a2a-python and a2a-js canonicalize the same Agent Card into different
+bytes. A card signed by one SDK then fails verification under the other. Two independent RFC 8785
+implementations adjudicated the difference and agree that a2a-js is conformant on every axis tested
+while a2a-python is not. The report, the reproduction steps, and the specification issue this corpus follows from are
+at a2aproject/A2A#2122, a2aproject/a2a-python#1174, and a2aproject/a2a-js#627.
+
+## Scope
+
+This corpus covers Layer A only. Layer A is RFC 8785 canonicalization, plus the a2a rule that
+excludes the signatures field before canonicalization runs. Layer B (JWS construction) and Layer C
+(verification) are not built yet.
+
+One group is missing from Layer A on purpose: field presence. That group tests whether REQUIRED
+fields with default values survive canonicalization. The answer is still an open question at
+a2aproject/A2A#2122. About a fifth of a full Layer A corpus would need a retraction if that question
+resolves the other way. Every vector below is independent of that question and safe to ship now.
+
+| Group | Clause | Count | Reject |
+|---|---|---:|---:|
+| A2 signatures exclusion | a2a spec 8.4.1 rule 3 | 4 | 2 |
+| A3 object key ordering | RFC 8785 3.2.3 | 12 | 2 |
+| A4 string serialization | RFC 8785 3.2.2.2 | 15 | 3 |
+| A5 number serialization | RFC 8785 3.2.2.3 | 18 | 3 |
+| A6 arrays, nesting, literals | RFC 8785 3.2.1, 3.2.2.1 | 8 | 0 |
+| Total | | 57 | 10 |
+
+The design doc estimated 56 vectors and 11 rejects for these five groups; the table above and
+MANIFEST.json carry the live count. Real oracle runs against real inputs changed two of the
+estimated numbers. A4 has 15 accept vectors, not 14. A second astral-plane
+character next to the first turned out to be a distinct, useful case, so it stayed. A5 has 3 rejects,
+not 4. NaN and positive or negative infinity are the only JSON number values with no ECMAScript
+Number toString form at all. Every finite double has one, so a fourth legitimate reject case for
+numbers does not exist.
+
+## How each expected byte was produced
+
+No expected byte here came from hand calculation. Every accept vector runs its input through two
+independent RFC 8785 implementations, rfc8785 0.1.4 on PyPI for Python and gowebpki/jcs v1.0.1 on
+GitHub for Go. Neither project wrote the other. The vector keeps the result only when both
+implementations agree, byte for byte. An accept vector never shipped if its two oracles disagreed
+on the bytes. The generator raises an error and refuses to write that file.
+
+Reject vectors carry the same rule in the other direction, and it got stricter partway through the
+build: both oracles must refuse the input, and one refusal alone stopped being enough. Two early candidates first
+shipped on a Python-only refusal: a reversed surrogate pair, and two consecutive high surrogates. The
+first version of the generator accepted either oracle's refusal, not both. The Go runner caught the
+gap. gowebpki/jcs quietly swaps in a Unicode replacement character for those two malformed
+sequences. It does not raise an error. rfc8785 does raise an error for the same input. Both vectors
+now use single unpaired surrogates instead, which both oracles genuinely refuse, and the generator
+requires that same double refusal before it will write any reject vector at all.
+
+## How to verify this corpus
+
+Run the Python reference runner from the repository root:
+
+    pip install rfc8785
+    python3 conformance-vectors/a2a-jcs-v01/run_python.py
+
+Run the Go reference runner:
+
+    cd conformance-vectors/a2a-jcs-v01/oracle-go && go build -o /tmp/a2a-runner ./runner/
+    /tmp/a2a-runner /path/to/conformance-vectors/a2a-jcs-v01
+
+Each runner prints one JSON result record. The record holds the corpus digest, the spec commit,
+a pass or fail mark per vector, and a coverage count. Each runner exits with a non-zero code on any
+failure. Two scripts in this same directory can regenerate the corpus and its manifest:
+gen_layer_a.py and gen_manifest.py, and both re-check every vector against both oracles on every
+run, so a stale or hand-edited vector gets overwritten the next time either one runs.
+
+## Manifest and digest
+
+MANIFEST.json lists every vector file with its own sha256 hash, sorted by path. The manifest also
+carries a corpus digest. That digest is the sha256 hash of the manifest body, taken without the
+digest field itself. A digest cannot include its own value. To reproduce it, strip that one field,
+re-serialize the file with the same key order, then hash what remains.
+
+## Signing
+
+This corpus is not signed yet. A future version can add a DSSE envelope over an in-toto statement,
+giving the corpus tamper evidence and a pinned revision that a third party can re-check later.
+Signing status does not block use of this corpus today. Both runners above check the corpus in full
+without a signature. A signature would add cryptographic proof that nobody altered a byte after
+publication, on top of what the runners already establish by running clean.
+
+## Status
+
+This corpus is offered at a2a-tck#227. giskard09 built their own canonicalizer, argentum-core, from
+the RFC 8785 text and has no tie to either a2a-python or a2a-js. giskard09 offered to run these vectors
+blind against argentum-core once the non-gated set existed, and that set exists now.

--- a/conformance-vectors/a2a-jcs-v01/a2-signatures-exclusion/A2-001.json
+++ b/conformance-vectors/a2a-jcs-v01/a2-signatures-exclusion/A2-001.json
@@ -1,0 +1,24 @@
+{
+  "id": "A2-001",
+  "clause": "a2a-spec-8.4.1-rule-3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "A card carrying a populated `signatures` array canonicalizes as if that key were absent entirely; the exclusion is unconditional, not conditional on the array being empty.",
+  "input": {
+    "name": "Example Agent",
+    "capabilities": {
+      "streaming": true,
+      "pushNotifications": false
+    },
+    "signatures": [
+      {
+        "protected": "eyJhbGciOiJFUzI1NiJ9",
+        "signature": "abc123"
+      }
+    ]
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226361706162696c6974696573223a7b22707573684e6f74696669636174696f6e73223a66616c73652c2273747265616d696e67223a747275657d2c226e616d65223a224578616d706c65204167656e74227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a2-signatures-exclusion/A2-002.json
+++ b/conformance-vectors/a2a-jcs-v01/a2-signatures-exclusion/A2-002.json
@@ -1,0 +1,19 @@
+{
+  "id": "A2-002",
+  "clause": "a2a-spec-8.4.1-rule-3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "A card carrying an EMPTY `signatures` array ([]) is excluded the same way as a populated one (A2-001): exclusion is by key presence, not by whether the value is 'interesting'. Compare directly against A6-001, which established that an empty array is otherwise a perfectly normal RFC 8785 value elsewhere in a document -- the only thing special about `signatures` is the key name.",
+  "input": {
+    "name": "Example Agent",
+    "capabilities": {
+      "streaming": true,
+      "pushNotifications": false
+    },
+    "signatures": []
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226361706162696c6974696573223a7b22707573684e6f74696669636174696f6e73223a66616c73652c2273747265616d696e67223a747275657d2c226e616d65223a224578616d706c65204167656e74227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a2-signatures-exclusion/A2-REJECT-003.json
+++ b/conformance-vectors/a2a-jcs-v01/a2-signatures-exclusion/A2-REJECT-003.json
@@ -1,0 +1,11 @@
+{
+  "id": "A2-REJECT-003",
+  "clause": "a2a-spec-8.4.1-rule-3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-REJECT",
+  "rejecting_clause": "a2a-spec-8.4.1-rule-3",
+  "rejection_layer": "canonicalization",
+  "rationale": "A single-signature payload presented as canonical output but still carrying its own `signatures` array is self-referential: the bytes a signature covers cannot include the signature that covers them, so any canonical form containing `signatures` is definitionally wrong regardless of what RFC 8785 alone would say about it. (confirmed: the input below is valid, well-formed JSON that parses cleanly -- both RFC 8785 oracles would canonicalize it without complaint -- and is refused ONLY because it retains the excluded key, which is an a2a-specific rule RFC 8785 itself has no opinion on.)",
+  "input_raw": "{\"capabilities\":{\"pushNotifications\":false,\"streaming\":true},\"name\":\"Example Agent\",\"signatures\":[{\"protected\":\"eyJhbGciOiJFUzI1NiJ9\",\"signature\":\"abc123\"}]}"
+}

--- a/conformance-vectors/a2a-jcs-v01/a2-signatures-exclusion/A2-REJECT-004.json
+++ b/conformance-vectors/a2a-jcs-v01/a2-signatures-exclusion/A2-REJECT-004.json
@@ -1,0 +1,11 @@
+{
+  "id": "A2-REJECT-004",
+  "clause": "a2a-spec-8.4.1-rule-3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-REJECT",
+  "rejecting_clause": "a2a-spec-8.4.1-rule-3",
+  "rejection_layer": "canonicalization",
+  "rationale": "Even a `signatures` key holding an empty array must still be rejected in claimed-canonical output: the exclusion rule is unconditional (A2-002), so its violation is unconditional too -- an empty array does not make the self-reference acceptable, it is still the wrong key present in the wrong place. (confirmed: the input below is valid, well-formed JSON that parses cleanly -- both RFC 8785 oracles would canonicalize it without complaint -- and is refused ONLY because it retains the excluded key, which is an a2a-specific rule RFC 8785 itself has no opinion on.)",
+  "input_raw": "{\"capabilities\":{\"pushNotifications\":false,\"streaming\":true},\"name\":\"Example Agent\",\"signatures\":[]}"
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-001.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-001.json
@@ -1,0 +1,16 @@
+{
+  "id": "A3-001",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Baseline: keys already in UTF-16 code-unit order pass through unchanged.",
+  "input": {
+    "a": 1,
+    "b": 2,
+    "c": 3
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2261223a312c2262223a322c2263223a337d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-002.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-002.json
@@ -1,0 +1,16 @@
+{
+  "id": "A3-002",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Keys given out of order must be reordered to UTF-16 code-unit order.",
+  "input": {
+    "zebra": 1,
+    "apple": 2,
+    "mango": 3
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226170706c65223a322c226d616e676f223a332c227a65627261223a317d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-003.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-003.json
@@ -1,0 +1,15 @@
+{
+  "id": "A3-003",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Case sensitivity: uppercase ASCII (U+0041 'A') sorts before lowercase ASCII (U+0061 'a') as a raw code unit.",
+  "input": {
+    "apple": 1,
+    "Apple": 2
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b224170706c65223a322c226170706c65223a317d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-004.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-004.json
@@ -1,0 +1,16 @@
+{
+  "id": "A3-004",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Numeric-looking keys sort as UTF-16 code-unit sequences, not as numbers: '1' < '10' < '2'.",
+  "input": {
+    "10": 1,
+    "2": 2,
+    "1": 3
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2231223a332c223130223a312c2232223a327d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-005.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-005.json
@@ -1,0 +1,15 @@
+{
+  "id": "A3-005",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "A BMP character above the ASCII range (U+00E9 'e with acute') sorts after every ASCII key.",
+  "input": {
+    "cafe": 1,
+    "café": 2
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2263616665223a312c22636166c3a9223a327d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-006.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-006.json
@@ -1,0 +1,15 @@
+{
+  "id": "A3-006",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "The a2aproject/A2A#2122 counterexample verbatim (case C3): a key containing U+1F600 (surrogate pair D83D DE00) sorts BEFORE a key containing U+FF01 (single unit FF01), because D83D < FF01 as raw UTF-16 code units, even though the code POINT 1F600 is numerically greater than FF01. Sorting by code point instead of UTF-16 code unit -- what a2a-python's sort_keys=True does -- gets this pair backwards.",
+  "input": {
+    "b😀key": 1,
+    "b！key": 2
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2262f09f98806b6579223a312c2262efbc816b6579223a327d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-007.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-007.json
@@ -1,0 +1,15 @@
+{
+  "id": "A3-007",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "A second astral-vs-high-BMP inversion pair, generalizing A3-006 beyond one example: U+10000 (surrogate pair D800 DC00) sorts before U+E000 (single unit E000, Private Use Area) by the same UTF-16-vs-code-point divergence.",
+  "input": {
+    "x𐀀end": 1,
+    "xend": 2
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2278f0908080656e64223a312c2278ee8080656e64223a327d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-008.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-008.json
@@ -1,0 +1,15 @@
+{
+  "id": "A3-008",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Two byte-distinct keys that render identically to a human (precomposed U+00E9 vs the combining-character sequence 'e' + U+0301) are different code-unit sequences with no normalization applied by RFC 8785; they sort as the distinct sequences they are, and the combining form (starts with plain ASCII 'e', U+0065) sorts before the precomposed form (starts with U+00E9).",
+  "input": {
+    "café": 1,
+    "café": 2
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2263616665cc81223a322c22636166c3a9223a317d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-009.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-009.json
@@ -1,0 +1,15 @@
+{
+  "id": "A3-009",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "The empty string is a valid key and, having zero code units, sorts before every non-empty key.",
+  "input": {
+    "": 1,
+    "a": 2
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b22223a312c2261223a327d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-010.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-010.json
@@ -1,0 +1,24 @@
+{
+  "id": "A3-010",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Stress case: eleven keys spanning ASCII, digits and mixed case sorted together, confirming the ordering rule is stable across more than a handful of keys at once.",
+  "input": {
+    "Zulu": 1,
+    "alpha": 2,
+    "Bravo": 3,
+    "charlie": 4,
+    "Delta": 5,
+    "9key": 6,
+    "echo": 7,
+    "Foxtrot": 8,
+    "1key": 9,
+    "golf": 10,
+    "Hotel": 11
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b22316b6579223a392c22396b6579223a362c22427261766f223a332c2244656c7461223a352c22466f7874726f74223a382c22486f74656c223a31312c225a756c75223a312c22616c706861223a322c22636861726c6965223a342c226563686f223a372c22676f6c66223a31307d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-REJECT-011.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-REJECT-011.json
@@ -1,0 +1,11 @@
+{
+  "id": "A3-REJECT-011",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-REJECT",
+  "rejecting_clause": "RFC8785-3.2.2.2",
+  "rejection_layer": "canonicalization",
+  "rationale": "A key containing a lone (unpaired) high surrogate U+D800 with no following low surrogate is not valid Unicode text and has no well-formed UTF-8 encoding, so it cannot be assigned a UTF-16 code-unit sort position or emitted as literal UTF-8 (RFC 8785 sect. 3.2.2.2); a conformant canonicalizer must refuse it rather than silently pass the unpaired surrogate through or substitute a replacement character. (confirmed refused by both independent oracles: go+py)",
+  "input_raw": "{\"b\\ud800key\": 1, \"a\": 2}"
+}

--- a/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-REJECT-012.json
+++ b/conformance-vectors/a2a-jcs-v01/a3-object-key-ordering/A3-REJECT-012.json
@@ -1,0 +1,11 @@
+{
+  "id": "A3-REJECT-012",
+  "clause": "RFC8785-3.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-REJECT",
+  "rejecting_clause": "RFC8785-3.2.2.2",
+  "rejection_layer": "canonicalization",
+  "rationale": "A key containing a lone (unpaired) LOW surrogate U+DC00 with no preceding high surrogate completes A3-REJECT-011's high-surrogate case with the low-surrogate half of the pair: equally invalid Unicode, equally unencodable as well-formed UTF-8, for the same reason. (confirmed refused by both independent oracles: go+py)",
+  "input_raw": "{\"b\\udc00key\": 1, \"a\": 2}"
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-001.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-001.json
@@ -1,0 +1,15 @@
+{
+  "id": "A4-001",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "The a2aproject/A2A#2122 counterexample verbatim (case C2): a non-ASCII scalar (e with acute, U+00E9) is emitted as literal UTF-8 bytes, never as a \\u00e9 escape. ensure_ascii=True in Python's json.dumps -- a2a-python's actual default -- produces the escaped form and fails this vector.",
+  "input": {
+    "name": "Café Agent",
+    "description": "Planifie des itinéraires."
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226465736372697074696f6e223a22506c616e6966696520646573206974696ec3a97261697265732e222c226e616d65223a22436166c3a9204167656e74227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-002.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-002.json
@@ -1,0 +1,14 @@
+{
+  "id": "A4-002",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Pure ASCII content is the trivial control case: no escaping needed, output equals input.",
+  "input": {
+    "name": "Example Agent"
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e616d65223a224578616d706c65204167656e74227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-003.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-003.json
@@ -1,0 +1,14 @@
+{
+  "id": "A4-003",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "An astral-plane character (U+1F600 GRINNING FACE, outside the Basic Multilingual Plane, requiring a UTF-16 surrogate pair to represent but a single 4-byte UTF-8 sequence) is emitted as literal UTF-8, not as a \\ud83d\\ude00 surrogate-pair escape.",
+  "input": {
+    "note": "hello 😀 world"
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e6f7465223a2268656c6c6f20f09f988020776f726c64227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-004.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-004.json
@@ -1,0 +1,14 @@
+{
+  "id": "A4-004",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "The mandatory escape set is exactly quote, backslash, and control characters below U+0020: this string exercises all three (a literal quote, a literal backslash, and a literal newline), each of which MUST still be escaped even though non-ASCII text is emitted literally.",
+  "input": {
+    "raw": "a \"quoted\" \\ path\nwith a newline"
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b22726177223a2261205c2271756f7465645c22205c5c20706174685c6e776974682061206e65776c696e65227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-005.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-005.json
@@ -1,0 +1,14 @@
+{
+  "id": "A4-005",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "The empty string is a valid scalar value and serializes as a pair of quote characters with nothing between them.",
+  "input": {
+    "empty": ""
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b22656d707479223a22227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-006.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-006.json
@@ -1,0 +1,14 @@
+{
+  "id": "A4-006",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Every remaining C0 control character (U+0001 through U+001F, excluding the ones with short escapes like \\n and \\t) must still be escaped as \\u00XX -- control-character escaping is required regardless of the literal-UTF-8 rule for ordinary text, since control characters are never literal in a JSON string.",
+  "input": {
+    "ctrl": "a\u0001b\u001fc"
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226374726c223a22615c7530303031625c753030316663227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-007.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-007.json
@@ -1,0 +1,14 @@
+{
+  "id": "A4-007",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "A CJK ideograph (U+4E2D, three-byte UTF-8) is emitted as literal UTF-8, the same rule as A4-001 applied to a script outside the Latin-1 range.",
+  "input": {
+    "label": "中文"
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226c6162656c223a22e4b8ade69687227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-008.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-008.json
@@ -1,0 +1,14 @@
+{
+  "id": "A4-008",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "U+007F (DELETE) sits immediately above the printable ASCII range and below the C1 control block; RFC 8785 requires literal UTF-8 for it like any other non-mandatory-escape character, it is not part of the U+0000-U+001F mandatory escape set.",
+  "input": {
+    "del": "ab"
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2264656c223a22617f62227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-009.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-009.json
@@ -1,0 +1,14 @@
+{
+  "id": "A4-009",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "A combining diacritic (U+0301 COMBINING ACUTE ACCENT) immediately following its base character is ordinary non-ASCII text with no special JSON-string handling; it is emitted as literal UTF-8 like any other codepoint outside the escape set.",
+  "input": {
+    "combining": "éclair"
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b22636f6d62696e696e67223a2265cc81636c616972227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-010.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-010.json
@@ -1,0 +1,14 @@
+{
+  "id": "A4-010",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Right-to-left script content (Arabic, U+0627 ALEF through U+0629 TEH MARBUTA) is emitted as literal UTF-8 bytes; RFC 8785 has no bidi-aware transform, only byte identity.",
+  "input": {
+    "rtl": "السلام"
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2272746c223a22d8a7d984d8b3d984d8a7d985227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-011.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-011.json
@@ -1,0 +1,14 @@
+{
+  "id": "A4-011",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Forward slash is explicitly NOT in JSON's mandatory escape set (unlike some JSON encoders' optional habit of escaping it as \\/) and must be emitted literally.",
+  "input": {
+    "url": "https://example.com/a2a/v1"
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2275726c223a2268747470733a2f2f6578616d706c652e636f6d2f6132612f7631227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-012.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-012.json
@@ -1,0 +1,14 @@
+{
+  "id": "A4-012",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "A string built entirely from two adjacent astral-plane characters (both requiring surrogate pairs in UTF-16) confirms multi-character non-BMP content is handled, not just a single isolated case like A4-003.",
+  "input": {
+    "emoji_pair": "😀😁"
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b22656d6f6a695f70616972223a22f09f9880f09f9881227d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-REJECT-013.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-REJECT-013.json
@@ -1,0 +1,11 @@
+{
+  "id": "A4-REJECT-013",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-REJECT",
+  "rejecting_clause": "RFC8785-3.2.2.2",
+  "rejection_layer": "canonicalization",
+  "rationale": "A lone (unpaired) low surrogate U+DC00 inside a STRING VALUE (not a key, unlike A3-REJECT-011/012) is not valid Unicode text and has no well-formed UTF-8 encoding; a conformant canonicalizer must refuse it rather than emit an invalid byte sequence or silently substitute U+FFFD. (confirmed refused by both independent oracles: go+py)",
+  "input_raw": "{\"name\": \"broken \\udc00 value\"}"
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-REJECT-014.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-REJECT-014.json
@@ -1,0 +1,11 @@
+{
+  "id": "A4-REJECT-014",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-REJECT",
+  "rejecting_clause": "RFC8785-3.2.2.2",
+  "rejection_layer": "canonicalization",
+  "rationale": "A lone low surrogate (U+DC00) embedded mid-string, with ordinary text both before and after it, is the string-value counterpart to A3-REJECT-012's key-position case: unpaired, not valid Unicode, no well-formed UTF-8 encoding, and unlike A4-REJECT-013's simpler isolated case this confirms the defect is caught with real surrounding content rather than only in a minimal reproduction. (confirmed refused by both independent oracles: go+py)",
+  "input_raw": "{\"name\": \"before\\udc00after\"}"
+}

--- a/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-REJECT-015.json
+++ b/conformance-vectors/a2a-jcs-v01/a4-string-serialization/A4-REJECT-015.json
@@ -1,0 +1,11 @@
+{
+  "id": "A4-REJECT-015",
+  "clause": "RFC8785-3.2.2.2",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-REJECT",
+  "rejecting_clause": "RFC8785-3.2.2.2",
+  "rejection_layer": "canonicalization",
+  "rationale": "A high surrogate (U+D800) followed by an ordinary BMP character (a plain letter, not its matching low surrogate) leaves the high surrogate unpaired for exactly the same reason as A4-REJECT-013/014, just constructed a third way. (confirmed refused by both independent oracles: go+py)",
+  "input_raw": "{\"name\": \"\\ud800x\"}"
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-001.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-001.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-001",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "The a2aproject/A2A#2122 counterexample verbatim (case C4): 0.000001 must serialize as the literal '0.000001', not as '1e-06' (Python's repr threshold, which is what a2a-python's json.dumps produces and what makes this a real cross-SDK break).",
+  "input": {
+    "tolerance": 1e-06
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b22746f6c6572616e6365223a302e3030303030317d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-002.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-002.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-002",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "The a2aproject/A2A#2122 'big' companion value from the same case C4: 1e21 crosses the ECMAScript fixed/exponential boundary on the large-magnitude side and must serialize in exponential form.",
+  "input": {
+    "big": 1e+21
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b22626967223a31652b32317d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-003.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-003.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-003",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Positive integers serialize with no decimal point and no fractional zeros.",
+  "input": {
+    "n": 42
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a34327d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-004.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-004.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-004",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Negative integers keep the sign and otherwise follow the same integer rule.",
+  "input": {
+    "n": -17
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a2d31377d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-005.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-005.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-005",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Zero serializes as the bare digit '0'.",
+  "input": {
+    "n": 0
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a307d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-006.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-006.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-006",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Negative zero is a distinct IEEE 754 bit pattern from positive zero, but ECMAScript's Number::toString collapses both to the same string '0' -- there is no '-0' output form.",
+  "input": {
+    "n": -0.0
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a307d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-007.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-007.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-007",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "0.1 cannot be represented exactly in IEEE 754 double precision; ECMAScript's algorithm prints the shortest decimal digit sequence that round-trips back to the same double, not the full ~17-digit exact binary expansion.",
+  "input": {
+    "n": 0.1
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a302e317d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-008.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-008.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-008",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "A five-significant-digit decimal exercises the shortest-round-trip rule on a value with more precision than 0.1.",
+  "input": {
+    "n": 3.14159
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a332e31343135397d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-009.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-009.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-009",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Number.MAX_SAFE_INTEGER (2^53 - 1): the largest integer every JS engine represents exactly, a natural boundary value for integer serialization.",
+  "input": {
+    "n": 9007199254740991
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a393030373139393235343734303939317d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-010.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-010.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-010",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "A negative decimal combines the sign rule (A5-004) with fractional shortest-digit serialization (A5-007) in one value.",
+  "input": {
+    "n": -123.456
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a2d3132332e3435367d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-011.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-011.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-011",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "One order of magnitude below the a2aproject/A2A#2122 case C4 value (A5-001): 0.0000001 (1e-7) probes the small-magnitude side of the fixed/exponential boundary that 0.000001 sits just on the fixed side of.",
+  "input": {
+    "n": 1e-07
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a31652d377d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-012.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-012.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-012",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "One order of magnitude below the C4 'big' value (A5-002): 1e20 probes the large-magnitude side of the same boundary that 1e21 sits just past.",
+  "input": {
+    "n": 1e+20
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a3130303030303030303030303030303030303030307d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-013.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-013.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-013",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "0.1 + 0.2 in IEEE 754 double arithmetic does not equal 0.3; this is the resulting value (0.30000000000000004), a classic case requiring the full shortest-round-trip digit count rather than a short 'looks clean' rounding.",
+  "input": {
+    "n": 0.30000000000000004
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a302e33303030303030303030303030303030347d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-014.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-014.json
@@ -1,0 +1,14 @@
+{
+  "id": "A5-014",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "A round integer must not be printed in exponential form just because it has trailing zeros; 100 stays '100', not '1e2'.",
+  "input": {
+    "n": 100
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226e223a3130307d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-015.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-015.json
@@ -1,0 +1,15 @@
+{
+  "id": "A5-015",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Input syntax is not preserved verbatim: '1E1' (uppercase E, RFC 8259 permits both cases) and a trailing '.0' both parse to the double values 10 and 1 respectively, and the canonical form is the ECMAScript string for that VALUE, not a copy of the input digit sequence -- this vector's input intentionally does not look like its output.",
+  "input": {
+    "exp_upper": 10.0,
+    "trailing_zero": 1.0
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226578705f7570706572223a31302c22747261696c696e675f7a65726f223a317d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-REJECT-016.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-REJECT-016.json
@@ -1,0 +1,11 @@
+{
+  "id": "A5-REJECT-016",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-REJECT",
+  "rejecting_clause": "RFC8785-3.2.2.3",
+  "rejection_layer": "canonicalization",
+  "rationale": "NaN is not a valid RFC 8259 JSON number and has no ECMAScript Number::toString representation as a JSON token; some lenient parsers accept the bare word NaN as a non-standard extension, but a conformant canonicalizer must refuse to emit it rather than pass the extension through. (confirmed refused by both independent oracles: go+py)",
+  "input_raw": "{\"n\": NaN}"
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-REJECT-017.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-REJECT-017.json
@@ -1,0 +1,11 @@
+{
+  "id": "A5-REJECT-017",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-REJECT",
+  "rejecting_clause": "RFC8785-3.2.2.3",
+  "rejection_layer": "canonicalization",
+  "rationale": "Infinity is the positive-magnitude sibling of A5-REJECT-016: not valid JSON, no canonical representation, must be refused rather than passed through by any parser lenient enough to accept the bare word. (confirmed refused by both independent oracles: go+py)",
+  "input_raw": "{\"n\": Infinity}"
+}

--- a/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-REJECT-018.json
+++ b/conformance-vectors/a2a-jcs-v01/a5-number-serialization/A5-REJECT-018.json
@@ -1,0 +1,11 @@
+{
+  "id": "A5-REJECT-018",
+  "clause": "RFC8785-3.2.2.3",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-REJECT",
+  "rejecting_clause": "RFC8785-3.2.2.3",
+  "rejection_layer": "canonicalization",
+  "rationale": "Negative infinity completes the set: same defect as A5-REJECT-017 with the sign flipped, confirming the rejection is not specific to the unsigned spelling. (confirmed refused by both independent oracles: go+py)",
+  "input_raw": "{\"n\": -Infinity}"
+}

--- a/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-001.json
+++ b/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-001.json
@@ -1,0 +1,14 @@
+{
+  "id": "A6-001",
+  "clause": "RFC8785-3.2.1",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "An empty array is a valid value and serializes as '[]' with no whitespace.",
+  "input": {
+    "items": []
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226974656d73223a5b5d7d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-002.json
+++ b/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-002.json
@@ -1,0 +1,14 @@
+{
+  "id": "A6-002",
+  "clause": "RFC8785-3.2.1",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "An empty object is a valid value and serializes as '{}' with no whitespace.",
+  "input": {
+    "config": {}
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b22636f6e666967223a7b7d7d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-003.json
+++ b/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-003.json
@@ -1,0 +1,23 @@
+{
+  "id": "A6-003",
+  "clause": "RFC8785-3.2.1",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Arrays preserve input order; RFC 8785 orders object keys, never array elements.",
+  "input": {
+    "matrix": [
+      [
+        1,
+        2
+      ],
+      [
+        3,
+        4
+      ]
+    ]
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226d6174726978223a5b5b312c325d2c5b332c345d5d7d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-004.json
+++ b/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-004.json
@@ -1,0 +1,18 @@
+{
+  "id": "A6-004",
+  "clause": "RFC8785-3.2.1",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Object nesting recurses the same key-ordering rule at every depth.",
+  "input": {
+    "a": {
+      "b": {
+        "c": 1
+      }
+    }
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2261223a7b2262223a7b2263223a317d7d7d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-005.json
+++ b/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-005.json
@@ -1,0 +1,21 @@
+{
+  "id": "A6-005",
+  "clause": "RFC8785-3.2.2.1",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "An array may mix every JSON primitive type; each element serializes per its own type's rule and array order is preserved regardless of type.",
+  "input": {
+    "mixed": [
+      1,
+      "two",
+      true,
+      false,
+      null,
+      3.5
+    ]
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b226d69786564223a5b312c2274776f222c747275652c66616c73652c6e756c6c2c332e355d7d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-006.json
+++ b/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-006.json
@@ -1,0 +1,14 @@
+{
+  "id": "A6-006",
+  "clause": "RFC8785-3.2.2.1",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "The null literal serializes as the bare token 'null'.",
+  "input": {
+    "value": null
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2276616c7565223a6e756c6c7d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-007.json
+++ b/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-007.json
@@ -1,0 +1,15 @@
+{
+  "id": "A6-007",
+  "clause": "RFC8785-3.2.2.1",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Boolean literals serialize as the bare tokens 'true'/'false', and sibling keys still sort (RFC8785-3.2.3) regardless of value type.",
+  "input": {
+    "flag_true": true,
+    "flag_false": false
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b22666c61675f66616c7365223a66616c73652c22666c61675f74727565223a747275657d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-008.json
+++ b/conformance-vectors/a2a-jcs-v01/a6-arrays-nesting-literals/A6-008.json
@@ -1,0 +1,26 @@
+{
+  "id": "A6-008",
+  "clause": "RFC8785-3.2.1",
+  "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+  "layer": "canonicalization",
+  "disposition": "MUST-ACCEPT",
+  "rationale": "Deep alternation of arrays containing objects containing arrays exercises the recursion to more than two levels; order is preserved at every array level and keys sorted at every object level.",
+  "input": {
+    "deep": [
+      {
+        "x": [
+          1,
+          {
+            "y": 2
+          }
+        ]
+      },
+      {
+        "x": []
+      }
+    ]
+  },
+  "expected": {
+    "canonical_utf8_hex": "7b2264656570223a5b7b2278223a5b312c7b2279223a327d5d7d2c7b2278223a5b5d7d5d7d"
+  }
+}

--- a/conformance-vectors/a2a-jcs-v01/gen_layer_a.py
+++ b/conformance-vectors/a2a-jcs-v01/gen_layer_a.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Generate Layer-A (canonicalization) conformance vectors for the A2A §8.4.1
-signature corpus.
+"""Generate Layer-A (canonicalization) conformance vectors for the A2A signature corpus.
 
 Every MUST-ACCEPT vector's expected bytes are computed by running the input
 through BOTH independent RFC 8785 oracles (rfc8785.py via PyPI, gowebpki/jcs
@@ -17,9 +16,11 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+
 from pathlib import Path
 
 import rfc8785
+
 
 HERE = Path(__file__).resolve().parent
 GO_ORACLE = HERE / "oracle-go" / "jcsoracle"
@@ -30,15 +31,17 @@ SPEC_REF_BASE = (
 )
 
 
-class OracleDisagreement(Exception):
-    pass
+class OracleDisagreementError(Exception):
+    """Raised when the two independent RFC 8785 oracles disagree on a MUST-ACCEPT vector."""
 
 
-def py_canonical(obj) -> bytes:
+def py_canonical(obj: object) -> bytes:
+    """Canonicalize obj with the Python (rfc8785) oracle."""
     return rfc8785.dumps(obj)
 
 
 def go_canonical(raw_json: bytes) -> bytes:
+    """Canonicalize raw_json with the Go (gowebpki/jcs) oracle."""
     p = subprocess.run(
         [str(GO_ORACLE)], input=raw_json, capture_output=True, check=False
     )
@@ -50,6 +53,7 @@ def go_canonical(raw_json: bytes) -> bytes:
 
 
 def go_rejects(raw_json: bytes) -> bool:
+    """True if the Go oracle refuses to canonicalize raw_json."""
     p = subprocess.run(
         [str(GO_ORACLE)], input=raw_json, capture_output=True, check=False
     )
@@ -83,12 +87,12 @@ def py_rejects(raw_json_text: str) -> bool:
 def make_accept(
     vid: str,
     group_dir: str,
+    *,
     clause: str,
     rationale: str,
-    input_obj,
-    *,
+    input_obj: object,
     raw_override: bytes | None = None,
-):
+) -> bytes:
     """Build one MUST-ACCEPT vector, cross-checking both oracles for real."""
     raw = (
         raw_override
@@ -98,7 +102,7 @@ def make_accept(
     py_out = py_canonical(json.loads(raw.decode("utf-8")))
     go_out = go_canonical(raw)
     if py_out != go_out:
-        raise OracleDisagreement(
+        raise OracleDisagreementError(
             f"{vid}: oracles disagree\n  py: {py_out!r}\n  go: {go_out!r}"
         )
     vector = {
@@ -118,20 +122,23 @@ def make_accept(
 def make_reject(
     vid: str,
     group_dir: str,
+    *,
     clause: str,
     rejecting_clause: str,
     rejection_layer: str,
     rationale: str,
     raw_text: str,
-):
-    """Build one MUST-REJECT vector. Requires BOTH independent oracles to
-    refuse the input -- a reject vector adjudicated by only one oracle is
-    not adjudicated at all, it is one implementation's opinion wearing a
-    two-oracle corpus's credibility. (Discovered the hard way: two earlier
-    surrogate-pair vectors passed on Python-only agreement while Go's
-    gowebpki/jcs silently substituted U+FFFD instead of erroring -- a real
-    oracle disagreement, not a harness bug, and exactly what an OR check
-    would hide.)"""
+) -> None:
+    """Build one MUST-REJECT vector.
+
+    Requires BOTH independent oracles to refuse the input -- a reject
+    vector adjudicated by only one oracle is not adjudicated at all, it is
+    one implementation's opinion wearing a two-oracle corpus's credibility.
+    (Discovered the hard way: two earlier surrogate-pair vectors passed on
+    Python-only agreement while Go's gowebpki/jcs silently substituted
+    U+FFFD instead of erroring -- a real oracle disagreement, not a harness
+    bug, and exactly what an OR check would hide.)
+    """
     refused_by_go = go_rejects(raw_text.encode("utf-8"))
     refused_by_py = py_rejects(raw_text)
     if not (refused_by_go and refused_by_py):
@@ -154,7 +161,8 @@ def make_reject(
     _write(group_dir, vid, vector)
 
 
-def _write(group_dir: str, vid: str, vector: dict):
+def _write(group_dir: str, vid: str, vector: dict) -> None:
+    """Write one vector JSON file into group_dir under OUT_ROOT."""
     d = OUT_ROOT / group_dir
     d.mkdir(parents=True, exist_ok=True)
     p = d / f"{vid}.json"
@@ -165,7 +173,8 @@ def _write(group_dir: str, vid: str, vector: dict):
     print(f"wrote {p.relative_to(HERE)}")
 
 
-def main():
+def main() -> int:
+    """Regenerate the requested groups (default: all five) into OUT_ROOT."""
     if not GO_ORACLE.exists():
         print(f"FATAL: go oracle not built at {GO_ORACLE}", file=sys.stderr)
         return 2

--- a/conformance-vectors/a2a-jcs-v01/gen_layer_a.py
+++ b/conformance-vectors/a2a-jcs-v01/gen_layer_a.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Generate Layer-A (canonicalization) conformance vectors for the A2A §8.4.1
+signature corpus.
+
+Every MUST-ACCEPT vector's expected bytes are computed by running the input
+through BOTH independent RFC 8785 oracles (rfc8785.py via PyPI, gowebpki/jcs
+via the jcsoracle Go binary) and asserting byte-for-byte agreement -- never
+hand-written or guessed. A vector whose oracles disagree is a hard error,
+not a vector.
+
+Every MUST-REJECT vector is checked against at least one oracle actually
+refusing the input (not asserted by description alone).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import rfc8785
+
+HERE = Path(__file__).resolve().parent
+GO_ORACLE = HERE / "oracle-go" / "jcsoracle"
+OUT_ROOT = HERE
+
+SPEC_REF_BASE = (
+    "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements"
+)
+
+
+class OracleDisagreement(Exception):
+    pass
+
+
+def py_canonical(obj) -> bytes:
+    return rfc8785.dumps(obj)
+
+
+def go_canonical(raw_json: bytes) -> bytes:
+    p = subprocess.run(
+        [str(GO_ORACLE)], input=raw_json, capture_output=True, check=False
+    )
+    if p.returncode != 0:
+        raise RuntimeError(
+            f"go oracle rejected input it should accept: {p.stderr.decode()}"
+        )
+    return p.stdout
+
+
+def go_rejects(raw_json: bytes) -> bool:
+    p = subprocess.run(
+        [str(GO_ORACLE)], input=raw_json, capture_output=True, check=False
+    )
+    return p.returncode != 0
+
+
+def py_rejects(raw_json_text: str) -> bool:
+    """True if the Python oracle path cannot produce valid RFC 8785 output.
+
+    Two distinct failure points count: json.loads itself refuses malformed
+    JSON (e.g. a lone surrogate that Python's json module happens to accept
+    as a string but that cannot round-trip through valid UTF-8), or
+    rfc8785.dumps refuses non-JSON values (NaN/Infinity) when asked not to
+    silently emit them.
+    """
+    try:
+        obj = json.loads(raw_json_text)
+    except (json.JSONDecodeError, ValueError):
+        return True
+    try:
+        out = rfc8785.dumps(obj)
+    except (ValueError, TypeError):
+        return True
+    try:
+        out.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return True
+    return False
+
+
+def make_accept(
+    vid: str,
+    group_dir: str,
+    clause: str,
+    rationale: str,
+    input_obj,
+    *,
+    raw_override: bytes | None = None,
+):
+    """Build one MUST-ACCEPT vector, cross-checking both oracles for real."""
+    raw = (
+        raw_override
+        if raw_override is not None
+        else json.dumps(input_obj, ensure_ascii=False).encode("utf-8")
+    )
+    py_out = py_canonical(json.loads(raw.decode("utf-8")))
+    go_out = go_canonical(raw)
+    if py_out != go_out:
+        raise OracleDisagreement(
+            f"{vid}: oracles disagree\n  py: {py_out!r}\n  go: {go_out!r}"
+        )
+    vector = {
+        "id": vid,
+        "clause": clause,
+        "spec_ref": SPEC_REF_BASE,
+        "layer": "canonicalization",
+        "disposition": "MUST-ACCEPT",
+        "rationale": rationale,
+        "input": input_obj,
+        "expected": {"canonical_utf8_hex": py_out.hex()},
+    }
+    _write(group_dir, vid, vector)
+    return py_out
+
+
+def make_reject(
+    vid: str,
+    group_dir: str,
+    clause: str,
+    rejecting_clause: str,
+    rejection_layer: str,
+    rationale: str,
+    raw_text: str,
+):
+    """Build one MUST-REJECT vector. Requires BOTH independent oracles to
+    refuse the input -- a reject vector adjudicated by only one oracle is
+    not adjudicated at all, it is one implementation's opinion wearing a
+    two-oracle corpus's credibility. (Discovered the hard way: two earlier
+    surrogate-pair vectors passed on Python-only agreement while Go's
+    gowebpki/jcs silently substituted U+FFFD instead of erroring -- a real
+    oracle disagreement, not a harness bug, and exactly what an OR check
+    would hide.)"""
+    refused_by_go = go_rejects(raw_text.encode("utf-8"))
+    refused_by_py = py_rejects(raw_text)
+    if not (refused_by_go and refused_by_py):
+        raise RuntimeError(
+            f"{vid}: oracles disagree on rejection (go={refused_by_go}, py={refused_by_py}) "
+            "-- not a valid two-oracle-adjudicated reject vector"
+        )
+    vector = {
+        "id": vid,
+        "clause": clause,
+        "spec_ref": SPEC_REF_BASE,
+        "layer": "canonicalization",
+        "disposition": "MUST-REJECT",
+        "rejecting_clause": rejecting_clause,
+        "rejection_layer": rejection_layer,
+        "rationale": rationale
+        + " (confirmed refused by both independent oracles: go+py)",
+        "input_raw": raw_text,
+    }
+    _write(group_dir, vid, vector)
+
+
+def _write(group_dir: str, vid: str, vector: dict):
+    d = OUT_ROOT / group_dir
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{vid}.json"
+    p.write_text(
+        json.dumps(vector, indent=2, ensure_ascii=False, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"wrote {p.relative_to(HERE)}")
+
+
+def main():
+    if not GO_ORACLE.exists():
+        print(f"FATAL: go oracle not built at {GO_ORACLE}", file=sys.stderr)
+        return 2
+    import importlib
+
+    all_groups = ["group_a2", "group_a3", "group_a4", "group_a5", "group_a6"]
+    for group_module in sys.argv[1:] or all_groups:
+        mod = importlib.import_module(group_module)
+        mod.generate()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance-vectors/a2a-jcs-v01/gen_manifest.py
+++ b/conformance-vectors/a2a-jcs-v01/gen_manifest.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Build MANIFEST.json for the a2a-jcs-v01 corpus: every vector's sha256,
+sorted by id, and a corpus digest that is the sha256 of the manifest body
+itself.
+"""
+
+import hashlib
+import json
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+VROOT = HERE
+
+
+def main():
+    entries = []
+    for f in sorted(VROOT.glob("*/*.json")):
+        digest = hashlib.sha256(f.read_bytes()).hexdigest()
+        entries.append({"path": str(f.relative_to(VROOT)), "sha256": digest})
+    entries.sort(key=lambda e: e["path"])
+
+    accept = sum(1 for e in entries if "REJECT" not in e["path"])
+    reject = sum(1 for e in entries if "REJECT" in e["path"])
+
+    manifest_body = {
+        "corpus": "a2a-jcs-v01",
+        "suite": "a2a-agent-card-canonicalization-conformance",
+        "specRef": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+        "layer": "canonicalization",
+        "scope": "Layer A only (RFC 8785 canonicalization + a2a signatures-exclusion); "
+        "field-presence vectors (spec section 8.4.1 rule 1) are deliberately excluded "
+        "pending resolution of a2aproject/A2A#2122's rule-1 question.",
+        "oracles": ["rfc8785 (PyPI, 0.1.4)", "gowebpki/jcs (Go, v1.0.1)"],
+        "counts": {"accept": accept, "reject": reject, "total": len(entries)},
+        "groups": sorted({e["path"].split("/")[0] for e in entries}),
+        "vectors": entries,
+    }
+    manifest_bytes = json.dumps(manifest_body, indent=2, sort_keys=False).encode(
+        "utf-8"
+    )
+    corpus_digest = hashlib.sha256(manifest_bytes).hexdigest()
+
+    manifest_body["corpusDigest"] = corpus_digest
+    out = VROOT / "MANIFEST.json"
+    out.write_text(
+        json.dumps(manifest_body, indent=2, sort_keys=False) + "\n", encoding="utf-8"
+    )
+    print(f"wrote {out}")
+    print(f"corpusDigest={corpus_digest}")
+    print(f"counts: accept={accept} reject={reject} total={len(entries)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/conformance-vectors/a2a-jcs-v01/gen_manifest.py
+++ b/conformance-vectors/a2a-jcs-v01/gen_manifest.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
-"""Build MANIFEST.json for the a2a-jcs-v01 corpus: every vector's sha256,
-sorted by id, and a corpus digest that is the sha256 of the manifest body
-itself.
+"""Build MANIFEST.json for the a2a-jcs-v01 corpus.
+
+Every vector's sha256, sorted by id, and a corpus digest that is the
+sha256 of the manifest body itself.
 """
 
 import hashlib
 import json
+
 from pathlib import Path
+
 
 HERE = Path(__file__).resolve().parent
 VROOT = HERE
 
 
-def main():
+def main() -> None:
+    """Build MANIFEST.json from every vector file under VROOT."""
     entries = []
     for f in sorted(VROOT.glob("*/*.json")):
         digest = hashlib.sha256(f.read_bytes()).hexdigest()

--- a/conformance-vectors/a2a-jcs-v01/group_a2.py
+++ b/conformance-vectors/a2a-jcs-v01/group_a2.py
@@ -1,0 +1,135 @@
+"""A2 -- signatures field exclusion. a2a spec section 8.4.1 rule 3. Reading
+a2a-python's own public source confirms the rule: `card_dict.pop(
+'signatures', None)` runs BEFORE canonicalization, because a signature
+cannot cover the field that carries itself -- the same self-reference RFC
+8785 has no opinion on, since RFC 8785 knows nothing about a2a's
+`signatures` field at all. 4 vectors, 2 MUST-REJECT.
+
+This is the one Layer-A group that is NOT pure RFC 8785: RFC 8785 has no
+concept of "exclude this key". So the verification shape differs from
+A3/A4/A5/A6, and deliberately so -- forcing it through the RFC-8785-only
+oracle harness would test the wrong thing:
+
+  MUST-ACCEPT vectors test the PRODUCTION direction: given a full object
+  that carries a `signatures` field, the canonical output is the RFC 8785
+  canonicalization of the SAME object with `signatures` removed first.
+  Both real oracles still compute the actual expected bytes (on the
+  post-exclusion object) -- nothing here is hand-derived.
+
+  MUST-REJECT vectors test the CONSUMPTION direction: a byte string
+  presented AS the canonical form that still contains a `signatures` key
+  violates the exclusion invariant and a conformant verifier must refuse
+  it before ever reaching RFC 8785 byte comparison. This is a structural
+  check (does the claimed-canonical string still carry `signatures`), not
+  an RFC-8785-well-formedness check, which is why it does not go through
+  make_reject's oracle-refusal path -- both oracles would happily
+  canonicalize a JSON object that happens to have a `signatures` key,
+  because RFC 8785 does not forbid it. a2a's OWN rule does.
+"""
+
+import json
+
+from gen_layer_a import _write, go_canonical, py_canonical
+
+GROUP = "a2-signatures-exclusion"
+
+
+def _strip_signatures(obj):
+    return {k: v for k, v in obj.items() if k != "signatures"}
+
+
+def _make_accept_excluding_signatures(vid, rationale, full_input):
+    stripped = _strip_signatures(full_input)
+    raw = json.dumps(stripped, ensure_ascii=False).encode("utf-8")
+    py_out = py_canonical(stripped)
+    go_out = go_canonical(raw)
+    if py_out != go_out:
+        raise RuntimeError(f"{vid}: oracles disagree on the post-exclusion object")
+    vector = {
+        "id": vid,
+        "clause": "a2a-spec-8.4.1-rule-3",
+        "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+        "layer": "canonicalization",
+        "disposition": "MUST-ACCEPT",
+        "rationale": rationale,
+        "input": full_input,
+        "expected": {"canonical_utf8_hex": py_out.hex()},
+    }
+    _write(GROUP, vid, vector)
+
+
+def _make_reject_signatures_present(vid, rationale, claimed_canonical_bytes: bytes):
+    # Structural check, not an oracle-refusal check: does the byte string
+    # actually being tested (what a producer WRONGLY emitted as canonical)
+    # still carry a top-level "signatures" key. Confirmed against the real
+    # parsed object rather than a substring search, so this is not fooled
+    # by e.g. a string VALUE that happens to contain the word "signatures".
+    obj = json.loads(claimed_canonical_bytes.decode("utf-8"))
+    if "signatures" not in obj:
+        raise RuntimeError(
+            f"{vid}: this is not actually a violating example -- fix the fixture"
+        )
+    vector = {
+        "id": vid,
+        "clause": "a2a-spec-8.4.1-rule-3",
+        "spec_ref": "https://a2a-protocol.org/latest/specification/#841-canonicalization-requirements",
+        "layer": "canonicalization",
+        "disposition": "MUST-REJECT",
+        "rejecting_clause": "a2a-spec-8.4.1-rule-3",
+        "rejection_layer": "canonicalization",
+        "rationale": rationale
+        + " (confirmed: the input below is valid, well-formed JSON that "
+        "parses cleanly -- both RFC 8785 oracles would canonicalize it without complaint -- and "
+        "is refused ONLY because it retains the excluded key, which is an a2a-specific rule RFC "
+        "8785 itself has no opinion on.)",
+        "input_raw": claimed_canonical_bytes.decode("utf-8"),
+    }
+    _write(GROUP, vid, vector)
+
+
+def generate():
+    _make_accept_excluding_signatures(
+        "A2-001",
+        "A card carrying a populated `signatures` array canonicalizes as if that key were "
+        "absent entirely; the exclusion is unconditional, not conditional on the array being "
+        "empty.",
+        {
+            "name": "Example Agent",
+            "capabilities": {"streaming": True, "pushNotifications": False},
+            "signatures": [
+                {"protected": "eyJhbGciOiJFUzI1NiJ9", "signature": "abc123"}
+            ],
+        },
+    )
+    _make_accept_excluding_signatures(
+        "A2-002",
+        "A card carrying an EMPTY `signatures` array ([]) is excluded the same way as a "
+        "populated one (A2-001): exclusion is by key presence, not by whether the value is "
+        "'interesting'. Compare directly against A6-001, which established that an empty array "
+        "is otherwise a perfectly normal RFC 8785 value elsewhere in a document -- the only "
+        "thing special about `signatures` is the key name.",
+        {
+            "name": "Example Agent",
+            "capabilities": {"streaming": True, "pushNotifications": False},
+            "signatures": [],
+        },
+    )
+    _make_reject_signatures_present(
+        "A2-REJECT-003",
+        "A single-signature payload presented as canonical output but still carrying its own "
+        "`signatures` array is self-referential: the bytes a signature covers cannot include "
+        "the signature that covers them, so any canonical form containing `signatures` is "
+        "definitionally wrong regardless of what RFC 8785 alone would say about it.",
+        b'{"capabilities":{"pushNotifications":false,"streaming":true},'
+        b'"name":"Example Agent",'
+        b'"signatures":[{"protected":"eyJhbGciOiJFUzI1NiJ9","signature":"abc123"}]}',
+    )
+    _make_reject_signatures_present(
+        "A2-REJECT-004",
+        "Even a `signatures` key holding an empty array must still be rejected in claimed-"
+        "canonical output: the exclusion rule is unconditional (A2-002), so its violation is "
+        "unconditional too -- an empty array does not make the self-reference acceptable, it is "
+        "still the wrong key present in the wrong place.",
+        b'{"capabilities":{"pushNotifications":false,"streaming":true},'
+        b'"name":"Example Agent","signatures":[]}',
+    )

--- a/conformance-vectors/a2a-jcs-v01/group_a2.py
+++ b/conformance-vectors/a2a-jcs-v01/group_a2.py
@@ -1,4 +1,6 @@
-"""A2 -- signatures field exclusion. a2a spec section 8.4.1 rule 3. Reading
+"""A2 -- signatures field exclusion.
+
+a2a spec section 8.4.1 rule 3. Reading
 a2a-python's own public source confirms the rule: `card_dict.pop(
 'signatures', None)` runs BEFORE canonicalization, because a signature
 cannot cover the field that carries itself -- the same self-reference RFC
@@ -31,14 +33,17 @@ import json
 
 from gen_layer_a import _write, go_canonical, py_canonical
 
+
 GROUP = "a2-signatures-exclusion"
 
 
-def _strip_signatures(obj):
+def _strip_signatures(obj: dict) -> dict:
+    """Return obj with its top-level `signatures` key removed."""
     return {k: v for k, v in obj.items() if k != "signatures"}
 
 
-def _make_accept_excluding_signatures(vid, rationale, full_input):
+def _make_accept_excluding_signatures(vid: str, rationale: str, full_input: dict) -> None:
+    """Build a MUST-ACCEPT vector for the signatures-exclusion rule."""
     stripped = _strip_signatures(full_input)
     raw = json.dumps(stripped, ensure_ascii=False).encode("utf-8")
     py_out = py_canonical(stripped)
@@ -58,12 +63,17 @@ def _make_accept_excluding_signatures(vid, rationale, full_input):
     _write(GROUP, vid, vector)
 
 
-def _make_reject_signatures_present(vid, rationale, claimed_canonical_bytes: bytes):
-    # Structural check, not an oracle-refusal check: does the byte string
-    # actually being tested (what a producer WRONGLY emitted as canonical)
-    # still carry a top-level "signatures" key. Confirmed against the real
-    # parsed object rather than a substring search, so this is not fooled
-    # by e.g. a string VALUE that happens to contain the word "signatures".
+def _make_reject_signatures_present(
+    vid: str, rationale: str, claimed_canonical_bytes: bytes
+) -> None:
+    """Build a MUST-REJECT vector for claimed-canonical output that still carries `signatures`.
+
+    Structural check, not an oracle-refusal check: does the byte string
+    actually being tested (what a producer WRONGLY emitted as canonical)
+    still carry a top-level "signatures" key. Confirmed against the real
+    parsed object rather than a substring search, so this is not fooled
+    by e.g. a string VALUE that happens to contain the word "signatures".
+    """
     obj = json.loads(claimed_canonical_bytes.decode("utf-8"))
     if "signatures" not in obj:
         raise RuntimeError(
@@ -87,7 +97,8 @@ def _make_reject_signatures_present(vid, rationale, claimed_canonical_bytes: byt
     _write(GROUP, vid, vector)
 
 
-def generate():
+def generate() -> None:
+    """Emit all four A2 (signatures-exclusion) vectors."""
     _make_accept_excluding_signatures(
         "A2-001",
         "A card carrying a populated `signatures` array canonicalizes as if that key were "

--- a/conformance-vectors/a2a-jcs-v01/group_a3.py
+++ b/conformance-vectors/a2a-jcs-v01/group_a3.py
@@ -1,8 +1,10 @@
-"""A3 -- object key ordering. RFC 8785 sect. 3.2.3: object properties are
-ordered by comparing their names as sequences of UTF-16 code units, NOT by
-Unicode code point and NOT "lexicographic by key" as the a2a spec's own
-gloss puts it -- that gloss is the defect reported at
-a2aproject/A2A#2122. 12 vectors, 2 MUST-REJECT; re-derive from MANIFEST.json.
+"""A3 -- object key ordering.
+
+RFC 8785 sect. 3.2.3: object properties are ordered by comparing their
+names as sequences of UTF-16 code units, NOT by Unicode code point and NOT
+"lexicographic by key" as the a2a spec's own gloss puts it -- that gloss is
+the defect reported at a2aproject/A2A#2122. 12 vectors, 2 MUST-REJECT;
+re-derive from MANIFEST.json.
 
 A3-006 is the load-bearing vector: it is the exact counterexample from
 that report (case C3), the case where a2a-python (code-point sort) and
@@ -15,90 +17,100 @@ import json
 
 from gen_layer_a import make_accept, make_reject
 
+
 GROUP = "a3-object-key-ordering"
 
 
-def generate():
+def generate() -> None:
+    """Emit all twelve A3 (object key ordering) vectors."""
     make_accept(
         "A3-001",
         GROUP,
-        "RFC8785-3.2.3",
-        "Baseline: keys already in UTF-16 code-unit order pass through unchanged.",
-        {"a": 1, "b": 2, "c": 3},
+        clause="RFC8785-3.2.3",
+        rationale="Baseline: keys already in UTF-16 code-unit order pass through unchanged.",
+        input_obj={"a": 1, "b": 2, "c": 3},
     )
     make_accept(
         "A3-002",
         GROUP,
-        "RFC8785-3.2.3",
-        "Keys given out of order must be reordered to UTF-16 code-unit order.",
-        {"zebra": 1, "apple": 2, "mango": 3},
+        clause="RFC8785-3.2.3",
+        rationale="Keys given out of order must be reordered to UTF-16 code-unit order.",
+        input_obj={"zebra": 1, "apple": 2, "mango": 3},
     )
     make_accept(
         "A3-003",
         GROUP,
-        "RFC8785-3.2.3",
-        "Case sensitivity: uppercase ASCII (U+0041 'A') sorts before lowercase ASCII (U+0061 'a') as a raw code unit.",
-        {"apple": 1, "Apple": 2},
+        clause="RFC8785-3.2.3",
+        rationale="Case sensitivity: uppercase ASCII (U+0041 'A') sorts before lowercase ASCII (U+0061 'a') as a raw code unit.",
+        input_obj={"apple": 1, "Apple": 2},
     )
     make_accept(
         "A3-004",
         GROUP,
-        "RFC8785-3.2.3",
-        "Numeric-looking keys sort as UTF-16 code-unit sequences, not as numbers: '1' < '10' < '2'.",
-        {"10": 1, "2": 2, "1": 3},
+        clause="RFC8785-3.2.3",
+        rationale="Numeric-looking keys sort as UTF-16 code-unit sequences, not as numbers: '1' < '10' < '2'.",
+        input_obj={"10": 1, "2": 2, "1": 3},
     )
     make_accept(
         "A3-005",
         GROUP,
-        "RFC8785-3.2.3",
-        "A BMP character above the ASCII range (U+00E9 'e with acute') sorts after every ASCII key.",
-        {"cafe": 1, "café": 2},
+        clause="RFC8785-3.2.3",
+        rationale="A BMP character above the ASCII range (U+00E9 'e with acute') sorts after every ASCII key.",
+        input_obj={"cafe": 1, "café": 2},
     )
     make_accept(
         "A3-006",
         GROUP,
-        "RFC8785-3.2.3",
-        "The a2aproject/A2A#2122 counterexample verbatim (case C3): "
-        "a key containing U+1F600 (surrogate pair D83D DE00) sorts BEFORE a key containing "
-        "U+FF01 (single unit FF01), because D83D < FF01 as raw UTF-16 code units, even though "
-        "the code POINT 1F600 is numerically greater than FF01. Sorting by code point instead "
-        "of UTF-16 code unit -- what a2a-python's sort_keys=True does -- gets this pair backwards.",
-        {"b\U0001f600key": 1, "b！key": 2},
+        clause="RFC8785-3.2.3",
+        rationale=(
+            "The a2aproject/A2A#2122 counterexample verbatim (case C3): "
+            "a key containing U+1F600 (surrogate pair D83D DE00) sorts BEFORE a key containing "
+            "U+FF01 (single unit FF01), because D83D < FF01 as raw UTF-16 code units, even though "
+            "the code POINT 1F600 is numerically greater than FF01. Sorting by code point instead "
+            "of UTF-16 code unit -- what a2a-python's sort_keys=True does -- gets this pair backwards."
+        ),
+        input_obj={"b\U0001f600key": 1, "b！key": 2},  # noqa: RUF001 -- U+FF01 is the deliberate test input, not a typo
     )
     make_accept(
         "A3-007",
         GROUP,
-        "RFC8785-3.2.3",
-        "A second astral-vs-high-BMP inversion pair, generalizing A3-006 beyond one example: "
-        "U+10000 (surrogate pair D800 DC00) sorts before U+E000 (single unit E000, Private Use "
-        "Area) by the same UTF-16-vs-code-point divergence.",
-        {"x\U00010000end": 1, "xend": 2},
+        clause="RFC8785-3.2.3",
+        rationale=(
+            "A second astral-vs-high-BMP inversion pair, generalizing A3-006 beyond one example: "
+            "U+10000 (surrogate pair D800 DC00) sorts before U+E000 (single unit E000, Private Use "
+            "Area) by the same UTF-16-vs-code-point divergence."
+        ),
+        input_obj={"x\U00010000end": 1, "xend": 2},
     )
     make_accept(
         "A3-008",
         GROUP,
-        "RFC8785-3.2.3",
-        "Two byte-distinct keys that render identically to a human (precomposed U+00E9 vs the "
-        "combining-character sequence 'e' + U+0301) are different code-unit sequences with no "
-        "normalization applied by RFC 8785; they sort as the distinct sequences they are, and "
-        "the combining form (starts with plain ASCII 'e', U+0065) sorts before the precomposed "
-        "form (starts with U+00E9).",
-        {"café": 1, "café": 2},
+        clause="RFC8785-3.2.3",
+        rationale=(
+            "Two byte-distinct keys that render identically to a human (precomposed U+00E9 vs the "
+            "combining-character sequence 'e' + U+0301) are different code-unit sequences with no "
+            "normalization applied by RFC 8785; they sort as the distinct sequences they are, and "
+            "the combining form (starts with plain ASCII 'e', U+0065) sorts before the precomposed "
+            "form (starts with U+00E9)."
+        ),
+        input_obj={"café": 1, "café": 2},  # precomposed U+00E9 vs combining form (e + U+0301)
     )
     make_accept(
         "A3-009",
         GROUP,
-        "RFC8785-3.2.3",
-        "The empty string is a valid key and, having zero code units, sorts before every non-empty key.",
-        {"": 1, "a": 2},
+        clause="RFC8785-3.2.3",
+        rationale="The empty string is a valid key and, having zero code units, sorts before every non-empty key.",
+        input_obj={"": 1, "a": 2},
     )
     make_accept(
         "A3-010",
         GROUP,
-        "RFC8785-3.2.3",
-        "Stress case: eleven keys spanning ASCII, digits and mixed case sorted together, "
-        "confirming the ordering rule is stable across more than a handful of keys at once.",
-        {
+        clause="RFC8785-3.2.3",
+        rationale=(
+            "Stress case: eleven keys spanning ASCII, digits and mixed case sorted together, "
+            "confirming the ordering rule is stable across more than a handful of keys at once."
+        ),
+        input_obj={
             "Zulu": 1,
             "alpha": 2,
             "Bravo": 3,
@@ -115,26 +127,30 @@ def generate():
     make_reject(
         "A3-REJECT-011",
         GROUP,
-        "RFC8785-3.2.3",
+        clause="RFC8785-3.2.3",
         rejecting_clause="RFC8785-3.2.2.2",
         rejection_layer="canonicalization",
-        rationale="A key containing a lone (unpaired) high surrogate U+D800 with no following "
-        "low surrogate is not valid Unicode text and has no well-formed UTF-8 encoding, so it "
-        "cannot be assigned a UTF-16 code-unit sort position or emitted as literal UTF-8 (RFC "
-        "8785 sect. 3.2.2.2); a conformant canonicalizer must refuse it rather than silently "
-        "pass the unpaired surrogate through or substitute a replacement character.",
+        rationale=(
+            "A key containing a lone (unpaired) high surrogate U+D800 with no following "
+            "low surrogate is not valid Unicode text and has no well-formed UTF-8 encoding, so it "
+            "cannot be assigned a UTF-16 code-unit sort position or emitted as literal UTF-8 (RFC "
+            "8785 sect. 3.2.2.2); a conformant canonicalizer must refuse it rather than silently "
+            "pass the unpaired surrogate through or substitute a replacement character."
+        ),
         raw_text='{"b\\ud800key": 1, "a": 2}',
     )
     make_reject(
         "A3-REJECT-012",
         GROUP,
-        "RFC8785-3.2.3",
+        clause="RFC8785-3.2.3",
         rejecting_clause="RFC8785-3.2.2.2",
         rejection_layer="canonicalization",
-        rationale="A key containing a lone (unpaired) LOW surrogate U+DC00 with no preceding "
-        "high surrogate completes A3-REJECT-011's high-surrogate case with the low-surrogate "
-        "half of the pair: equally invalid Unicode, equally unencodable as well-formed UTF-8, "
-        "for the same reason.",
+        rationale=(
+            "A key containing a lone (unpaired) LOW surrogate U+DC00 with no preceding "
+            "high surrogate completes A3-REJECT-011's high-surrogate case with the low-surrogate "
+            "half of the pair: equally invalid Unicode, equally unencodable as well-formed UTF-8, "
+            "for the same reason."
+        ),
         raw_text='{"b\\udc00key": 1, "a": 2}',
     )
 

--- a/conformance-vectors/a2a-jcs-v01/group_a3.py
+++ b/conformance-vectors/a2a-jcs-v01/group_a3.py
@@ -1,0 +1,150 @@
+"""A3 -- object key ordering. RFC 8785 sect. 3.2.3: object properties are
+ordered by comparing their names as sequences of UTF-16 code units, NOT by
+Unicode code point and NOT "lexicographic by key" as the a2a spec's own
+gloss puts it -- that gloss is the defect reported at
+a2aproject/A2A#2122. 12 vectors, 2 MUST-REJECT; re-derive from MANIFEST.json.
+
+A3-006 is the load-bearing vector: it is the exact counterexample from
+that report (case C3), the case where a2a-python (code-point sort) and
+a2a-js (UTF-16 sort) produce different bytes for the same card. Any
+canonicalizer that sorts by code point instead of UTF-16 code unit fails
+this single vector, which is the entire point of shipping it.
+"""
+
+import json
+
+from gen_layer_a import make_accept, make_reject
+
+GROUP = "a3-object-key-ordering"
+
+
+def generate():
+    make_accept(
+        "A3-001",
+        GROUP,
+        "RFC8785-3.2.3",
+        "Baseline: keys already in UTF-16 code-unit order pass through unchanged.",
+        {"a": 1, "b": 2, "c": 3},
+    )
+    make_accept(
+        "A3-002",
+        GROUP,
+        "RFC8785-3.2.3",
+        "Keys given out of order must be reordered to UTF-16 code-unit order.",
+        {"zebra": 1, "apple": 2, "mango": 3},
+    )
+    make_accept(
+        "A3-003",
+        GROUP,
+        "RFC8785-3.2.3",
+        "Case sensitivity: uppercase ASCII (U+0041 'A') sorts before lowercase ASCII (U+0061 'a') as a raw code unit.",
+        {"apple": 1, "Apple": 2},
+    )
+    make_accept(
+        "A3-004",
+        GROUP,
+        "RFC8785-3.2.3",
+        "Numeric-looking keys sort as UTF-16 code-unit sequences, not as numbers: '1' < '10' < '2'.",
+        {"10": 1, "2": 2, "1": 3},
+    )
+    make_accept(
+        "A3-005",
+        GROUP,
+        "RFC8785-3.2.3",
+        "A BMP character above the ASCII range (U+00E9 'e with acute') sorts after every ASCII key.",
+        {"cafe": 1, "café": 2},
+    )
+    make_accept(
+        "A3-006",
+        GROUP,
+        "RFC8785-3.2.3",
+        "The a2aproject/A2A#2122 counterexample verbatim (case C3): "
+        "a key containing U+1F600 (surrogate pair D83D DE00) sorts BEFORE a key containing "
+        "U+FF01 (single unit FF01), because D83D < FF01 as raw UTF-16 code units, even though "
+        "the code POINT 1F600 is numerically greater than FF01. Sorting by code point instead "
+        "of UTF-16 code unit -- what a2a-python's sort_keys=True does -- gets this pair backwards.",
+        {"b\U0001f600key": 1, "b！key": 2},
+    )
+    make_accept(
+        "A3-007",
+        GROUP,
+        "RFC8785-3.2.3",
+        "A second astral-vs-high-BMP inversion pair, generalizing A3-006 beyond one example: "
+        "U+10000 (surrogate pair D800 DC00) sorts before U+E000 (single unit E000, Private Use "
+        "Area) by the same UTF-16-vs-code-point divergence.",
+        {"x\U00010000end": 1, "xend": 2},
+    )
+    make_accept(
+        "A3-008",
+        GROUP,
+        "RFC8785-3.2.3",
+        "Two byte-distinct keys that render identically to a human (precomposed U+00E9 vs the "
+        "combining-character sequence 'e' + U+0301) are different code-unit sequences with no "
+        "normalization applied by RFC 8785; they sort as the distinct sequences they are, and "
+        "the combining form (starts with plain ASCII 'e', U+0065) sorts before the precomposed "
+        "form (starts with U+00E9).",
+        {"café": 1, "café": 2},
+    )
+    make_accept(
+        "A3-009",
+        GROUP,
+        "RFC8785-3.2.3",
+        "The empty string is a valid key and, having zero code units, sorts before every non-empty key.",
+        {"": 1, "a": 2},
+    )
+    make_accept(
+        "A3-010",
+        GROUP,
+        "RFC8785-3.2.3",
+        "Stress case: eleven keys spanning ASCII, digits and mixed case sorted together, "
+        "confirming the ordering rule is stable across more than a handful of keys at once.",
+        {
+            "Zulu": 1,
+            "alpha": 2,
+            "Bravo": 3,
+            "charlie": 4,
+            "Delta": 5,
+            "9key": 6,
+            "echo": 7,
+            "Foxtrot": 8,
+            "1key": 9,
+            "golf": 10,
+            "Hotel": 11,
+        },
+    )
+    make_reject(
+        "A3-REJECT-011",
+        GROUP,
+        "RFC8785-3.2.3",
+        rejecting_clause="RFC8785-3.2.2.2",
+        rejection_layer="canonicalization",
+        rationale="A key containing a lone (unpaired) high surrogate U+D800 with no following "
+        "low surrogate is not valid Unicode text and has no well-formed UTF-8 encoding, so it "
+        "cannot be assigned a UTF-16 code-unit sort position or emitted as literal UTF-8 (RFC "
+        "8785 sect. 3.2.2.2); a conformant canonicalizer must refuse it rather than silently "
+        "pass the unpaired surrogate through or substitute a replacement character.",
+        raw_text='{"b\\ud800key": 1, "a": 2}',
+    )
+    make_reject(
+        "A3-REJECT-012",
+        GROUP,
+        "RFC8785-3.2.3",
+        rejecting_clause="RFC8785-3.2.2.2",
+        rejection_layer="canonicalization",
+        rationale="A key containing a lone (unpaired) LOW surrogate U+DC00 with no preceding "
+        "high surrogate completes A3-REJECT-011's high-surrogate case with the low-surrogate "
+        "half of the pair: equally invalid Unicode, equally unencodable as well-formed UTF-8, "
+        "for the same reason.",
+        raw_text='{"b\\udc00key": 1, "a": 2}',
+    )
+
+
+if __name__ == "__main__":
+    # smoke: confirm the raw JSON literals above are syntactically valid JSON
+    # (Python's json.loads accepts lone surrogates in \u escapes, which is
+    # exactly why these are schema-valid-but-canonicalization-invalid rather
+    # than parser-rejected -- the distinction the design doc requires for a
+    # vector to count toward coverage at all).
+    for t in ['{"b\\ud800key": 1, "a": 2}', '{"b\\udc00key": 1, "a": 2}']:
+        json.loads(t)
+    print("raw reject literals are schema-valid JSON, as required")

--- a/conformance-vectors/a2a-jcs-v01/group_a4.py
+++ b/conformance-vectors/a2a-jcs-v01/group_a4.py
@@ -1,0 +1,159 @@
+"""A4 -- string serialization. RFC 8785 sect. 3.2.2.2: string values are
+emitted as literal UTF-8 outside the mandatory JSON escape set (quote,
+backslash, and control characters below U+0020), NEVER as \\uXXXX escapes
+for ordinary non-ASCII text. 15 vectors, 3 MUST-REJECT; re-derive from MANIFEST.json.
+
+A4-001 is the load-bearing vector: it is the exact counterexample from
+a2aproject/A2A#2122 (case C2) -- the case where a2a-python's
+ensure_ascii=True default breaks cross-SDK verification for any card with
+an accent in it.
+"""
+
+from gen_layer_a import make_accept, make_reject
+
+GROUP = "a4-string-serialization"
+
+
+def generate():
+    make_accept(
+        "A4-001",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "The a2aproject/A2A#2122 counterexample verbatim (case C2): "
+        "a non-ASCII scalar (e with acute, U+00E9) is emitted as literal UTF-8 bytes, never as "
+        "a \\u00e9 escape. ensure_ascii=True in Python's json.dumps -- a2a-python's actual "
+        "default -- produces the escaped form and fails this vector.",
+        {"name": "Café Agent", "description": "Planifie des itinéraires."},
+    )
+    make_accept(
+        "A4-002",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "Pure ASCII content is the trivial control case: no escaping needed, output equals input.",
+        {"name": "Example Agent"},
+    )
+    make_accept(
+        "A4-003",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "An astral-plane character (U+1F600 GRINNING FACE, outside the Basic Multilingual "
+        "Plane, requiring a UTF-16 surrogate pair to represent but a single 4-byte UTF-8 "
+        "sequence) is emitted as literal UTF-8, not as a \\ud83d\\ude00 surrogate-pair escape.",
+        {"note": "hello \U0001f600 world"},
+    )
+    make_accept(
+        "A4-004",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "The mandatory escape set is exactly quote, backslash, and control characters below "
+        "U+0020: this string exercises all three (a literal quote, a literal backslash, and a "
+        "literal newline), each of which MUST still be escaped even though non-ASCII text is "
+        "emitted literally.",
+        {"raw": 'a "quoted" \\ path\nwith a newline'},
+    )
+    make_accept(
+        "A4-005",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "The empty string is a valid scalar value and serializes as a pair of quote characters "
+        "with nothing between them.",
+        {"empty": ""},
+    )
+    make_accept(
+        "A4-006",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "Every remaining C0 control character (U+0001 through U+001F, excluding the ones with "
+        "short escapes like \\n and \\t) must still be escaped as \\u00XX -- control-character "
+        "escaping is required regardless of the literal-UTF-8 rule for ordinary text, since "
+        "control characters are never literal in a JSON string.",
+        {"ctrl": "abc"},
+    )
+    make_accept(
+        "A4-007",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "A CJK ideograph (U+4E2D, three-byte UTF-8) is emitted as literal UTF-8, the same rule "
+        "as A4-001 applied to a script outside the Latin-1 range.",
+        {"label": "中文"},
+    )
+    make_accept(
+        "A4-008",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "U+007F (DELETE) sits immediately above the printable ASCII range and below the C1 "
+        "control block; RFC 8785 requires literal UTF-8 for it like any other non-mandatory-"
+        "escape character, it is not part of the U+0000-U+001F mandatory escape set.",
+        {"del": "ab"},
+    )
+    make_accept(
+        "A4-009",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "A combining diacritic (U+0301 COMBINING ACUTE ACCENT) immediately following its base "
+        "character is ordinary non-ASCII text with no special JSON-string handling; it is "
+        "emitted as literal UTF-8 like any other codepoint outside the escape set.",
+        {"combining": "éclair"},
+    )
+    make_accept(
+        "A4-010",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "Right-to-left script content (Arabic, U+0627 ALEF through U+0629 TEH MARBUTA) is "
+        "emitted as literal UTF-8 bytes; RFC 8785 has no bidi-aware transform, only byte "
+        "identity.",
+        {"rtl": "السلام"},
+    )
+    make_accept(
+        "A4-011",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "Forward slash is explicitly NOT in JSON's mandatory escape set (unlike some JSON "
+        "encoders' optional habit of escaping it as \\/) and must be emitted literally.",
+        {"url": "https://example.com/a2a/v1"},
+    )
+    make_accept(
+        "A4-012",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        "A string built entirely from two adjacent astral-plane characters (both requiring "
+        "surrogate pairs in UTF-16) confirms multi-character non-BMP content is handled, not "
+        "just a single isolated case like A4-003.",
+        {"emoji_pair": "\U0001f600\U0001f601"},
+    )
+    make_reject(
+        "A4-REJECT-013",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        rejecting_clause="RFC8785-3.2.2.2",
+        rejection_layer="canonicalization",
+        rationale="A lone (unpaired) low surrogate U+DC00 inside a STRING VALUE (not a key, "
+        "unlike A3-REJECT-011/012) is not valid Unicode text and has no well-formed UTF-8 "
+        "encoding; a conformant canonicalizer must refuse it rather than emit an invalid byte "
+        "sequence or silently substitute U+FFFD.",
+        raw_text='{"name": "broken \\udc00 value"}',
+    )
+    make_reject(
+        "A4-REJECT-014",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        rejecting_clause="RFC8785-3.2.2.2",
+        rejection_layer="canonicalization",
+        rationale="A lone low surrogate (U+DC00) embedded mid-string, with ordinary text both "
+        "before and after it, is the string-value counterpart to A3-REJECT-012's key-position "
+        "case: unpaired, not valid Unicode, no well-formed UTF-8 encoding, and unlike "
+        "A4-REJECT-013's simpler isolated case this confirms the defect is caught with real "
+        "surrounding content rather than only in a minimal reproduction.",
+        raw_text='{"name": "before\\udc00after"}',
+    )
+    make_reject(
+        "A4-REJECT-015",
+        GROUP,
+        "RFC8785-3.2.2.2",
+        rejecting_clause="RFC8785-3.2.2.2",
+        rejection_layer="canonicalization",
+        rationale="A high surrogate (U+D800) followed by an ordinary BMP character (a plain "
+        "letter, not its matching low surrogate) leaves the high surrogate unpaired for "
+        "exactly the same reason as A4-REJECT-013/014, just constructed a third way.",
+        raw_text='{"name": "\\ud800x"}',
+    )

--- a/conformance-vectors/a2a-jcs-v01/group_a4.py
+++ b/conformance-vectors/a2a-jcs-v01/group_a4.py
@@ -1,7 +1,9 @@
-"""A4 -- string serialization. RFC 8785 sect. 3.2.2.2: string values are
-emitted as literal UTF-8 outside the mandatory JSON escape set (quote,
-backslash, and control characters below U+0020), NEVER as \\uXXXX escapes
-for ordinary non-ASCII text. 15 vectors, 3 MUST-REJECT; re-derive from MANIFEST.json.
+r"""A4 -- string serialization.
+
+RFC 8785 sect. 3.2.2.2: string values are emitted as literal UTF-8 outside
+the mandatory JSON escape set (quote, backslash, and control characters
+below U+0020), NEVER as \uXXXX escapes for ordinary non-ASCII text.
+15 vectors, 3 MUST-REJECT; re-derive from MANIFEST.json.
 
 A4-001 is the load-bearing vector: it is the exact counterexample from
 a2aproject/A2A#2122 (case C2) -- the case where a2a-python's
@@ -11,149 +13,176 @@ an accent in it.
 
 from gen_layer_a import make_accept, make_reject
 
+
 GROUP = "a4-string-serialization"
 
 
-def generate():
+def generate() -> None:
+    """Emit all fifteen A4 (string serialization) vectors."""
     make_accept(
         "A4-001",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "The a2aproject/A2A#2122 counterexample verbatim (case C2): "
-        "a non-ASCII scalar (e with acute, U+00E9) is emitted as literal UTF-8 bytes, never as "
-        "a \\u00e9 escape. ensure_ascii=True in Python's json.dumps -- a2a-python's actual "
-        "default -- produces the escaped form and fails this vector.",
-        {"name": "Café Agent", "description": "Planifie des itinéraires."},
+        clause="RFC8785-3.2.2.2",
+        rationale=(
+            "The a2aproject/A2A#2122 counterexample verbatim (case C2): "
+            "a non-ASCII scalar (e with acute, U+00E9) is emitted as literal UTF-8 bytes, never as "
+            "a \\u00e9 escape. ensure_ascii=True in Python's json.dumps -- a2a-python's actual "
+            "default -- produces the escaped form and fails this vector."
+        ),
+        input_obj={"name": "Café Agent", "description": "Planifie des itinéraires."},
     )
     make_accept(
         "A4-002",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "Pure ASCII content is the trivial control case: no escaping needed, output equals input.",
-        {"name": "Example Agent"},
+        clause="RFC8785-3.2.2.2",
+        rationale="Pure ASCII content is the trivial control case: no escaping needed, output equals input.",
+        input_obj={"name": "Example Agent"},
     )
     make_accept(
         "A4-003",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "An astral-plane character (U+1F600 GRINNING FACE, outside the Basic Multilingual "
-        "Plane, requiring a UTF-16 surrogate pair to represent but a single 4-byte UTF-8 "
-        "sequence) is emitted as literal UTF-8, not as a \\ud83d\\ude00 surrogate-pair escape.",
-        {"note": "hello \U0001f600 world"},
+        clause="RFC8785-3.2.2.2",
+        rationale=(
+            "An astral-plane character (U+1F600 GRINNING FACE, outside the Basic Multilingual "
+            "Plane, requiring a UTF-16 surrogate pair to represent but a single 4-byte UTF-8 "
+            "sequence) is emitted as literal UTF-8, not as a \\ud83d\\ude00 surrogate-pair escape."
+        ),
+        input_obj={"note": "hello \U0001f600 world"},
     )
     make_accept(
         "A4-004",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "The mandatory escape set is exactly quote, backslash, and control characters below "
-        "U+0020: this string exercises all three (a literal quote, a literal backslash, and a "
-        "literal newline), each of which MUST still be escaped even though non-ASCII text is "
-        "emitted literally.",
-        {"raw": 'a "quoted" \\ path\nwith a newline'},
+        clause="RFC8785-3.2.2.2",
+        rationale=(
+            "The mandatory escape set is exactly quote, backslash, and control characters below "
+            "U+0020: this string exercises all three (a literal quote, a literal backslash, and a "
+            "literal newline), each of which MUST still be escaped even though non-ASCII text is "
+            "emitted literally."
+        ),
+        input_obj={"raw": 'a "quoted" \\ path\nwith a newline'},
     )
     make_accept(
         "A4-005",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "The empty string is a valid scalar value and serializes as a pair of quote characters "
-        "with nothing between them.",
-        {"empty": ""},
+        clause="RFC8785-3.2.2.2",
+        rationale="The empty string is a valid scalar value and serializes as a pair of quote characters with nothing between them.",
+        input_obj={"empty": ""},
     )
     make_accept(
         "A4-006",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "Every remaining C0 control character (U+0001 through U+001F, excluding the ones with "
-        "short escapes like \\n and \\t) must still be escaped as \\u00XX -- control-character "
-        "escaping is required regardless of the literal-UTF-8 rule for ordinary text, since "
-        "control characters are never literal in a JSON string.",
-        {"ctrl": "abc"},
+        clause="RFC8785-3.2.2.2",
+        rationale=(
+            "Every remaining C0 control character (U+0001 through U+001F, excluding the ones with "
+            "short escapes like \\n and \\t) must still be escaped as \\u00XX -- control-character "
+            "escaping is required regardless of the literal-UTF-8 rule for ordinary text, since "
+            "control characters are never literal in a JSON string."
+        ),
+        input_obj={"ctrl": "abc"},
     )
     make_accept(
         "A4-007",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "A CJK ideograph (U+4E2D, three-byte UTF-8) is emitted as literal UTF-8, the same rule "
-        "as A4-001 applied to a script outside the Latin-1 range.",
-        {"label": "中文"},
+        clause="RFC8785-3.2.2.2",
+        rationale=(
+            "A CJK ideograph (U+4E2D, three-byte UTF-8) is emitted as literal UTF-8, the same rule "
+            "as A4-001 applied to a script outside the Latin-1 range."
+        ),
+        input_obj={"label": "中文"},
     )
     make_accept(
         "A4-008",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "U+007F (DELETE) sits immediately above the printable ASCII range and below the C1 "
-        "control block; RFC 8785 requires literal UTF-8 for it like any other non-mandatory-"
-        "escape character, it is not part of the U+0000-U+001F mandatory escape set.",
-        {"del": "ab"},
+        clause="RFC8785-3.2.2.2",
+        rationale=(
+            "U+007F (DELETE) sits immediately above the printable ASCII range and below the C1 "
+            "control block; RFC 8785 requires literal UTF-8 for it like any other non-mandatory-"
+            "escape character, it is not part of the U+0000-U+001F mandatory escape set."
+        ),
+        input_obj={"del": "ab"},
     )
     make_accept(
         "A4-009",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "A combining diacritic (U+0301 COMBINING ACUTE ACCENT) immediately following its base "
-        "character is ordinary non-ASCII text with no special JSON-string handling; it is "
-        "emitted as literal UTF-8 like any other codepoint outside the escape set.",
-        {"combining": "éclair"},
+        clause="RFC8785-3.2.2.2",
+        rationale=(
+            "A combining diacritic (U+0301 COMBINING ACUTE ACCENT) immediately following its base "
+            "character is ordinary non-ASCII text with no special JSON-string handling; it is "
+            "emitted as literal UTF-8 like any other codepoint outside the escape set."
+        ),
+        input_obj={"combining": "éclair"},
     )
     make_accept(
         "A4-010",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "Right-to-left script content (Arabic, U+0627 ALEF through U+0629 TEH MARBUTA) is "
-        "emitted as literal UTF-8 bytes; RFC 8785 has no bidi-aware transform, only byte "
-        "identity.",
-        {"rtl": "السلام"},
+        clause="RFC8785-3.2.2.2",
+        rationale=(
+            "Right-to-left script content (Arabic, U+0627 ALEF through U+0629 TEH MARBUTA) is "
+            "emitted as literal UTF-8 bytes; RFC 8785 has no bidi-aware transform, only byte "
+            "identity."
+        ),
+        input_obj={"rtl": "السلام"},
     )
     make_accept(
         "A4-011",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "Forward slash is explicitly NOT in JSON's mandatory escape set (unlike some JSON "
-        "encoders' optional habit of escaping it as \\/) and must be emitted literally.",
-        {"url": "https://example.com/a2a/v1"},
+        clause="RFC8785-3.2.2.2",
+        rationale=(
+            "Forward slash is explicitly NOT in JSON's mandatory escape set (unlike some JSON "
+            "encoders' optional habit of escaping it as \\/) and must be emitted literally."
+        ),
+        input_obj={"url": "https://example.com/a2a/v1"},
     )
     make_accept(
         "A4-012",
         GROUP,
-        "RFC8785-3.2.2.2",
-        "A string built entirely from two adjacent astral-plane characters (both requiring "
-        "surrogate pairs in UTF-16) confirms multi-character non-BMP content is handled, not "
-        "just a single isolated case like A4-003.",
-        {"emoji_pair": "\U0001f600\U0001f601"},
+        clause="RFC8785-3.2.2.2",
+        rationale=(
+            "A string built entirely from two adjacent astral-plane characters (both requiring "
+            "surrogate pairs in UTF-16) confirms multi-character non-BMP content is handled, not "
+            "just a single isolated case like A4-003."
+        ),
+        input_obj={"emoji_pair": "\U0001f600\U0001f601"},
     )
     make_reject(
         "A4-REJECT-013",
         GROUP,
-        "RFC8785-3.2.2.2",
+        clause="RFC8785-3.2.2.2",
         rejecting_clause="RFC8785-3.2.2.2",
         rejection_layer="canonicalization",
-        rationale="A lone (unpaired) low surrogate U+DC00 inside a STRING VALUE (not a key, "
-        "unlike A3-REJECT-011/012) is not valid Unicode text and has no well-formed UTF-8 "
-        "encoding; a conformant canonicalizer must refuse it rather than emit an invalid byte "
-        "sequence or silently substitute U+FFFD.",
+        rationale=(
+            "A lone (unpaired) low surrogate U+DC00 inside a STRING VALUE (not a key, "
+            "unlike A3-REJECT-011/012) is not valid Unicode text and has no well-formed UTF-8 "
+            "encoding; a conformant canonicalizer must refuse it rather than emit an invalid byte "
+            "sequence or silently substitute U+FFFD."
+        ),
         raw_text='{"name": "broken \\udc00 value"}',
     )
     make_reject(
         "A4-REJECT-014",
         GROUP,
-        "RFC8785-3.2.2.2",
+        clause="RFC8785-3.2.2.2",
         rejecting_clause="RFC8785-3.2.2.2",
         rejection_layer="canonicalization",
-        rationale="A lone low surrogate (U+DC00) embedded mid-string, with ordinary text both "
-        "before and after it, is the string-value counterpart to A3-REJECT-012's key-position "
-        "case: unpaired, not valid Unicode, no well-formed UTF-8 encoding, and unlike "
-        "A4-REJECT-013's simpler isolated case this confirms the defect is caught with real "
-        "surrounding content rather than only in a minimal reproduction.",
+        rationale=(
+            "A lone low surrogate (U+DC00) embedded mid-string, with ordinary text both "
+            "before and after it, is the string-value counterpart to A3-REJECT-012's key-position "
+            "case: unpaired, not valid Unicode, no well-formed UTF-8 encoding, and unlike "
+            "A4-REJECT-013's simpler isolated case this confirms the defect is caught with real "
+            "surrounding content rather than only in a minimal reproduction."
+        ),
         raw_text='{"name": "before\\udc00after"}',
     )
     make_reject(
         "A4-REJECT-015",
         GROUP,
-        "RFC8785-3.2.2.2",
+        clause="RFC8785-3.2.2.2",
         rejecting_clause="RFC8785-3.2.2.2",
         rejection_layer="canonicalization",
-        rationale="A high surrogate (U+D800) followed by an ordinary BMP character (a plain "
-        "letter, not its matching low surrogate) leaves the high surrogate unpaired for "
-        "exactly the same reason as A4-REJECT-013/014, just constructed a third way.",
+        rationale=(
+            "A high surrogate (U+D800) followed by an ordinary BMP character (a plain "
+            "letter, not its matching low surrogate) leaves the high surrogate unpaired for "
+            "exactly the same reason as A4-REJECT-013/014, just constructed a third way."
+        ),
         raw_text='{"name": "\\ud800x"}',
     )

--- a/conformance-vectors/a2a-jcs-v01/group_a5.py
+++ b/conformance-vectors/a2a-jcs-v01/group_a5.py
@@ -1,0 +1,185 @@
+"""A5 -- number serialization. RFC 8785 sect. 3.2.2.3: numbers are
+serialized using the ECMAScript Number::toString algorithm, never a
+language's default float formatter. 18 vectors per the design doc's count
+table; re-derive the live count from MANIFEST.json.
+
+Every expected byte string here is computed by the two independent
+oracles, never hand-derived from a mental model of the ECMA-262 boundary
+rules -- that is the entire point of dual-oracle verification: the exact
+fixed/exponential switch points do not need to be memorized correctly by
+whoever writes the test inputs, only agreed upon by two implementations
+that were not written by the same person testing them.
+
+Reject count: 3, not the doc's estimated 4. NaN and +/-Infinity are the
+only JSON number values with no ECMAScript Number::toString representation
+at all -- every finite double has a well-defined one, so there is no
+fourth legitimate canonicalization-layer number rejection to manufacture
+without inventing one. Shipping 3 solid vectors beats forcing a 4th.
+"""
+
+from gen_layer_a import make_accept, make_reject
+
+GROUP = "a5-number-serialization"
+
+
+def generate():
+    make_accept(
+        "A5-001",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "The a2aproject/A2A#2122 counterexample verbatim (case C4): "
+        "0.000001 must serialize as the literal '0.000001', not as '1e-06' (Python's repr "
+        "threshold, which is what a2a-python's json.dumps produces and what makes this a real "
+        "cross-SDK break).",
+        {"tolerance": 0.000001},
+    )
+    make_accept(
+        "A5-002",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "The a2aproject/A2A#2122 'big' companion value from the same case C4: 1e21 crosses the "
+        "ECMAScript fixed/exponential boundary on the large-magnitude side and must serialize "
+        "in exponential form.",
+        {"big": 1e21},
+    )
+    make_accept(
+        "A5-003",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "Positive integers serialize with no decimal point and no fractional zeros.",
+        {"n": 42},
+    )
+    make_accept(
+        "A5-004",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "Negative integers keep the sign and otherwise follow the same integer rule.",
+        {"n": -17},
+    )
+    make_accept(
+        "A5-005",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "Zero serializes as the bare digit '0'.",
+        {"n": 0},
+    )
+    make_accept(
+        "A5-006",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "Negative zero is a distinct IEEE 754 bit pattern from positive zero, but "
+        "ECMAScript's Number::toString collapses both to the same string '0' -- there is no "
+        "'-0' output form.",
+        {"n": -0.0},
+    )
+    make_accept(
+        "A5-007",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "0.1 cannot be represented exactly in IEEE 754 double precision; ECMAScript's "
+        "algorithm prints the shortest decimal digit sequence that round-trips back to the "
+        "same double, not the full ~17-digit exact binary expansion.",
+        {"n": 0.1},
+    )
+    make_accept(
+        "A5-008",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "A five-significant-digit decimal exercises the shortest-round-trip rule on a value "
+        "with more precision than 0.1.",
+        {"n": 3.14159},
+    )
+    make_accept(
+        "A5-009",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "Number.MAX_SAFE_INTEGER (2^53 - 1): the largest integer every JS engine represents "
+        "exactly, a natural boundary value for integer serialization.",
+        {"n": 9007199254740991},
+    )
+    make_accept(
+        "A5-010",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "A negative decimal combines the sign rule (A5-004) with fractional shortest-digit "
+        "serialization (A5-007) in one value.",
+        {"n": -123.456},
+    )
+    make_accept(
+        "A5-011",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "One order of magnitude below the a2aproject/A2A#2122 case C4 value (A5-001): 0.0000001 (1e-7) "
+        "probes the small-magnitude side of the fixed/exponential boundary that 0.000001 sits "
+        "just on the fixed side of.",
+        {"n": 0.0000001},
+    )
+    make_accept(
+        "A5-012",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "One order of magnitude below the C4 'big' value (A5-002): 1e20 probes the "
+        "large-magnitude side of the same boundary that 1e21 sits just past.",
+        {"n": 100000000000000000000.0},
+    )
+    make_accept(
+        "A5-013",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "0.1 + 0.2 in IEEE 754 double arithmetic does not equal 0.3; this is the resulting "
+        "value (0.30000000000000004), a classic case requiring the full shortest-round-trip "
+        "digit count rather than a short 'looks clean' rounding.",
+        {"n": 0.1 + 0.2},
+    )
+    make_accept(
+        "A5-014",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "A round integer must not be printed in exponential form just because it has trailing "
+        "zeros; 100 stays '100', not '1e2'.",
+        {"n": 100},
+    )
+    make_accept(
+        "A5-015",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        "Input syntax is not preserved verbatim: '1E1' (uppercase E, RFC 8259 permits both "
+        "cases) and a trailing '.0' both parse to the double values 10 and 1 respectively, and "
+        "the canonical form is the ECMAScript string for that VALUE, not a copy of the input "
+        "digit sequence -- this vector's input intentionally does not look like its output.",
+        {"exp_upper": 1e1, "trailing_zero": 1.0},
+        raw_override=b'{"exp_upper": 1E1, "trailing_zero": 1.0}',
+    )
+    make_reject(
+        "A5-REJECT-016",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        rejecting_clause="RFC8785-3.2.2.3",
+        rejection_layer="canonicalization",
+        rationale="NaN is not a valid RFC 8259 JSON number and has no ECMAScript "
+        "Number::toString representation as a JSON token; some lenient parsers accept the bare "
+        "word NaN as a non-standard extension, but a conformant canonicalizer must refuse to "
+        "emit it rather than pass the extension through.",
+        raw_text='{"n": NaN}',
+    )
+    make_reject(
+        "A5-REJECT-017",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        rejecting_clause="RFC8785-3.2.2.3",
+        rejection_layer="canonicalization",
+        rationale="Infinity is the positive-magnitude sibling of A5-REJECT-016: not valid "
+        "JSON, no canonical representation, must be refused rather than passed through by any "
+        "parser lenient enough to accept the bare word.",
+        raw_text='{"n": Infinity}',
+    )
+    make_reject(
+        "A5-REJECT-018",
+        GROUP,
+        "RFC8785-3.2.2.3",
+        rejecting_clause="RFC8785-3.2.2.3",
+        rejection_layer="canonicalization",
+        rationale="Negative infinity completes the set: same defect as A5-REJECT-017 with the "
+        "sign flipped, confirming the rejection is not specific to the unsigned spelling.",
+        raw_text='{"n": -Infinity}',
+    )

--- a/conformance-vectors/a2a-jcs-v01/group_a5.py
+++ b/conformance-vectors/a2a-jcs-v01/group_a5.py
@@ -1,7 +1,9 @@
-"""A5 -- number serialization. RFC 8785 sect. 3.2.2.3: numbers are
-serialized using the ECMAScript Number::toString algorithm, never a
-language's default float formatter. 18 vectors per the design doc's count
-table; re-derive the live count from MANIFEST.json.
+"""A5 -- number serialization.
+
+RFC 8785 sect. 3.2.2.3: numbers are serialized using the ECMAScript
+Number::toString algorithm, never a language's default float formatter.
+18 vectors per the design doc's count table; re-derive the live count
+from MANIFEST.json.
 
 Every expected byte string here is computed by the two independent
 oracles, never hand-derived from a mental model of the ECMA-262 boundary
@@ -19,167 +21,199 @@ without inventing one. Shipping 3 solid vectors beats forcing a 4th.
 
 from gen_layer_a import make_accept, make_reject
 
+
 GROUP = "a5-number-serialization"
 
 
-def generate():
+def generate() -> None:
+    """Emit all eighteen A5 (number serialization) vectors."""
     make_accept(
         "A5-001",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "The a2aproject/A2A#2122 counterexample verbatim (case C4): "
-        "0.000001 must serialize as the literal '0.000001', not as '1e-06' (Python's repr "
-        "threshold, which is what a2a-python's json.dumps produces and what makes this a real "
-        "cross-SDK break).",
-        {"tolerance": 0.000001},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "The a2aproject/A2A#2122 counterexample verbatim (case C4): "
+            "0.000001 must serialize as the literal '0.000001', not as '1e-06' (Python's repr "
+            "threshold, which is what a2a-python's json.dumps produces and what makes this a real "
+            "cross-SDK break)."
+        ),
+        input_obj={"tolerance": 0.000001},
     )
     make_accept(
         "A5-002",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "The a2aproject/A2A#2122 'big' companion value from the same case C4: 1e21 crosses the "
-        "ECMAScript fixed/exponential boundary on the large-magnitude side and must serialize "
-        "in exponential form.",
-        {"big": 1e21},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "The a2aproject/A2A#2122 'big' companion value from the same case C4: 1e21 crosses the "
+            "ECMAScript fixed/exponential boundary on the large-magnitude side and must serialize "
+            "in exponential form."
+        ),
+        input_obj={"big": 1e21},
     )
     make_accept(
         "A5-003",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "Positive integers serialize with no decimal point and no fractional zeros.",
-        {"n": 42},
+        clause="RFC8785-3.2.2.3",
+        rationale="Positive integers serialize with no decimal point and no fractional zeros.",
+        input_obj={"n": 42},
     )
     make_accept(
         "A5-004",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "Negative integers keep the sign and otherwise follow the same integer rule.",
-        {"n": -17},
+        clause="RFC8785-3.2.2.3",
+        rationale="Negative integers keep the sign and otherwise follow the same integer rule.",
+        input_obj={"n": -17},
     )
     make_accept(
         "A5-005",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "Zero serializes as the bare digit '0'.",
-        {"n": 0},
+        clause="RFC8785-3.2.2.3",
+        rationale="Zero serializes as the bare digit '0'.",
+        input_obj={"n": 0},
     )
     make_accept(
         "A5-006",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "Negative zero is a distinct IEEE 754 bit pattern from positive zero, but "
-        "ECMAScript's Number::toString collapses both to the same string '0' -- there is no "
-        "'-0' output form.",
-        {"n": -0.0},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "Negative zero is a distinct IEEE 754 bit pattern from positive zero, but "
+            "ECMAScript's Number::toString collapses both to the same string '0' -- there is no "
+            "'-0' output form."
+        ),
+        input_obj={"n": -0.0},
     )
     make_accept(
         "A5-007",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "0.1 cannot be represented exactly in IEEE 754 double precision; ECMAScript's "
-        "algorithm prints the shortest decimal digit sequence that round-trips back to the "
-        "same double, not the full ~17-digit exact binary expansion.",
-        {"n": 0.1},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "0.1 cannot be represented exactly in IEEE 754 double precision; ECMAScript's "
+            "algorithm prints the shortest decimal digit sequence that round-trips back to the "
+            "same double, not the full ~17-digit exact binary expansion."
+        ),
+        input_obj={"n": 0.1},
     )
     make_accept(
         "A5-008",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "A five-significant-digit decimal exercises the shortest-round-trip rule on a value "
-        "with more precision than 0.1.",
-        {"n": 3.14159},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "A five-significant-digit decimal exercises the shortest-round-trip rule on a value "
+            "with more precision than 0.1."
+        ),
+        input_obj={"n": 3.14159},
     )
     make_accept(
         "A5-009",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "Number.MAX_SAFE_INTEGER (2^53 - 1): the largest integer every JS engine represents "
-        "exactly, a natural boundary value for integer serialization.",
-        {"n": 9007199254740991},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "Number.MAX_SAFE_INTEGER (2^53 - 1): the largest integer every JS engine represents "
+            "exactly, a natural boundary value for integer serialization."
+        ),
+        input_obj={"n": 9007199254740991},
     )
     make_accept(
         "A5-010",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "A negative decimal combines the sign rule (A5-004) with fractional shortest-digit "
-        "serialization (A5-007) in one value.",
-        {"n": -123.456},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "A negative decimal combines the sign rule (A5-004) with fractional shortest-digit "
+            "serialization (A5-007) in one value."
+        ),
+        input_obj={"n": -123.456},
     )
     make_accept(
         "A5-011",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "One order of magnitude below the a2aproject/A2A#2122 case C4 value (A5-001): 0.0000001 (1e-7) "
-        "probes the small-magnitude side of the fixed/exponential boundary that 0.000001 sits "
-        "just on the fixed side of.",
-        {"n": 0.0000001},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "One order of magnitude below the a2aproject/A2A#2122 case C4 value (A5-001): "
+            "0.0000001 (1e-7) probes the small-magnitude side of the fixed/exponential boundary "
+            "that 0.000001 sits just on the fixed side of."
+        ),
+        input_obj={"n": 0.0000001},
     )
     make_accept(
         "A5-012",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "One order of magnitude below the C4 'big' value (A5-002): 1e20 probes the "
-        "large-magnitude side of the same boundary that 1e21 sits just past.",
-        {"n": 100000000000000000000.0},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "One order of magnitude below the C4 'big' value (A5-002): 1e20 probes the "
+            "large-magnitude side of the same boundary that 1e21 sits just past."
+        ),
+        input_obj={"n": 100000000000000000000.0},
     )
     make_accept(
         "A5-013",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "0.1 + 0.2 in IEEE 754 double arithmetic does not equal 0.3; this is the resulting "
-        "value (0.30000000000000004), a classic case requiring the full shortest-round-trip "
-        "digit count rather than a short 'looks clean' rounding.",
-        {"n": 0.1 + 0.2},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "0.1 + 0.2 in IEEE 754 double arithmetic does not equal 0.3; this is the resulting "
+            "value (0.30000000000000004), a classic case requiring the full shortest-round-trip "
+            "digit count rather than a short 'looks clean' rounding."
+        ),
+        input_obj={"n": 0.1 + 0.2},
     )
     make_accept(
         "A5-014",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "A round integer must not be printed in exponential form just because it has trailing "
-        "zeros; 100 stays '100', not '1e2'.",
-        {"n": 100},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "A round integer must not be printed in exponential form just because it has trailing "
+            "zeros; 100 stays '100', not '1e2'."
+        ),
+        input_obj={"n": 100},
     )
     make_accept(
         "A5-015",
         GROUP,
-        "RFC8785-3.2.2.3",
-        "Input syntax is not preserved verbatim: '1E1' (uppercase E, RFC 8259 permits both "
-        "cases) and a trailing '.0' both parse to the double values 10 and 1 respectively, and "
-        "the canonical form is the ECMAScript string for that VALUE, not a copy of the input "
-        "digit sequence -- this vector's input intentionally does not look like its output.",
-        {"exp_upper": 1e1, "trailing_zero": 1.0},
+        clause="RFC8785-3.2.2.3",
+        rationale=(
+            "Input syntax is not preserved verbatim: '1E1' (uppercase E, RFC 8259 permits both "
+            "cases) and a trailing '.0' both parse to the double values 10 and 1 respectively, and "
+            "the canonical form is the ECMAScript string for that VALUE, not a copy of the input "
+            "digit sequence -- this vector's input intentionally does not look like its output."
+        ),
+        input_obj={"exp_upper": 1e1, "trailing_zero": 1.0},
         raw_override=b'{"exp_upper": 1E1, "trailing_zero": 1.0}',
     )
     make_reject(
         "A5-REJECT-016",
         GROUP,
-        "RFC8785-3.2.2.3",
+        clause="RFC8785-3.2.2.3",
         rejecting_clause="RFC8785-3.2.2.3",
         rejection_layer="canonicalization",
-        rationale="NaN is not a valid RFC 8259 JSON number and has no ECMAScript "
-        "Number::toString representation as a JSON token; some lenient parsers accept the bare "
-        "word NaN as a non-standard extension, but a conformant canonicalizer must refuse to "
-        "emit it rather than pass the extension through.",
+        rationale=(
+            "NaN is not a valid RFC 8259 JSON number and has no ECMAScript "
+            "Number::toString representation as a JSON token; some lenient parsers accept the bare "
+            "word NaN as a non-standard extension, but a conformant canonicalizer must refuse to "
+            "emit it rather than pass the extension through."
+        ),
         raw_text='{"n": NaN}',
     )
     make_reject(
         "A5-REJECT-017",
         GROUP,
-        "RFC8785-3.2.2.3",
+        clause="RFC8785-3.2.2.3",
         rejecting_clause="RFC8785-3.2.2.3",
         rejection_layer="canonicalization",
-        rationale="Infinity is the positive-magnitude sibling of A5-REJECT-016: not valid "
-        "JSON, no canonical representation, must be refused rather than passed through by any "
-        "parser lenient enough to accept the bare word.",
+        rationale=(
+            "Infinity is the positive-magnitude sibling of A5-REJECT-016: not valid "
+            "JSON, no canonical representation, must be refused rather than passed through by any "
+            "parser lenient enough to accept the bare word."
+        ),
         raw_text='{"n": Infinity}',
     )
     make_reject(
         "A5-REJECT-018",
         GROUP,
-        "RFC8785-3.2.2.3",
+        clause="RFC8785-3.2.2.3",
         rejecting_clause="RFC8785-3.2.2.3",
         rejection_layer="canonicalization",
-        rationale="Negative infinity completes the set: same defect as A5-REJECT-017 with the "
-        "sign flipped, confirming the rejection is not specific to the unsigned spelling.",
+        rationale=(
+            "Negative infinity completes the set: same defect as A5-REJECT-017 with the "
+            "sign flipped, confirming the rejection is not specific to the unsigned spelling."
+        ),
         raw_text='{"n": -Infinity}',
     )

--- a/conformance-vectors/a2a-jcs-v01/group_a6.py
+++ b/conformance-vectors/a2a-jcs-v01/group_a6.py
@@ -1,69 +1,83 @@
-"""A6 -- arrays, nesting, literals. RFC 8785 sect. 3.2.1 (array/object
-recursion, order preservation within arrays) and sect. 3.2.2.1 (literal
-values: null, true, false). 8 vectors, 0 MUST-REJECT per the design doc's
-count table -- these are all structural cases where a CONFORMANT input has
-one unambiguous canonical form; there is nothing here for a canonicalizer
-to legitimately refuse."""
+"""A6 -- arrays, nesting, literals.
+
+RFC 8785 sect. 3.2.1 (array/object recursion, order preservation within
+arrays) and sect. 3.2.2.1 (literal values: null, true, false). 8 vectors,
+0 MUST-REJECT per the design doc's count table -- these are all structural
+cases where a CONFORMANT input has one unambiguous canonical form; there is
+nothing here for a canonicalizer to legitimately refuse.
+"""
 
 from gen_layer_a import make_accept
+
 
 GROUP = "a6-arrays-nesting-literals"
 
 
-def generate():
+def generate() -> None:
+    """Emit all eight A6 (arrays, nesting, literals) vectors."""
     make_accept(
         "A6-001",
         GROUP,
-        "RFC8785-3.2.1",
-        "An empty array is a valid value and serializes as '[]' with no whitespace.",
-        {"items": []},
+        clause="RFC8785-3.2.1",
+        rationale="An empty array is a valid value and serializes as '[]' with no whitespace.",
+        input_obj={"items": []},
     )
     make_accept(
         "A6-002",
         GROUP,
-        "RFC8785-3.2.1",
-        "An empty object is a valid value and serializes as '{}' with no whitespace.",
-        {"config": {}},
+        clause="RFC8785-3.2.1",
+        rationale="An empty object is a valid value and serializes as '{}' with no whitespace.",
+        input_obj={"config": {}},
     )
     make_accept(
         "A6-003",
         GROUP,
-        "RFC8785-3.2.1",
-        "Arrays preserve input order; RFC 8785 orders object keys, never array elements.",
-        {"matrix": [[1, 2], [3, 4]]},
+        clause="RFC8785-3.2.1",
+        rationale="Arrays preserve input order; RFC 8785 orders object keys, never array elements.",
+        input_obj={"matrix": [[1, 2], [3, 4]]},
     )
     make_accept(
         "A6-004",
         GROUP,
-        "RFC8785-3.2.1",
-        "Object nesting recurses the same key-ordering rule at every depth.",
-        {"a": {"b": {"c": 1}}},
+        clause="RFC8785-3.2.1",
+        rationale="Object nesting recurses the same key-ordering rule at every depth.",
+        input_obj={"a": {"b": {"c": 1}}},
     )
     make_accept(
         "A6-005",
         GROUP,
-        "RFC8785-3.2.2.1",
-        "An array may mix every JSON primitive type; each element serializes per its own type's rule and array order is preserved regardless of type.",
-        {"mixed": [1, "two", True, False, None, 3.5]},
+        clause="RFC8785-3.2.2.1",
+        rationale=(
+            "An array may mix every JSON primitive type; each element serializes per its own "
+            "type's rule and array order is preserved regardless of type."
+        ),
+        input_obj={"mixed": [1, "two", True, False, None, 3.5]},
     )
     make_accept(
         "A6-006",
         GROUP,
-        "RFC8785-3.2.2.1",
-        "The null literal serializes as the bare token 'null'.",
-        {"value": None},
+        clause="RFC8785-3.2.2.1",
+        rationale="The null literal serializes as the bare token 'null'.",
+        input_obj={"value": None},
     )
     make_accept(
         "A6-007",
         GROUP,
-        "RFC8785-3.2.2.1",
-        "Boolean literals serialize as the bare tokens 'true'/'false', and sibling keys still sort (RFC8785-3.2.3) regardless of value type.",
-        {"flag_true": True, "flag_false": False},
+        clause="RFC8785-3.2.2.1",
+        rationale=(
+            "Boolean literals serialize as the bare tokens 'true'/'false', and sibling keys still "
+            "sort (RFC8785-3.2.3) regardless of value type."
+        ),
+        input_obj={"flag_true": True, "flag_false": False},
     )
     make_accept(
         "A6-008",
         GROUP,
-        "RFC8785-3.2.1",
-        "Deep alternation of arrays containing objects containing arrays exercises the recursion to more than two levels; order is preserved at every array level and keys sorted at every object level.",
-        {"deep": [{"x": [1, {"y": 2}]}, {"x": []}]},
+        clause="RFC8785-3.2.1",
+        rationale=(
+            "Deep alternation of arrays containing objects containing arrays exercises the "
+            "recursion to more than two levels; order is preserved at every array level and keys "
+            "sorted at every object level."
+        ),
+        input_obj={"deep": [{"x": [1, {"y": 2}]}, {"x": []}]},
     )

--- a/conformance-vectors/a2a-jcs-v01/group_a6.py
+++ b/conformance-vectors/a2a-jcs-v01/group_a6.py
@@ -1,0 +1,69 @@
+"""A6 -- arrays, nesting, literals. RFC 8785 sect. 3.2.1 (array/object
+recursion, order preservation within arrays) and sect. 3.2.2.1 (literal
+values: null, true, false). 8 vectors, 0 MUST-REJECT per the design doc's
+count table -- these are all structural cases where a CONFORMANT input has
+one unambiguous canonical form; there is nothing here for a canonicalizer
+to legitimately refuse."""
+
+from gen_layer_a import make_accept
+
+GROUP = "a6-arrays-nesting-literals"
+
+
+def generate():
+    make_accept(
+        "A6-001",
+        GROUP,
+        "RFC8785-3.2.1",
+        "An empty array is a valid value and serializes as '[]' with no whitespace.",
+        {"items": []},
+    )
+    make_accept(
+        "A6-002",
+        GROUP,
+        "RFC8785-3.2.1",
+        "An empty object is a valid value and serializes as '{}' with no whitespace.",
+        {"config": {}},
+    )
+    make_accept(
+        "A6-003",
+        GROUP,
+        "RFC8785-3.2.1",
+        "Arrays preserve input order; RFC 8785 orders object keys, never array elements.",
+        {"matrix": [[1, 2], [3, 4]]},
+    )
+    make_accept(
+        "A6-004",
+        GROUP,
+        "RFC8785-3.2.1",
+        "Object nesting recurses the same key-ordering rule at every depth.",
+        {"a": {"b": {"c": 1}}},
+    )
+    make_accept(
+        "A6-005",
+        GROUP,
+        "RFC8785-3.2.2.1",
+        "An array may mix every JSON primitive type; each element serializes per its own type's rule and array order is preserved regardless of type.",
+        {"mixed": [1, "two", True, False, None, 3.5]},
+    )
+    make_accept(
+        "A6-006",
+        GROUP,
+        "RFC8785-3.2.2.1",
+        "The null literal serializes as the bare token 'null'.",
+        {"value": None},
+    )
+    make_accept(
+        "A6-007",
+        GROUP,
+        "RFC8785-3.2.2.1",
+        "Boolean literals serialize as the bare tokens 'true'/'false', and sibling keys still sort (RFC8785-3.2.3) regardless of value type.",
+        {"flag_true": True, "flag_false": False},
+    )
+    make_accept(
+        "A6-008",
+        GROUP,
+        "RFC8785-3.2.1",
+        "Deep alternation of arrays containing objects containing arrays exercises the recursion to more than two levels; order is preserved at every array level and keys sorted at every object level.",
+        {"deep": [{"x": [1, {"y": 2}]}, {"x": []}]},
+    )

--- a/conformance-vectors/a2a-jcs-v01/oracle-go/go.mod
+++ b/conformance-vectors/a2a-jcs-v01/oracle-go/go.mod
@@ -1,0 +1,5 @@
+module jcsoracle
+
+go 1.25.5
+
+require github.com/gowebpki/jcs v1.0.1

--- a/conformance-vectors/a2a-jcs-v01/oracle-go/go.sum
+++ b/conformance-vectors/a2a-jcs-v01/oracle-go/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gowebpki/jcs v1.0.1 h1:Qjzg8EOkrOTuWP7DqQ1FbYtcpEbeTzUoTN9bptp8FOU=
+github.com/gowebpki/jcs v1.0.1/go.mod h1:CID1cNZ+sHp1CCpAR8mPf6QRtagFBgPJE0FCUQ6+BrI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/conformance-vectors/a2a-jcs-v01/oracle-go/main.go
+++ b/conformance-vectors/a2a-jcs-v01/oracle-go/main.go
@@ -1,0 +1,26 @@
+// jcsoracle reads a JSON value from stdin and writes its RFC 8785 (JCS)
+// canonical form to stdout, using gowebpki/jcs directly (the second,
+// independent oracle -- do not reimplement canonicalization here).
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/gowebpki/jcs"
+)
+
+func main() {
+	raw, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "read stdin:", err)
+		os.Exit(1)
+	}
+	out, err := jcs.Transform(raw)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "REJECT:", err)
+		os.Exit(2)
+	}
+	os.Stdout.Write(out)
+}

--- a/conformance-vectors/a2a-jcs-v01/oracle-go/runner/main.go
+++ b/conformance-vectors/a2a-jcs-v01/oracle-go/runner/main.go
@@ -1,0 +1,150 @@
+// runner is the Go reference runner for the a2a-jcs-v01 corpus, validating
+// against gowebpki/jcs -- the second, independent implementation the
+// corpus was cross-checked against at generation time. Two runners in two
+// languages exist so the vectors are demonstrably not encoding one
+// implementation's habits.
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/gowebpki/jcs"
+)
+
+const specCommitPinned = "19598c4" // a2a-protocol.org/A2A commit this corpus's clauses were read from
+
+type vector struct {
+	ID          string                 `json:"id"`
+	Clause      string                 `json:"clause"`
+	Disposition string                 `json:"disposition"`
+	Input       map[string]interface{} `json:"input,omitempty"`
+	InputRaw    string                 `json:"input_raw,omitempty"`
+	Expected    struct {
+		CanonicalUTF8Hex string `json:"canonical_utf8_hex"`
+	} `json:"expected"`
+}
+
+type manifestEntry struct {
+	Path string `json:"path"`
+}
+
+type manifest struct {
+	CorpusDigest string          `json:"corpusDigest"`
+	Vectors      []manifestEntry `json:"vectors"`
+}
+
+type result struct {
+	ID     string `json:"id"`
+	Pass   bool   `json:"pass"`
+	Detail string `json:"detail"`
+}
+
+func stripSignatures(m map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		if k == "signatures" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func checkVector(v vector) (bool, string) {
+	if v.Disposition == "MUST-ACCEPT" {
+		obj := v.Input
+		if v.Clause == "a2a-spec-8.4.1-rule-3" {
+			obj = stripSignatures(obj)
+		}
+		raw, err := json.Marshal(obj)
+		if err != nil {
+			return false, "could not re-marshal input: " + err.Error()
+		}
+		out, err := jcs.Transform(raw)
+		if err != nil {
+			return false, "canonicalization errored, expected success: " + err.Error()
+		}
+		want, err := hex.DecodeString(v.Expected.CanonicalUTF8Hex)
+		if err != nil {
+			return false, "bad expected hex in vector file: " + err.Error()
+		}
+		if string(out) != string(want) {
+			return false, fmt.Sprintf("byte mismatch: got %q want %q", out, want)
+		}
+		return true, "ok"
+	}
+	// MUST-REJECT
+	if v.Clause == "a2a-spec-8.4.1-rule-3" {
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(v.InputRaw), &obj); err != nil {
+			return false, "could not parse input_raw: " + err.Error()
+		}
+		if _, has := obj["signatures"]; has {
+			return true, "correctly detected forbidden 'signatures' key"
+		}
+		return false, "failed to detect the violation this vector carries"
+	}
+	if _, err := jcs.Transform([]byte(v.InputRaw)); err != nil {
+		return true, "correctly refused: " + err.Error()
+	}
+	return false, "accepted input that should have been refused"
+}
+
+func main() {
+	vroot := "vectors"
+	if len(os.Args) > 1 {
+		vroot = os.Args[1]
+	}
+	mraw, err := os.ReadFile(filepath.Join(vroot, "MANIFEST.json"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "read manifest:", err)
+		os.Exit(2)
+	}
+	var m manifest
+	if err := json.Unmarshal(mraw, &m); err != nil {
+		fmt.Fprintln(os.Stderr, "parse manifest:", err)
+		os.Exit(2)
+	}
+
+	var results []result
+	passed := 0
+	entries := append([]manifestEntry(nil), m.Vectors...)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	for _, e := range entries {
+		raw, err := os.ReadFile(filepath.Join(vroot, e.Path))
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "read vector:", e.Path, err)
+			os.Exit(2)
+		}
+		var v vector
+		if err := json.Unmarshal(raw, &v); err != nil {
+			fmt.Fprintln(os.Stderr, "parse vector:", e.Path, err)
+			os.Exit(2)
+		}
+		ok, detail := checkVector(v)
+		if ok {
+			passed++
+		}
+		results = append(results, result{ID: v.ID, Pass: ok, Detail: detail})
+	}
+
+	record := map[string]interface{}{
+		"runner":       "go/gowebpki-jcs",
+		"corpusDigest": m.CorpusDigest,
+		"specCommit":   specCommitPinned,
+		"coverage": map[string]int{
+			"total": len(results), "passed": passed, "failed": len(results) - passed,
+		},
+		"results": results,
+	}
+	out, _ := json.MarshalIndent(record, "", "  ")
+	fmt.Println(string(out))
+	if passed != len(results) {
+		os.Exit(1)
+	}
+}

--- a/conformance-vectors/a2a-jcs-v01/run_python.py
+++ b/conformance-vectors/a2a-jcs-v01/run_python.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python3
-"""Reference runner (Python / rfc8785). Validates every vector in the
-a2a-jcs-v01 corpus against rfc8785 and prints the result record the
-design doc specifies: corpus digest, spec commit, per-vector pass/fail,
-coverage count. Run this against ANY other RFC 8785 implementation by
-swapping the `canonicalize`/`detects_signatures_violation` functions --
+"""Reference runner (Python / rfc8785).
+
+Validates every vector in the a2a-jcs-v01 corpus against rfc8785 and
+prints the result record the design doc specifies: corpus digest, spec
+commit, per-vector pass/fail, coverage count. Run this against ANY other
+RFC 8785 implementation by swapping the `canonicalize` function --
 that substitution is the entire point of a runner separate from the
 generator.
 """
 
 import json
 import sys
+
 from pathlib import Path
 
 import rfc8785
+
 
 HERE = Path(__file__).resolve().parent
 DEFAULT_VROOT = HERE
@@ -21,7 +24,8 @@ SPEC_COMMIT_PINNED = (
 )
 
 
-def canonicalize(obj) -> bytes | None:
+def canonicalize(obj: object) -> bytes | None:
+    """Canonicalize obj with rfc8785, or None if it refuses the input."""
     try:
         return rfc8785.dumps(obj)
     except (ValueError, TypeError):
@@ -29,6 +33,7 @@ def canonicalize(obj) -> bytes | None:
 
 
 def check_vector(v: dict) -> tuple[bool, str]:
+    """Check one vector record against this runner's oracle."""
     if v["disposition"] == "MUST-ACCEPT":
         obj = v["input"]
         if v["clause"] == "a2a-spec-8.4.1-rule-3":
@@ -40,23 +45,24 @@ def check_vector(v: dict) -> tuple[bool, str]:
         if out != want:
             return False, f"byte mismatch: got {out!r} want {want!r}"
         return True, "ok"
-    else:  # MUST-REJECT
-        if v["clause"] == "a2a-spec-8.4.1-rule-3":
-            obj = json.loads(v["input_raw"])
-            if "signatures" in obj:
-                return True, "correctly detected forbidden 'signatures' key"
-            return False, "failed to detect the violation this vector carries"
-        try:
-            obj = json.loads(v["input_raw"])
-        except json.JSONDecodeError:
-            return True, "correctly refused (parse-level)"
-        out = canonicalize(obj)
-        if out is None:
-            return True, "correctly refused (canonicalization-level)"
-        return False, f"accepted input that should have been refused, produced {out!r}"
+    # MUST-REJECT
+    if v["clause"] == "a2a-spec-8.4.1-rule-3":
+        obj = json.loads(v["input_raw"])
+        if "signatures" in obj:
+            return True, "correctly detected forbidden 'signatures' key"
+        return False, "failed to detect the violation this vector carries"
+    try:
+        obj = json.loads(v["input_raw"])
+    except json.JSONDecodeError:
+        return True, "correctly refused (parse-level)"
+    out = canonicalize(obj)
+    if out is None:
+        return True, "correctly refused (canonicalization-level)"
+    return False, f"accepted input that should have been refused, produced {out!r}"
 
 
 def main() -> int:
+    """Run every vector in DEFAULT_VROOT (or sys.argv[1]) and print the result record."""
     vroot = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_VROOT
     manifest = json.loads((vroot / "MANIFEST.json").read_text())
     results = []

--- a/conformance-vectors/a2a-jcs-v01/run_python.py
+++ b/conformance-vectors/a2a-jcs-v01/run_python.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Reference runner (Python / rfc8785). Validates every vector in the
+a2a-jcs-v01 corpus against rfc8785 and prints the result record the
+design doc specifies: corpus digest, spec commit, per-vector pass/fail,
+coverage count. Run this against ANY other RFC 8785 implementation by
+swapping the `canonicalize`/`detects_signatures_violation` functions --
+that substitution is the entire point of a runner separate from the
+generator.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import rfc8785
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_VROOT = HERE
+SPEC_COMMIT_PINNED = (
+    "19598c4"  # a2a-protocol.org/A2A commit this corpus's clauses were read from
+)
+
+
+def canonicalize(obj) -> bytes | None:
+    try:
+        return rfc8785.dumps(obj)
+    except (ValueError, TypeError):
+        return None
+
+
+def check_vector(v: dict) -> tuple[bool, str]:
+    if v["disposition"] == "MUST-ACCEPT":
+        obj = v["input"]
+        if v["clause"] == "a2a-spec-8.4.1-rule-3":
+            obj = {k: val for k, val in obj.items() if k != "signatures"}
+        out = canonicalize(obj)
+        if out is None:
+            return False, "canonicalization raised, expected success"
+        want = bytes.fromhex(v["expected"]["canonical_utf8_hex"])
+        if out != want:
+            return False, f"byte mismatch: got {out!r} want {want!r}"
+        return True, "ok"
+    else:  # MUST-REJECT
+        if v["clause"] == "a2a-spec-8.4.1-rule-3":
+            obj = json.loads(v["input_raw"])
+            if "signatures" in obj:
+                return True, "correctly detected forbidden 'signatures' key"
+            return False, "failed to detect the violation this vector carries"
+        try:
+            obj = json.loads(v["input_raw"])
+        except json.JSONDecodeError:
+            return True, "correctly refused (parse-level)"
+        out = canonicalize(obj)
+        if out is None:
+            return True, "correctly refused (canonicalization-level)"
+        return False, f"accepted input that should have been refused, produced {out!r}"
+
+
+def main() -> int:
+    vroot = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_VROOT
+    manifest = json.loads((vroot / "MANIFEST.json").read_text())
+    results = []
+    for entry in manifest["vectors"]:
+        v = json.loads((vroot / entry["path"]).read_text())
+        ok, detail = check_vector(v)
+        results.append({"id": v["id"], "pass": ok, "detail": detail})
+
+    passed = sum(1 for r in results if r["pass"])
+    record = {
+        "runner": "python/rfc8785",
+        "corpusDigest": manifest["corpusDigest"],
+        "specCommit": SPEC_COMMIT_PINNED,
+        "coverage": {
+            "total": len(results),
+            "passed": passed,
+            "failed": len(results) - passed,
+        },
+        "results": results,
+    }
+    print(json.dumps(record, indent=2))
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tck/canonicalization/__init__.py
+++ b/tck/canonicalization/__init__.py
@@ -1,0 +1,20 @@
+"""Agent Card canonicalization utilities for A2A TCK."""
+
+from tck.canonicalization.jcs import (
+    SIGNATURES_FIELD,
+    CanonicalizationError,
+    assert_signatures_excluded,
+    canonicalize,
+    canonicalize_agent_card,
+    signing_payload,
+)
+
+
+__all__ = [
+    "SIGNATURES_FIELD",
+    "CanonicalizationError",
+    "assert_signatures_excluded",
+    "canonicalize",
+    "canonicalize_agent_card",
+    "signing_payload",
+]

--- a/tck/canonicalization/jcs.py
+++ b/tck/canonicalization/jcs.py
@@ -1,0 +1,352 @@
+"""RFC 8785 JSON Canonicalization Scheme, as required for Agent Card signing.
+
+Specification Section 8.4.1 requires that Agent Card content be canonicalized
+with JCS before it is signed, and that the ``signatures`` field be excluded
+from the content being signed.  This module implements both rules so that the
+TCK can compute the canonical signing payload itself instead of trusting a
+server to have computed it correctly.
+
+Number formatting follows ECMAScript ``Number.prototype.toString`` as RFC 8785
+Section 3.2.2.3 requires.  Object keys are ordered by UTF-16 code unit, not by
+Unicode code point (RFC 8785 Section 3.2.3); the two orders disagree whenever a
+key mixes astral-plane characters with characters in U+E000..U+FFFF, because
+astral characters are represented by surrogate code units that sort lower.
+
+This implementation is held to the ``a2a-jcs-v01`` conformance corpus under
+``conformance-vectors/`` by ``tests/unit/canonicalization/test_jcs_vectors.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+#: Agent Card field that Section 8.4.1 rule 3 excludes from the signed content.
+SIGNATURES_FIELD = "signatures"
+
+# RFC 8785 Section 3.2.2.2: only code points below U+0020 are escaped; every
+# other character, including U+007F, is emitted literally as UTF-8.
+_MIN_UNESCAPED_CODE_POINT = 0x20
+
+# ECMAScript Number::toString switches to exponential notation outside these
+# bounds on the decimal exponent (ECMA-262, Number::toString step 5).
+_ES6_MAX_FIXED_EXPONENT = 21
+_ES6_MIN_FRACTION_EXPONENT = -6
+
+# Two-character escapes mandated by RFC 8785 Section 3.2.2.2.
+_SHORT_ESCAPES = {
+    '"': '\\"',
+    "\\": "\\\\",
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+}
+
+
+class CanonicalizationError(ValueError):
+    """Raised when a value has no canonical RFC 8785 representation.
+
+    A conformant canonicalizer must refuse such input rather than emit
+    approximate bytes; the corpus's MUST-REJECT vectors assert exactly that.
+    """
+
+
+def _reject_unencodable(value: str, role: str) -> None:
+    """Reject a string that is not well-formed Unicode text.
+
+    Args:
+        value: The string to check.
+        role: Either ``"key"`` or ``"string"``, used in the error message.
+
+    Raises:
+        CanonicalizationError: If the string contains an unpaired surrogate.
+    """
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise CanonicalizationError(
+            f"{role} contains an unpaired surrogate and has no well-formed "
+            f"UTF-8 encoding (RFC 8785 section 3.2.2.2): {value!r}"
+        ) from exc
+
+
+def _utf16_sort_key(key: str) -> bytes:
+    """Return the sort key that orders object keys by UTF-16 code unit.
+
+    Big-endian UTF-16 bytes compare in exactly UTF-16 code unit order, which
+    is what RFC 8785 Section 3.2.3 specifies.
+
+    Args:
+        key: The object key.
+
+    Returns:
+        The key encoded as big-endian UTF-16.
+
+    Raises:
+        CanonicalizationError: If the key contains an unpaired surrogate.
+    """
+    try:
+        return key.encode("utf-16-be")
+    except UnicodeEncodeError as exc:
+        raise CanonicalizationError(
+            f"object key contains an unpaired surrogate and cannot be assigned "
+            f"a UTF-16 sort position (RFC 8785 section 3.2.3): {key!r}"
+        ) from exc
+
+
+def _shortest_digits(value: float) -> tuple[str, int]:
+    """Decompose a positive finite float into shortest digits and exponent.
+
+    ``repr`` already produces the shortest decimal string that round-trips,
+    which is the digit sequence ECMAScript's Number::toString is defined over.
+
+    Args:
+        value: A strictly positive, finite float.
+
+    Returns:
+        A tuple ``(digits, n)`` where ``digits`` has no leading or trailing
+        zeros and the represented value is ``0.digits * 10**n``.
+    """
+    mantissa, _, exponent_text = repr(value).partition("e")
+    exponent = int(exponent_text) if exponent_text else 0
+    integer_text, _, fraction_text = mantissa.partition(".")
+
+    digits = integer_text + fraction_text
+    position = len(integer_text) + exponent
+
+    leading = 0
+    while leading < len(digits) - 1 and digits[leading] == "0":
+        leading += 1
+        position -= 1
+    digits = digits[leading:].rstrip("0") or "0"
+
+    return digits, position
+
+
+def _es6_number_to_string(value: float) -> str:
+    """Format a finite float exactly as ECMAScript ``Number.prototype.toString`` does.
+
+    Args:
+        value: A finite float.
+
+    Returns:
+        The ECMAScript string form, e.g. ``"1e+21"``, ``"0.000001"``, ``"100"``.
+    """
+    if value == 0:
+        # Covers negative zero, which ECMAScript renders as "0".
+        return "0"
+    if value < 0:
+        return "-" + _es6_number_to_string(-value)
+
+    digits, position = _shortest_digits(value)
+    count = len(digits)
+
+    if count <= position <= _ES6_MAX_FIXED_EXPONENT:
+        return digits + "0" * (position - count)
+    if 0 < position <= _ES6_MAX_FIXED_EXPONENT:
+        return f"{digits[:position]}.{digits[position:]}"
+    if _ES6_MIN_FRACTION_EXPONENT < position <= 0:
+        return "0." + "0" * (-position) + digits
+
+    exponent = position - 1
+    sign = "+" if exponent >= 0 else "-"
+    stem = digits if count == 1 else f"{digits[0]}.{digits[1:]}"
+    return f"{stem}e{sign}{abs(exponent)}"
+
+
+def _serialize_number(value: float) -> str:
+    """Serialize a JSON number per RFC 8785 Section 3.2.2.3.
+
+    Every JSON number is treated as an IEEE 754 double, so integers are
+    converted before formatting.
+
+    Args:
+        value: The number to serialize.
+
+    Returns:
+        The canonical textual form.
+
+    Raises:
+        CanonicalizationError: If the value is NaN, infinite, or an integer
+            too large to represent as a double.
+    """
+    try:
+        as_float = float(value)
+    except OverflowError as exc:
+        raise CanonicalizationError(
+            f"integer {value!r} exceeds the IEEE 754 double range and has no "
+            f"RFC 8785 number representation"
+        ) from exc
+
+    if as_float != as_float:  # noqa: PLR0124 - the standard NaN test
+        raise CanonicalizationError("NaN has no RFC 8785 number representation")
+    if as_float in (float("inf"), float("-inf")):
+        raise CanonicalizationError(
+            f"{value!r} is infinite and has no RFC 8785 number representation"
+        )
+
+    return _es6_number_to_string(as_float)
+
+
+def _serialize_string(value: str) -> str:
+    """Serialize a JSON string per RFC 8785 Section 3.2.2.2.
+
+    Args:
+        value: The string to serialize.
+
+    Returns:
+        The quoted, minimally escaped textual form.
+
+    Raises:
+        CanonicalizationError: If the string contains an unpaired surrogate.
+    """
+    _reject_unencodable(value, "string")
+
+    parts = ['"']
+    for char in value:
+        escape = _SHORT_ESCAPES.get(char)
+        if escape is not None:
+            parts.append(escape)
+        elif ord(char) < _MIN_UNESCAPED_CODE_POINT:
+            parts.append(f"\\u{ord(char):04x}")
+        else:
+            parts.append(char)
+    parts.append('"')
+    return "".join(parts)
+
+
+def _serialize(value: Any) -> str:
+    """Serialize any JSON value into its canonical textual form.
+
+    Args:
+        value: A value drawn from the JSON data model.
+
+    Returns:
+        The canonical textual form.
+
+    Raises:
+        CanonicalizationError: If the value or any value nested inside it has
+            no canonical representation.
+    """
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return _serialize_string(value)
+    if isinstance(value, (int, float)):
+        return _serialize_number(value)
+    if isinstance(value, dict):
+        return _serialize_object(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_serialize(item) for item in value) + "]"
+    raise CanonicalizationError(
+        f"value of type {type(value).__name__!r} is outside the JSON data model "
+        f"and cannot be canonicalized"
+    )
+
+
+def _serialize_object(value: Mapping[str, Any]) -> str:
+    """Serialize a JSON object with keys ordered by UTF-16 code unit.
+
+    Args:
+        value: The mapping to serialize.
+
+    Returns:
+        The canonical textual form.
+
+    Raises:
+        CanonicalizationError: If a key is not a string, or any key or nested
+            value has no canonical representation.
+    """
+    for key in value:
+        if not isinstance(key, str):
+            raise CanonicalizationError(
+                f"object key {key!r} is not a string and has no place in the "
+                f"JSON data model"
+            )
+
+    ordered = sorted(value.items(), key=lambda item: _utf16_sort_key(item[0]))
+    body = ",".join(f"{_serialize_string(key)}:{_serialize(item)}" for key, item in ordered)
+    return "{" + body + "}"
+
+
+def canonicalize(value: Any) -> bytes:
+    """Canonicalize a JSON value into RFC 8785 bytes.
+
+    Args:
+        value: A value drawn from the JSON data model.
+
+    Returns:
+        The canonical UTF-8 encoding.
+
+    Raises:
+        CanonicalizationError: If the value has no canonical representation.
+    """
+    return _serialize(value).encode("utf-8")
+
+
+def signing_payload(card: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the Agent Card signing payload by applying the exclusion rule.
+
+    Implements Section 8.4.1 rule 3: the ``signatures`` field is excluded from
+    the content being signed, unconditionally, whether or not it is populated.
+
+    Args:
+        card: The Agent Card as received.
+
+    Returns:
+        A copy of the card with the ``signatures`` field removed.
+
+    Raises:
+        CanonicalizationError: If the card is not a JSON object.
+    """
+    if not isinstance(card, dict):
+        raise CanonicalizationError(
+            f"Agent Card must be a JSON object, got {type(card).__name__!r}"
+        )
+    return {key: item for key, item in card.items() if key != SIGNATURES_FIELD}
+
+
+def canonicalize_agent_card(card: Mapping[str, Any]) -> bytes:
+    """Compute the canonical signing payload bytes for an Agent Card.
+
+    Applies Section 8.4.1 rule 3 (exclude ``signatures``) and then rule 2
+    (canonicalize per RFC 8785).
+
+    Args:
+        card: The Agent Card as received.
+
+    Returns:
+        The canonical UTF-8 bytes an implementation must sign.
+
+    Raises:
+        CanonicalizationError: If the card has no canonical representation.
+    """
+    return canonicalize(signing_payload(card))
+
+
+def assert_signatures_excluded(payload: Mapping[str, Any]) -> None:
+    """Check that a prepared signing payload no longer carries ``signatures``.
+
+    Section 8.4.1 rule 3 makes a payload that still carries the field invalid
+    signing input, because signing it would create the circular dependency the
+    rule exists to prevent.
+
+    Args:
+        payload: The signing payload to check.
+
+    Raises:
+        CanonicalizationError: If the payload still carries the field.
+    """
+    if isinstance(payload, dict) and SIGNATURES_FIELD in payload:
+        raise CanonicalizationError(
+            f"signing payload still carries the {SIGNATURES_FIELD!r} field, which "
+            f"specification section 8.4.1 rule 3 requires to be excluded"
+        )

--- a/tck/requirements/agent_card.py
+++ b/tck/requirements/agent_card.py
@@ -139,7 +139,10 @@ AGENT_CARD_REQUIREMENTS: list[RequirementSpec] = [
         ),
         expected_behavior="Agent Card canonicalized per RFC 8785 before signing",
         spec_url=f"{SPEC_BASE}841-canonicalization-requirements",
-        tags=[AGENT_CARD, SIGNING, JCS, NOT_AUTOMATABLE],
+        # Covered by the a2a-jcs-v01 conformance corpus (groups A3 to A6) in
+        # tests/unit/canonicalization/test_jcs_vectors.py, and against a live
+        # server in tests/compatibility/agent_card/test_agent_card_signing.py.
+        tags=[AGENT_CARD, SIGNING, JCS],
     ),
     RequirementSpec(
         id="CARD-SIGN-002",
@@ -152,7 +155,10 @@ AGENT_CARD_REQUIREMENTS: list[RequirementSpec] = [
         ),
         expected_behavior="Signatures field excluded from signing payload",
         spec_url=f"{SPEC_BASE}841-canonicalization-requirements",
-        tags=[AGENT_CARD, SIGNING, NOT_AUTOMATABLE],
+        # Covered by the a2a-jcs-v01 conformance corpus (group A2) in
+        # tests/unit/canonicalization/test_jcs_vectors.py, and against a live
+        # server in tests/compatibility/agent_card/test_agent_card_signing.py.
+        tags=[AGENT_CARD, SIGNING],
     ),
     RequirementSpec(
         id="CARD-SIGN-003",
@@ -165,6 +171,8 @@ AGENT_CARD_REQUIREMENTS: list[RequirementSpec] = [
         ),
         expected_behavior="Protected header contains alg and kid",
         spec_url=f"{SPEC_BASE}842-signature-format",
+        # JWS construction (Section 8.4.2), not canonicalization: the
+        # a2a-jcs-v01 corpus carries no vectors for protected headers.
         tags=[AGENT_CARD, SIGNING, JWS, NOT_AUTOMATABLE],
     ),
     RequirementSpec(
@@ -178,6 +186,8 @@ AGENT_CARD_REQUIREMENTS: list[RequirementSpec] = [
         ),
         expected_behavior="Expired/revoked keys rejected during verification",
         spec_url=f"{SPEC_BASE}843-signature-verification",
+        # Constrains a verifying client's key handling over time (Section
+        # 8.4.3), which no canonicalization vector can decide.
         tags=[AGENT_CARD, SIGNING, SECURITY, NOT_AUTOMATABLE],
     ),
     # --- Agent Card Caching (Section 8.6) ---

--- a/tests/compatibility/agent_card/test_agent_card_signing.py
+++ b/tests/compatibility/agent_card/test_agent_card_signing.py
@@ -1,0 +1,226 @@
+"""Agent Card signing conformance tests against a live SUT.
+
+Validates the Section 8.4.1 canonicalization rules against the Agent Card a
+server actually serves.
+
+Requirements tested:
+    CARD-SIGN-001, CARD-SIGN-002
+
+Signing is optional for an A2A server (Section 8.4), so these tests skip when
+the served card carries no ``signatures`` array.  When it does, the card is
+held to the two rules that are decidable from the card alone:
+
+* CARD-SIGN-001 -- the signing payload must have an RFC 8785 canonical form at
+  all.  A card carrying an unpaired surrogate, a non-finite number, or a value
+  outside the JSON data model cannot have been canonicalized per RFC 8785, so
+  whatever the server signed was not the canonical form of this card.
+* CARD-SIGN-002 -- the payload that gets signed must not carry the
+  ``signatures`` field, and the canonical bytes must be reachable while the
+  served card still carries it.
+
+Both checks are necessary conditions rather than proof of a correct signature.
+Confirming that the server signed *these* bytes means verifying the JWS, which
+needs a signature-verification dependency the TCK does not currently take; the
+byte-exact half of both requirements is carried by the a2a-jcs-v01 conformance
+corpus in ``tests/unit/canonicalization/test_jcs_vectors.py`` instead.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from tck.canonicalization.jcs import (
+    SIGNATURES_FIELD,
+    CanonicalizationError,
+    assert_signatures_excluded,
+    canonicalize_agent_card,
+    signing_payload,
+)
+from tck.requirements.registry import get_requirement_by_id
+from tests.compatibility.markers import core, must
+
+
+if TYPE_CHECKING:
+    from tck.requirements.base import RequirementSpec
+
+
+# ---------------------------------------------------------------------------
+# Requirement lookups
+# ---------------------------------------------------------------------------
+
+CARD_SIGN_001 = get_requirement_by_id("CARD-SIGN-001")
+CARD_SIGN_002 = get_requirement_by_id("CARD-SIGN-002")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fail_msg(req: RequirementSpec, detail: str) -> str:
+    return (
+        f"{req.id} [{req.title}]: {detail} (see {req.spec_url})"
+    )
+
+
+def _record(
+    collector: Any,
+    req: RequirementSpec,
+    passed: bool,
+    errors: list[str] | None = None,
+) -> None:
+    collector.record(
+        requirement_id=req.id,
+        transport="agent_card",
+        level=req.level.value,
+        passed=passed,
+        errors=errors or [],
+    )
+
+
+def _require_signatures(card: dict[str, Any]) -> list[Any]:
+    """Return the card's signatures, or skip when the server does not sign.
+
+    Args:
+        card: The served Agent Card.
+
+    Returns:
+        The non-empty ``signatures`` array.
+
+    Raises:
+        pytest.skip: If the card carries no signatures, since Section 8.4
+            makes signing optional.
+    """
+    signatures: list[Any] = card.get(SIGNATURES_FIELD) or []
+    if not signatures:
+        pytest.skip(
+            "Agent Card carries no signatures; Section 8.4 makes Agent Card "
+            "signing optional, so the Section 8.4.1 rules do not apply"
+        )
+    return signatures
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization (CARD-SIGN-001)
+# ---------------------------------------------------------------------------
+
+
+@must
+@core
+class TestAgentCardCanonicalization:
+    """CARD-SIGN-001: Agent Card canonicalized with JCS before signing."""
+
+    def test_signing_payload_has_a_canonical_form(
+        self,
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+    ) -> None:
+        """CARD-SIGN-001: the served card's signing payload canonicalizes per RFC 8785."""
+        req = CARD_SIGN_001
+        _require_signatures(agent_card)
+
+        errors: list[str] = []
+        try:
+            canonical = canonicalize_agent_card(agent_card)
+        except CanonicalizationError as exc:
+            canonical = b""
+            errors.append(
+                f"the served Agent Card has no RFC 8785 canonical form, so it "
+                f"cannot have been canonicalized before signing: {exc}"
+            )
+
+        valid = not errors
+        _record(collector=compatibility_collector, req=req,
+                passed=valid, errors=errors)
+        assert valid, _fail_msg(req, errors[0])
+        assert canonical, _fail_msg(req, "canonicalization produced no bytes")
+
+    def test_canonicalization_is_stable(
+        self,
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+    ) -> None:
+        """CARD-SIGN-001: canonicalizing the served card twice yields identical bytes.
+
+        RFC 8785 exists to make one document produce one byte string.  A card
+        whose canonical form varies between runs cannot carry a signature that
+        verifies reliably, whatever the signature itself contains.
+        """
+        req = CARD_SIGN_001
+        _require_signatures(agent_card)
+
+        first = canonicalize_agent_card(agent_card)
+        second = canonicalize_agent_card(agent_card)
+
+        valid = first == second
+        errors = (
+            []
+            if valid
+            else [f"canonicalization is not deterministic: {first!r} then {second!r}"]
+        )
+        _record(collector=compatibility_collector, req=req,
+                passed=valid, errors=errors)
+        assert valid, _fail_msg(req, errors[0])
+
+
+# ---------------------------------------------------------------------------
+# Signatures exclusion (CARD-SIGN-002)
+# ---------------------------------------------------------------------------
+
+
+@must
+@core
+class TestAgentCardSignaturesExclusion:
+    """CARD-SIGN-002: Signatures field excluded from signed content."""
+
+    def test_signing_payload_excludes_signatures(
+        self,
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+    ) -> None:
+        """CARD-SIGN-002: the signing payload drops the signatures field."""
+        req = CARD_SIGN_002
+        _require_signatures(agent_card)
+
+        payload = signing_payload(agent_card)
+        errors: list[str] = []
+        try:
+            assert_signatures_excluded(payload)
+        except CanonicalizationError as exc:
+            errors.append(str(exc))
+
+        valid = not errors
+        _record(collector=compatibility_collector, req=req,
+                passed=valid, errors=errors)
+        assert valid, _fail_msg(req, errors[0])
+
+    def test_canonical_bytes_omit_the_signatures_key(
+        self,
+        agent_card: dict[str, Any],
+        compatibility_collector: Any,
+    ) -> None:
+        """CARD-SIGN-002: the canonical signing bytes contain no signatures key.
+
+        Checked against the emitted bytes rather than the payload dict, because
+        the bytes are what a verifier actually re-derives and compares.
+        """
+        req = CARD_SIGN_002
+        _require_signatures(agent_card)
+
+        canonical = canonicalize_agent_card(agent_card)
+        marker = b'"' + SIGNATURES_FIELD.encode("utf-8") + b'":'
+
+        valid = marker not in canonical
+        errors = (
+            []
+            if valid
+            else [
+                f"canonical signing bytes still carry a {SIGNATURES_FIELD!r} key, "
+                f"which Section 8.4.1 rule 3 requires to be excluded"
+            ]
+        )
+        _record(collector=compatibility_collector, req=req,
+                passed=valid, errors=errors)
+        assert valid, _fail_msg(req, errors[0])

--- a/tests/unit/canonicalization/test_jcs_vectors.py
+++ b/tests/unit/canonicalization/test_jcs_vectors.py
@@ -1,0 +1,245 @@
+"""Agent Card canonicalization conformance tests driven by the a2a-jcs-v01 corpus.
+
+Requirements tested:
+    CARD-SIGN-001, CARD-SIGN-002
+
+Specification Section 8.4.1 states two rules that are pure functions of the
+Agent Card content, so both are decidable from a vector corpus without a
+running server:
+
+* rule 2, canonicalize the card per RFC 8785 -- CARD-SIGN-001, exercised by
+  the A3, A4, A5 and A6 groups;
+* rule 3, exclude the ``signatures`` field from the signed content --
+  CARD-SIGN-002, exercised by the A2 group.
+
+Each vector carries a disposition.  MUST-ACCEPT vectors pin the exact canonical
+bytes; MUST-REJECT vectors pin input a conformant canonicalizer has to refuse.
+The expected bytes were not written by hand -- every one is the agreed output
+of two independent RFC 8785 implementations, so this module measures the TCK's
+canonicalizer against outside work rather than against itself.
+
+A MUST-REJECT vector also asserts *where* the refusal happened.  Malformed
+input that never reaches the canonicalizer would let a canonicalizer that
+refuses nothing at all pass the whole reject half of the corpus.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tck.canonicalization.jcs import (
+    CanonicalizationError,
+    assert_signatures_excluded,
+    canonicalize,
+    canonicalize_agent_card,
+)
+from tck.requirements.registry import get_requirement_by_id
+from tck.requirements.tags import NOT_AUTOMATABLE
+
+
+CORPUS_ROOT = Path(__file__).parent.parent.parent.parent / "conformance-vectors" / "a2a-jcs-v01"
+MANIFEST_PATH = CORPUS_ROOT / "MANIFEST.json"
+
+#: Clause marking the a2a-specific rule, as opposed to a plain RFC 8785 clause.
+SIGNATURES_EXCLUSION_CLAUSE = "a2a-spec-8.4.1-rule-3"
+
+#: Which requirement each vector group discharges.  Every group in the corpus
+#: must appear here exactly once; ``test_every_group_is_claimed`` enforces it,
+#: so a group added upstream cannot land silently unattributed.
+GROUP_REQUIREMENTS = {
+    "a2-signatures-exclusion": "CARD-SIGN-002",
+    "a3-object-key-ordering": "CARD-SIGN-001",
+    "a4-string-serialization": "CARD-SIGN-001",
+    "a5-number-serialization": "CARD-SIGN-001",
+    "a6-arrays-nesting-literals": "CARD-SIGN-001",
+}
+
+#: Requirements this corpus discharges, and which therefore must not carry the
+#: ``not-automatable`` tag any more.
+COVERED_REQUIREMENTS = sorted(set(GROUP_REQUIREMENTS.values()))
+
+
+def _load_manifest() -> dict[str, Any]:
+    """Read the corpus manifest."""
+    manifest: dict[str, Any] = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return manifest
+
+
+def _load_vectors() -> list[dict[str, Any]]:
+    """Read every vector the manifest lists, in manifest order."""
+    manifest = _load_manifest()
+    vectors = []
+    for entry in manifest["vectors"]:
+        record = json.loads((CORPUS_ROOT / entry["path"]).read_text(encoding="utf-8"))
+        record["_path"] = entry["path"]
+        record["_group"] = entry["path"].split("/")[0]
+        vectors.append(record)
+    return vectors
+
+
+MANIFEST = _load_manifest()
+VECTORS = _load_vectors()
+
+ACCEPT_VECTORS = [v for v in VECTORS if v["disposition"] == "MUST-ACCEPT"]
+REJECT_VECTORS = [v for v in VECTORS if v["disposition"] == "MUST-REJECT"]
+
+
+def _canonicalize_vector_input(vector: dict[str, Any]) -> bytes:
+    """Canonicalize a MUST-ACCEPT vector's input the way its clause requires.
+
+    Args:
+        vector: The vector record.
+
+    Returns:
+        The canonical bytes produced by the TCK canonicalizer.
+    """
+    if vector["clause"] == SIGNATURES_EXCLUSION_CLAUSE:
+        return canonicalize_agent_card(vector["input"])
+    return canonicalize(vector["input"])
+
+
+class TestCorpusIntegrity:
+    """The corpus must be intact before any verdict drawn from it means anything."""
+
+    def test_manifest_lists_every_vector_file_on_disk(self) -> None:
+        """CARD-SIGN-001: the manifest accounts for every vector file present."""
+        on_disk = {
+            str(path.relative_to(CORPUS_ROOT))
+            for path in CORPUS_ROOT.rglob("*.json")
+            if path.name != "MANIFEST.json"
+        }
+        listed = {entry["path"] for entry in MANIFEST["vectors"]}
+        assert on_disk == listed, (
+            f"corpus and manifest disagree; only on disk: {sorted(on_disk - listed)}, "
+            f"only in manifest: {sorted(listed - on_disk)}"
+        )
+
+    def test_every_vector_matches_its_recorded_hash(self) -> None:
+        """CARD-SIGN-001: no vector file has been edited since the manifest was built."""
+        mismatched = []
+        for entry in MANIFEST["vectors"]:
+            digest = hashlib.sha256((CORPUS_ROOT / entry["path"]).read_bytes()).hexdigest()
+            if digest != entry["sha256"]:
+                mismatched.append(f"{entry['path']}: got {digest}, manifest says {entry['sha256']}")
+        assert not mismatched, "vector files altered since the manifest was built: " + "; ".join(mismatched)
+
+    def test_corpus_digest_reproduces(self) -> None:
+        """CARD-SIGN-001: the manifest body hashes to the digest it carries."""
+        body = _load_manifest()
+        stored = body.pop("corpusDigest")
+        recomputed = hashlib.sha256(
+            json.dumps(body, indent=2, sort_keys=False).encode("utf-8")
+        ).hexdigest()
+        assert recomputed == stored, f"manifest body hashes to {recomputed}, but it carries {stored}"
+
+    def test_counts_match_the_manifest(self) -> None:
+        """CARD-SIGN-001: the loaded vector counts match the manifest's own tally.
+
+        A truncated corpus otherwise passes every remaining vector and reports
+        a clean run, which is the one failure this whole module cannot survive.
+        """
+        counts = MANIFEST["counts"]
+        assert len(VECTORS) == counts["total"]
+        assert len(ACCEPT_VECTORS) == counts["accept"]
+        assert len(REJECT_VECTORS) == counts["reject"]
+
+
+class TestRequirementBinding:
+    """The corpus groups and the requirement registry must stay in agreement."""
+
+    def test_every_group_is_claimed(self) -> None:
+        """CARD-SIGN-001: every corpus group is attributed to a requirement."""
+        assert set(MANIFEST["groups"]) == set(GROUP_REQUIREMENTS)
+
+    @pytest.mark.parametrize("requirement_id", COVERED_REQUIREMENTS)
+    def test_covered_requirement_exists(self, requirement_id: str) -> None:
+        """CARD-SIGN-001: each covered requirement resolves in the registry."""
+        assert get_requirement_by_id(requirement_id).id == requirement_id
+
+    @pytest.mark.parametrize("requirement_id", COVERED_REQUIREMENTS)
+    def test_covered_requirement_is_not_tagged_not_automatable(self, requirement_id: str) -> None:
+        """CARD-SIGN-001: a requirement this corpus tests is no longer not-automatable.
+
+        This is the assertion that keeps the tag honest.  Restoring the
+        ``not-automatable`` tag on a requirement these vectors exercise turns
+        this test red rather than quietly re-hiding covered ground.
+        """
+        requirement = get_requirement_by_id(requirement_id)
+        assert NOT_AUTOMATABLE not in requirement.tags, (
+            f"{requirement_id} is exercised by the a2a-jcs-v01 corpus but is still "
+            f"tagged {NOT_AUTOMATABLE!r}"
+        )
+
+    @pytest.mark.parametrize("requirement_id", COVERED_REQUIREMENTS)
+    def test_covered_requirement_has_vectors(self, requirement_id: str) -> None:
+        """CARD-SIGN-001: each covered requirement actually has vectors behind it."""
+        groups = {group for group, req in GROUP_REQUIREMENTS.items() if req == requirement_id}
+        owned = [v for v in VECTORS if v["_group"] in groups]
+        assert owned, f"{requirement_id} claims groups {sorted(groups)} but no vector loaded from them"
+
+
+class TestMustAcceptVectors:
+    """Every MUST-ACCEPT vector pins exact canonical bytes."""
+
+    @pytest.mark.parametrize("vector", ACCEPT_VECTORS, ids=lambda v: v["id"])
+    def test_canonical_bytes_match(self, vector: dict[str, Any]) -> None:
+        """CARD-SIGN-001: canonicalization produces the corpus's expected bytes.
+
+        The A2 group vectors additionally cover CARD-SIGN-002, since their
+        expected bytes are only reachable once the ``signatures`` field has
+        been excluded.
+        """
+        expected = bytes.fromhex(vector["expected"]["canonical_utf8_hex"])
+        produced = _canonicalize_vector_input(vector)
+        assert produced == expected, (
+            f"{vector['id']} ({vector['clause']}): canonicalization produced "
+            f"{produced!r}, corpus expects {expected!r}. {vector['rationale']}"
+        )
+
+    @pytest.mark.parametrize("vector", ACCEPT_VECTORS, ids=lambda v: v["id"])
+    def test_canonical_bytes_are_valid_utf8(self, vector: dict[str, Any]) -> None:
+        """CARD-SIGN-001: canonical output decodes as UTF-8, as RFC 8785 requires."""
+        _canonicalize_vector_input(vector).decode("utf-8")
+
+
+class TestMustRejectVectors:
+    """Every MUST-REJECT vector pins input a conformant canonicalizer refuses."""
+
+    @pytest.mark.parametrize(
+        "vector",
+        [v for v in REJECT_VECTORS if v["clause"] != SIGNATURES_EXCLUSION_CLAUSE],
+        ids=lambda v: v["id"],
+    )
+    def test_canonicalizer_refuses(self, vector: dict[str, Any]) -> None:
+        """CARD-SIGN-001: the canonicalizer refuses input that has no canonical form.
+
+        The refusal has to come from the canonicalizer.  ``json.loads`` accepts
+        every one of these inputs -- lone surrogate escapes become real lone
+        surrogates and ``NaN``/``Infinity`` become real floats -- so a refusal
+        raised at parse time would mean the canonicalizer was never asked.
+        """
+        parsed = json.loads(vector["input_raw"])
+        with pytest.raises(CanonicalizationError):
+            canonicalize(parsed)
+
+    @pytest.mark.parametrize(
+        "vector",
+        [v for v in REJECT_VECTORS if v["clause"] == SIGNATURES_EXCLUSION_CLAUSE],
+        ids=lambda v: v["id"],
+    )
+    def test_signatures_field_is_detected_in_signing_input(self, vector: dict[str, Any]) -> None:
+        """CARD-SIGN-002: a signing payload still carrying ``signatures`` is refused.
+
+        These vectors present already-canonical bytes that were signed without
+        the exclusion applied.  The field's presence is the whole defect, and
+        it must be detected whether the array is populated or empty.
+        """
+        parsed = json.loads(vector["input_raw"])
+        with pytest.raises(CanonicalizationError):
+            assert_signatures_excluded(parsed)


### PR DESCRIPTION
The four CARD-SIGN requirements are tagged not-automatable at #227. A corpus of 57 language-neutral vectors here checks the underlying canonicalization rules.

a2a-python and a2a-js canonicalize the same Agent Card into different bytes, so a card signed by one fails verification under the other. Two independent RFC 8785 implementations, used as oracles throughout this corpus, adjudicated the difference and agree that a2a-js is conformant on every canonicalization axis this corpus tests, while a2a-python is not. The report, the reproduction steps, and the specification issue this corpus follows from are at A2A#2122, a2a-python#1174, and a2a-js#627.

This corpus does not resolve whether CARD-SIGN is automatable at all. It covers the first of three verification stages, Layer A: RFC 8785 canonicalization plus the a2a rule that excludes the signatures field before canonicalization runs, except for field presence, withheld because it tests whether REQUIRED fields with default values survive canonicalization: that question is still open at A2A#2122, and roughly a fifth of a full Layer A corpus turns on how it resolves.

47 accept and 10 reject, across five groups (signatures exclusion, key ordering, string serialization, number serialization, arrays/nesting/literals). No expected byte here came from hand calculation. A script builds every vector by running its input through both oracles (rfc8785 on PyPI for Python, gowebpki/jcs on GitHub for Go). It keeps an accept vector's result only when they agree, byte for byte. A reject vector requires the same double check to refuse the input, not just one; an earlier version of that script accepted either oracle's refusal alone, and the Go runner caught two vectors that shipped on Python-only agreement before that rule tightened.

Two reference runners are included, one per oracle: `python3 run_python.py` and a Go runner under oracle-go/. They run without touching either SDK. Each prints a pass/fail record with a coverage count and exits non-zero on any failure.
