### PR TITLE
fix(sut): add Cache-Control and ETag headers to agent card endpoint

### DIFF
--- a/codegen/a2a-python/sut_agent.py.j2
+++ b/codegen/a2a-python/sut_agent.py.j2
@@ -4,6 +4,8 @@ Generated from Gherkin scenarios — do not edit by hand.
 """
 
 import asyncio
+import hashlib
+import json
 import logging
 import os
 
@@ -14,6 +16,8 @@ from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Value
 
 from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import Response
 
 import a2a.types.a2a_pb2_grpc as a2a_grpc
 
@@ -23,6 +27,7 @@ from a2a.server.agent_execution.context import RequestContext
 from a2a.server.events.event_queue import EventQueue
 from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.request_handlers.grpc_handler import GrpcHandler
+from a2a.server.request_handlers.response_helpers import agent_card_to_dict
 from a2a.server.routes import (
     create_agent_card_routes,
     create_jsonrpc_routes,
@@ -170,7 +175,30 @@ async def main() -> None:
         path_prefix=REST_URL,
     )
     # Agent card discovery (/.well-known/agent-card.json)
-    agent_card_routes = create_agent_card_routes(agent_card=agent_card)
+    # Compute caching headers once — the card is static for the process
+    # lifetime, so these values never change.
+    card_json = json.dumps(agent_card_to_dict(agent_card), sort_keys=True)
+    card_etag = '"' + hashlib.sha256(card_json.encode()).hexdigest()[:16] + '"'
+    card_cache_control = "public, max-age=3600"
+
+    _sdk_card_routes = create_agent_card_routes(agent_card=agent_card)
+    _orig_endpoint = _sdk_card_routes[0].endpoint
+
+    async def _agent_card_with_caching(request: Request) -> Response:
+        response = await _orig_endpoint(request)
+        response.headers["Cache-Control"] = card_cache_control
+        response.headers["ETag"] = card_etag
+        return response
+
+    from starlette.routing import Route
+
+    agent_card_routes = [
+        Route(
+            path=_sdk_card_routes[0].path,
+            endpoint=_agent_card_with_caching,
+            methods=["GET"],
+        )
+    ]
 
     # NOTE: agent_card_routes must precede rest_routes — REST exposes a
     # catch-all Mount('/{tenant}', ...) that would otherwise swallow

--- a/sut/a2a-python/sut_agent.py
+++ b/sut/a2a-python/sut_agent.py
@@ -4,6 +4,8 @@ Generated from Gherkin scenarios — do not edit by hand.
 """
 
 import asyncio
+import hashlib
+import json
 import logging
 import os
 
@@ -14,6 +16,8 @@ from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Value
 
 from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import Response
 
 import a2a.types.a2a_pb2_grpc as a2a_grpc
 
@@ -23,6 +27,7 @@ from a2a.server.agent_execution.context import RequestContext
 from a2a.server.events.event_queue import EventQueue
 from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.request_handlers.grpc_handler import GrpcHandler
+from a2a.server.request_handlers.response_helpers import agent_card_to_dict
 from a2a.server.routes import (
     create_agent_card_routes,
     create_jsonrpc_routes,
@@ -244,7 +249,30 @@ async def main() -> None:
         path_prefix=REST_URL,
     )
     # Agent card discovery (/.well-known/agent-card.json)
-    agent_card_routes = create_agent_card_routes(agent_card=agent_card)
+    # Compute caching headers once — the card is static for the process
+    # lifetime, so these values never change.
+    card_json = json.dumps(agent_card_to_dict(agent_card), sort_keys=True)
+    card_etag = '"' + hashlib.sha256(card_json.encode()).hexdigest()[:16] + '"'
+    card_cache_control = "public, max-age=3600"
+
+    _sdk_card_routes = create_agent_card_routes(agent_card=agent_card)
+    _orig_endpoint = _sdk_card_routes[0].endpoint
+
+    async def _agent_card_with_caching(request: Request) -> Response:
+        response = await _orig_endpoint(request)
+        response.headers["Cache-Control"] = card_cache_control
+        response.headers["ETag"] = card_etag
+        return response
+
+    from starlette.routing import Route
+
+    agent_card_routes = [
+        Route(
+            path=_sdk_card_routes[0].path,
+            endpoint=_agent_card_with_caching,
+            methods=["GET"],
+        )
+    ]
 
     # NOTE: agent_card_routes must precede rest_routes — REST exposes a
     # catch-all Mount('/{tenant}', ...) that would otherwise swallow


### PR DESCRIPTION
## Summary

Fixes https://github.com/a2aproject/a2a-tck/issues/234 — two TCK caching requirements fail against the reference SUT because `create_agent_card_routes()` in the SDK returns a bare `JSONResponse` with no caching headers:

| Requirement | Level | What it checks | Status |
|---|---|---|---|
| CARD-CACHE-001 | SHOULD | `Cache-Control` header present with `max-age` directive | **Fixed** |
| CARD-CACHE-002 | SHOULD | `ETag` header present | **Fixed** |
| CARD-CACHE-003 | MAY | `Last-Modified` header present | **Omitted** (see #236) |

The SDK's `create_agent_card_routes()` has no header-injection seam — it constructs a `JSONResponse` internally — but it returns a `list[Route]`. Because Starlette compiles `endpoint` → ASGI app at `Route.__init__` time, mutating `.endpoint` after construction is a no-op. Instead, the fix constructs a **new `Route`** with a wrapper endpoint that delegates to the SDK's original handler and injects the caching headers.

Headers are computed once at startup (the card is static for the process lifetime):
- `Cache-Control: public, max-age=3600`
- `ETag`: quoted truncated SHA-256 of the serialized card JSON

Patched **both** `codegen/a2a-python/sut_agent.py.j2` and the generated `sut/a2a-python/sut_agent.py` — regenerating from an unpatched template would silently revert the fix, so the template needed the same treatment as the fixture it produces (precedent set by #222).

### Notice on CARD-CACHE-003

`CARD-CACHE-003` is registered as `RequirementLevel.MAY` per RFC 2119 and decorated `@may`, but the test hard-`assert`s on header presence — causing a hard `FAIL` when omitted. Implementing `Last-Modified` in the SUT purely to satisfy this test would paper over a TCK classification bug where an optional MAY requirement is treated as mandatory. We have intentionally omitted `Last-Modified` here and reported the classification bug separately in https://github.com/a2aproject/a2a-tck/issues/236.

## Test plan

- [x] `ruff check sut/a2a-python/sut_agent.py`: all checks passed
- [x] `curl -sI localhost:9999/.well-known/agent-card.json` confirms `Cache-Control` and `ETag` headers are present:
  ```http
  HTTP/1.1 200 OK
  date: Fri, 04 Sep 2026 07:46:36 GMT
  server: uvicorn
  content-length: 735
  content-type: application/json
  cache-control: public, max-age=3600
  etag: "18d6e4259473fbec"
  ```
- [x] `uv run pytest tests/compatibility/agent_card/test_agent_card_caching.py --sut-host=http://localhost:9999`:
  - `TestAgentCardCacheControl::test_cache_control_present` PASSED
  - `TestAgentCardCacheControl::test_cache_control_has_max_age` PASSED
  - `TestAgentCardETag::test_etag_present` PASSED
  - `TestAgentCardLastModified::test_last_modified_present` FAILED (expected due to #236)