### PR TITLE
fix: align HTTP+JSON conformance checks

### DIFF
--- a/tck/requirements/binding_http_json.py
+++ b/tck/requirements/binding_http_json.py
@@ -58,13 +58,13 @@ BINDING_HTTP_JSON_REQUIREMENTS: list[RequirementSpec] = [
     RequirementSpec(
         id="HTTP_JSON-SVC-001",
         section="11.1",
-        title="Content-Type is application/json",
-        level=RequirementLevel.MUST,
+        title="Content-Type is application/a2a+json",
+        level=RequirementLevel.SHOULD,
         description=(
-            "HTTP+JSON/REST binding MUST use Content-Type application/json "
-            "for requests and responses."
+            "HTTP+JSON/REST requests and responses SHOULD use Content-Type "
+            "application/a2a+json."
         ),
-        expected_behavior="Content-Type header is application/json",
+        expected_behavior="Content-Type header is application/a2a+json",
         spec_url=f"{SPEC_BASE}111-protocol-requirements",
         tags=[REST, CONTENT_TYPE],
     ),
@@ -101,8 +101,7 @@ BINDING_HTTP_JSON_REQUIREMENTS: list[RequirementSpec] = [
         level=RequirementLevel.MUST,
         description=(
             "HTTP error responses MUST use the AIP-193 representation with "
-            "Content-Type application/json containing an error object with "
-            "code, status, message, and details fields."
+            "an error object containing code, status, message, and details fields."
         ),
         expected_behavior="Error responses conform to AIP-193 structure",
         spec_url=f"{SPEC_BASE}116-error-handling",

--- a/tck/requirements/core_operations.py
+++ b/tck/requirements/core_operations.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from tck.requirements.base import (
     CANCEL_TASK_BINDING,
+    CONTENT_TYPE_NOT_SUPPORTED_ERROR,
     EXTENSION_SUPPORT_REQUIRED_ERROR,
     GET_TASK_BINDING,
     LIST_TASKS_BINDING,
@@ -108,6 +109,7 @@ CORE_OPERATIONS_REQUIREMENTS: list[RequirementSpec] = [
         binding=SEND_MESSAGE_BINDING,
         proto_request_type="SendMessageRequest",
         expected_behavior="ContentTypeNotSupportedError returned",
+        expected_error=CONTENT_TYPE_NOT_SUPPORTED_ERROR,
         spec_url=f"{SPEC_BASE}311-send-message",
         tags=[CORE, SEND_MESSAGE, ERROR],
         sample_input={

--- a/tck/validators/http_json/media_type.py
+++ b/tck/validators/http_json/media_type.py
@@ -1,0 +1,12 @@
+"""Media-type helpers for the HTTP+JSON binding."""
+
+from __future__ import annotations
+
+
+A2A_JSON_MEDIA_TYPE = "application/a2a+json"
+
+
+def is_a2a_json_media_type(content_type: str) -> bool:
+    """Return whether a Content-Type value uses the A2A JSON media type."""
+    media_type = content_type.split(";", 1)[0].strip().lower()
+    return media_type == A2A_JSON_MEDIA_TYPE

--- a/tests/compatibility/core_operations/test_error_handling.py
+++ b/tests/compatibility/core_operations/test_error_handling.py
@@ -774,14 +774,14 @@ class TestRestErrorStructure:
         raw = response.raw_response
         if not isinstance(raw, httpx.Response):
             pytest.skip("Error response is not an HTTP response object")
-        ct = raw.headers.get("content-type", "")
         errors = []
-        if "application/json" not in ct:
+        try:
+            body = raw.json()
+        except ValueError:
             errors.append(
-                f"Error Content-Type must be application/json, got: {ct!r}"
+                "AIP-193 error response body must contain valid JSON"
             )
         else:
-            body = raw.json()
             if "error" not in body:
                 errors.append(
                     "AIP-193 error response must include 'error' object"

--- a/tests/compatibility/core_operations/test_transport_behavior.py
+++ b/tests/compatibility/core_operations/test_transport_behavior.py
@@ -22,8 +22,9 @@ import pytest
 from tck.requirements.base import tck_id
 from tck.requirements.registry import get_requirement_by_id
 from tck.transport._helpers import A2A_VERSION, A2A_VERSION_HEADER
+from tck.validators.http_json.media_type import is_a2a_json_media_type
 from tests.compatibility._test_helpers import assert_and_record, get_client, record
-from tests.compatibility.markers import grpc, http_json, jsonrpc, must, streaming
+from tests.compatibility.markers import grpc, http_json, jsonrpc, must, should, streaming
 
 
 if TYPE_CHECKING:
@@ -231,10 +232,10 @@ class TestJsonRpcStreaming:
 # ---------------------------------------------------------------------------
 
 
-@must
+@should
 @http_json
 class TestRestFormat:
-    """HTTP_JSON-SVC-001: Content-Type and response schema validation."""
+    """HTTP_JSON-SVC-001: Prefer the A2A JSON media type."""
 
     @pytest.fixture()
     def rest_response(
@@ -251,31 +252,25 @@ class TestRestFormat:
         rest_response: TransportResponse,
         compatibility_collector: Any,
     ) -> None:
-        """HTTP_JSON-SVC-001: Content-Type must be application/json."""
+        """HTTP_JSON-SVC-001: Content-Type should be application/a2a+json."""
         req = HTTP_JSON_SVC_001
         transport = "http_json"
         ct = rest_response.headers.get("content-type", "")
-        errors = []
-        if "application/json" not in ct:
-            errors.append(f"Expected Content-Type application/json, got: {ct!r}")
-        assert_and_record(compatibility_collector, req, transport, errors)
-
-    def test_response_validates_against_schema(
-        self,
-        rest_response: TransportResponse,
-        validators: dict[str, Any],
-        compatibility_collector: Any,
-    ) -> None:
-        """HTTP_JSON-SVC-001: Response payload conforms to SendMessageResponse schema."""
-        req = HTTP_JSON_SVC_001
-        transport = "http_json"
-        if not rest_response.success:
-            pytest.skip(f"SendMessage failed: {rest_response.error}")
-        validator = validators[transport]
-        result = validator.validate(
-            rest_response.raw_response, "Send Message Response"
+        valid = is_a2a_json_media_type(ct)
+        errors = (
+            []
+            if valid
+            else [f"Expected Content-Type application/a2a+json, got: {ct!r}"]
         )
-        assert_and_record(compatibility_collector, req, transport, result.errors)
+        record(
+            collector=compatibility_collector,
+            req=req,
+            transport=transport,
+            passed=valid,
+            errors=errors,
+        )
+        if errors:
+            pytest.xfail(errors[0])
 
 
 @must

--- a/tests/compatibility/http_json/test_problem_details.py
+++ b/tests/compatibility/http_json/test_problem_details.py
@@ -81,40 +81,6 @@ def _get_error_body(response: Any) -> dict[str, Any] | None:
 class TestAIP193ErrorFormat:
     """HTTP_JSON-ERR-001: Error responses use AIP-193 format."""
 
-    def test_error_content_type(
-        self,
-        transport_clients: dict[str, BaseTransportClient],
-        compatibility_collector: Any,
-    ) -> None:
-        """Error response has Content-Type: application/json."""
-        req = HTTP_JSON_ERR_001
-        client = get_client(transport_clients, TRANSPORT, compatibility_collector=compatibility_collector, req=req)
-        response = _get_error_response(client)
-
-        headers = response.headers or {}
-        ct = ""
-        for key, value in headers.items():
-            if key.lower() == "content-type":
-                ct = value
-                break
-
-        valid = "application/json" in ct.lower()
-        errors = (
-            []
-            if valid
-            else [
-                f"Error Content-Type must be application/json, got: {ct!r}"
-            ]
-        )
-        record(
-            collector=compatibility_collector,
-            req=req,
-            transport=TRANSPORT,
-            passed=valid,
-            errors=errors,
-        )
-        assert valid, fail_msg(req, TRANSPORT, errors[0])
-
     def test_error_object_present(
         self,
         transport_clients: dict[str, BaseTransportClient],

--- a/tests/unit/requirements/test_expected_error_declared.py
+++ b/tests/unit/requirements/test_expected_error_declared.py
@@ -15,7 +15,9 @@ import re
 from tck.requirements.registry import ALL_REQUIREMENTS
 
 
-_MUST_RETURN_ERROR = re.compile(r"MUST return (?:a |an )?(\w*Error)\b")
+_MUST_RETURN_ERROR = re.compile(
+    r"MUST (?:return|result in) (?:a |an )?(\w*Error)\b"
+)
 
 
 def test_named_error_requirements_declare_expected_error() -> None:

--- a/tests/unit/validators/http_json/test_media_type.py
+++ b/tests/unit/validators/http_json/test_media_type.py
@@ -1,0 +1,38 @@
+"""Tests for HTTP+JSON response media-type validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from tck.requirements.base import RequirementLevel
+from tck.requirements.registry import get_requirement_by_id
+from tck.validators.http_json.media_type import is_a2a_json_media_type
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    [
+        "application/a2a+json",
+        "application/a2a+json; charset=utf-8",
+        "Application/A2A+JSON",
+    ],
+)
+def test_is_a2a_json_media_type_accepts_a2a_json(content_type: str) -> None:
+    """The preferred A2A v1.0 media type is matched case-insensitively."""
+    assert is_a2a_json_media_type(content_type)
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    ["", "application/json", "text/plain", "application/xml", "application/problem+json"],
+)
+def test_is_a2a_json_media_type_rejects_other_types(content_type: str) -> None:
+    """Other JSON types do not satisfy the A2A-specific preference."""
+    assert not is_a2a_json_media_type(content_type)
+
+
+def test_http_json_content_type_requirement_is_should() -> None:
+    """Section 11.1 expresses the A2A media type as a SHOULD, not a MUST."""
+    requirement = get_requirement_by_id("HTTP_JSON-SVC-001")
+    assert requirement.level is RequirementLevel.SHOULD
+    assert "application/a2a+json" in requirement.expected_behavior


### PR DESCRIPTION
## Summary
- model the v1.0 HTTP+JSON media type as the Section 11.1 SHOULD for application/a2a+json
- keep AIP-193 MUST checks focused on the required error object instead of rejecting the A2A media type
- declare ContentTypeNotSupportedError for CORE-SEND-003 so the generic runner validates the exact protocol error
- extend the requirement invariant and add focused media-type regression coverage

This complements #232, which updates the v1.0.1 error-code mappings.

## Verification
- make lint
- make unit-test (285 passed)