### PR TITLE
fix(transport): follow redirects in harness HTTP clients

### DIFF
--- a/tck/transport/http_json_client.py
+++ b/tck/transport/http_json_client.py
@@ -114,6 +114,7 @@ class HttpJsonClient(BaseTransportClient):
             base_url=base_url,
             timeout=httpx.Timeout(5.0, read=30.0),
             headers={A2A_VERSION_HEADER: A2A_VERSION},
+            follow_redirects=True,
         )
 
     def close(self) -> None:

--- a/tck/transport/jsonrpc_client.py
+++ b/tck/transport/jsonrpc_client.py
@@ -82,6 +82,7 @@ class JsonRpcClient(BaseTransportClient):
             base_url=base_url,
             timeout=httpx.Timeout(5.0, read=30.0),
             headers={A2A_VERSION_HEADER: A2A_VERSION},
+            follow_redirects=True,
         )
 
     def close(self) -> None:


### PR DESCRIPTION
## Summary

The JSON-RPC and HTTP+JSON harness clients construct `httpx.Client` without following redirects (`follow_redirects` defaults to `False` in httpx), and both POST to `"/"` (i.e. `base_url + "/"`). When a SUT's framework redirects the trailing-slash variant — Starlette's default `redirect_slashes` answers it with a **307**, which preserves method and body — the harness treats the SUT as unreachable even though the endpoint answers at the canonical path.

This is the harness-side half of a2aproject/a2a-python#1165 (SDK client already follows redirects; the TCK's own clients didn't).

## Change

- `tck/transport/jsonrpc_client.py` — `follow_redirects=True` on the httpx client
- `tck/transport/http_json_client.py` — `follow_redirects=True` on the httpx client

Verification: `make lint` clean, `make unit-test` 253 passed.
