### PR TITLE
fix: skip absent optional Last-Modified header

### DIFF
--- a/tests/compatibility/agent_card/test_agent_card_caching.py
+++ b/tests/compatibility/agent_card/test_agent_card_caching.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import httpx
+import pytest
 
 from tck.requirements.registry import get_requirement_by_id
 from tests.compatibility.markers import core, may, should
@@ -46,6 +47,8 @@ def _record(
     req: RequirementSpec,
     passed: bool,
     errors: list[str] | None = None,
+    *,
+    skipped: bool = False,
 ) -> None:
     collector.record(
         requirement_id=req.id,
@@ -53,6 +56,7 @@ def _record(
         level=req.level.value,
         passed=passed,
         errors=errors or [],
+        skipped=skipped,
     )
 
 
@@ -112,8 +116,7 @@ class TestAgentCardCacheControl:
             []
             if valid
             else [
-                f"Cache-Control should include max-age directive, "
-                f"got: {cache_control!r}"
+                f"Cache-Control should include max-age directive, got: {cache_control!r}"
             ]
         )
         _record(collector=compatibility_collector, req=req,
@@ -174,14 +177,16 @@ class TestAgentCardLastModified:
         response = _fetch_agent_card(sut_host)
 
         last_modified = response.headers.get("last-modified")
-        valid = last_modified is not None
-        errors = (
-            []
-            if valid
-            else [
-                "Agent Card response may include a Last-Modified header"
-            ]
-        )
-        _record(collector=compatibility_collector, req=req,
-                passed=valid, errors=errors)
-        assert valid, _fail_msg(req, errors[0])
+        if last_modified is None:
+            _record(
+                collector=compatibility_collector,
+                req=req,
+                passed=False,
+                skipped=True,
+            )
+            pytest.skip(
+                "Agent Card response does not include the optional "
+                "Last-Modified header"
+            )
+
+        _record(collector=compatibility_collector, req=req, passed=True)

--- a/tests/unit/compatibility/test_agent_card_caching.py
+++ b/tests/unit/compatibility/test_agent_card_caching.py
@@ -1,0 +1,70 @@
+"""Regression tests for optional Agent Card caching requirements."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from tck.reporting.aggregator import CompatibilityAggregator
+from tck.reporting.collector import CompatibilityCollector
+from tests.compatibility.agent_card import test_agent_card_caching as caching_tests
+
+
+_SUT_URL = "http://sut.example"
+
+
+def _response(*, headers: dict[str, str]) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        headers=headers,
+        request=httpx.Request("GET", f"{_SUT_URL}/.well-known/agent-card.json"),
+    )
+
+
+class TestOptionalLastModified:
+    """CARD-CACHE-003 is optional when the header is absent."""
+
+    def test_missing_header_is_recorded_as_skipped(self) -> None:
+        """An absent optional header is represented as a skipped result."""
+        collector = CompatibilityCollector()
+
+        with patch.object(
+            caching_tests,
+            "_fetch_agent_card",
+            return_value=_response(headers={}),
+        ), pytest.raises(pytest.skip.Exception, match="optional"):
+            caching_tests.TestAgentCardLastModified().test_last_modified_present(
+                _SUT_URL,
+                collector,
+            )
+
+        results = collector.get_results()
+        assert len(results) == 1
+        assert results[0].requirement_id == "CARD-CACHE-003"
+        assert results[0].passed is False
+        assert results[0].skipped is True
+
+        report = CompatibilityAggregator(collector).aggregate()
+        assert report.per_requirement["CARD-CACHE-003"].status == "SKIPPED"
+
+    def test_present_header_is_recorded_as_passed(self) -> None:
+        """A present optional header remains a passing result."""
+        collector = CompatibilityCollector()
+
+        with patch.object(
+            caching_tests,
+            "_fetch_agent_card",
+            return_value=_response(headers={"last-modified": "Wed, 01 Jan 2025 00:00:00 GMT"}),
+        ):
+            caching_tests.TestAgentCardLastModified().test_last_modified_present(
+                _SUT_URL,
+                collector,
+            )
+
+        results = collector.get_results()
+        assert len(results) == 1
+        assert results[0].requirement_id == "CARD-CACHE-003"
+        assert results[0].passed is True
+        assert results[0].skipped is False


### PR DESCRIPTION
## Summary

CARD-CACHE-003 is an RFC 2119 MAY requirement, but the compatibility test recorded an omitted Last-Modified header as a normal failure and then asserted. That made a legitimate optional capability appear as FAIL in compatibility reports.

This change:

- records an omitted Last-Modified header as SKIPPED and calls pytest.skip();
- keeps the present-header path as PASS;
- adds regression coverage for both report states.

The SUT and the CARD-CACHE-001/CARD-CACHE-002 checks are unchanged.

Fixes #236

## Verification

- [x] make lint
- [x] make unit-test (278 passed)
