### PR TITLE
feat: support custom message parts fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Compatibility reports are generated in the `reports/` directory after every run.
 | `--sut-host URL` | **(required)** Base URL of the System Under Test |
 | `--transport LIST` | Comma-separated transport filter (e.g. `grpc`, `jsonrpc,http_json`). Default: all transports declared in the agent card |
 | `--level LEVEL` | Run only requirements at a specific RFC 2119 level: `must`, `should`, or `may` |
+| `--message-parts-file PATH` | Replace generic message parts in parametrized, non-error requirement scenarios with a non-empty JSON array from `PATH` |
 | `-v, --verbose` | Verbose pytest output |
 | `--verbose-log` | Verbose output with log capture (`-v -s --log-cli-level=INFO`) |
 | `-- pytest_args...` | Additional arguments passed through to pytest (e.g. `-- -x --pdb`) |
@@ -58,6 +59,9 @@ Compatibility reports are generated in the `reports/` directory after every run.
 
 # Run gRPC and JSON-RPC transports with verbose output
 ./run_tck.py --sut-host http://localhost:9999 --transport grpc,jsonrpc -v
+
+# Exercise a structured-data agent with domain-valid input parts
+./run_tck.py --sut-host http://localhost:9999 --message-parts-file fixtures/parts.json
 
 # Pass extra pytest flags
 ./run_tck.py --sut-host http://localhost:9999 -- -x --pdb

--- a/run_tck.py
+++ b/run_tck.py
@@ -51,6 +51,9 @@ def build_pytest_command(args: argparse.Namespace) -> list[str]:
         m_expr = LEVEL_FILTERS[args.level]
         cmd.extend(["-m", m_expr])
 
+    if args.message_parts_file:
+        cmd.append(f"--message-parts-file={args.message_parts_file}")
+
     # Verbosity
     if args.verbose_log:
         cmd.extend(["-v", "-s", "--log-cli-level=INFO"])
@@ -119,6 +122,14 @@ Requirement levels:
         choices=["must", "should", "may"],
         default=None,
         help="Run only requirements at this RFC 2119 level",
+    )
+    parser.add_argument(
+        "--message-parts-file",
+        default=None,
+        help=(
+            "JSON file containing an A2A Message.parts array for generic, "
+            "non-error requirement scenarios"
+        ),
     )
     parser.add_argument(
         "-v", "--verbose",

--- a/tck/message_parts.py
+++ b/tck/message_parts.py
@@ -1,0 +1,29 @@
+"""Load operator-supplied Message.parts for generic requirement scenarios."""
+
+from __future__ import annotations
+
+import json
+
+from pathlib import Path
+from typing import Any
+
+
+class MessagePartsError(ValueError):
+    """Raised when a message-parts fixture cannot be loaded safely."""
+
+
+def load_message_parts(path: str | Path) -> list[dict[str, Any]]:
+    """Load and validate a non-empty JSON array of A2A Part objects."""
+    fixture_path = Path(path)
+    try:
+        payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise MessagePartsError(
+            f"Unable to load message parts from {fixture_path}: {exc}"
+        ) from exc
+
+    if not isinstance(payload, list) or not payload:
+        raise MessagePartsError("Message parts fixture must be a non-empty JSON array")
+    if not all(isinstance(part, dict) for part in payload):
+        raise MessagePartsError("Every message part must be a JSON object")
+    return payload

--- a/tck/transport/dispatch.py
+++ b/tck/transport/dispatch.py
@@ -113,6 +113,8 @@ OPERATION_DESCRIPTORS: dict[OperationType, _OperationDescriptor] = {
 def execute_operation(
     client: BaseTransportClient,
     requirement: RequirementSpec,
+    *,
+    message_parts: list[dict[str, Any]] | None = None,
 ) -> TransportResponse | StreamingResponse:
     """Execute the operation associated with a requirement on the given client.
 
@@ -124,6 +126,8 @@ def execute_operation(
     Args:
         client: The transport client to use.
         requirement: The requirement whose operation to execute.
+        message_parts: Optional replacement for the generic sample message's
+            parts. Deliberate error cases always retain their original parts.
 
     Returns:
         The transport response.
@@ -155,6 +159,11 @@ def execute_operation(
         )
 
     sample = copy.deepcopy(requirement.sample_input)
+
+    if message_parts is not None and requirement.expected_error is None:
+        message = sample.get("message")
+        if isinstance(message, dict):
+            message["parts"] = copy.deepcopy(message_parts)
 
     # Append the transport name to message IDs so that each transport gets
     # its own task/message on the SUT, preventing cross-transport state

--- a/tests/compatibility/conftest.py
+++ b/tests/compatibility/conftest.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 import pytest
 
+from tck.message_parts import MessagePartsError, load_message_parts
 from tck.reporting.collector import CompatibilityCollector
 from tck.transport.grpc_client import GrpcClient
 from tck.transport.http_json_client import HttpJsonClient
@@ -76,6 +77,15 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "(default: localhost)."
         ),
     )
+    group.addoption(
+        "--message-parts-file",
+        dest="message_parts_file",
+        default=None,
+        help=(
+            "JSON file containing a non-empty A2A Message.parts array used by "
+            "generic, non-error requirement scenarios."
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -87,6 +97,18 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 def sut_host(request: pytest.FixtureRequest) -> str:
     """Return the SUT hostname."""
     return request.config.getoption("--sut-host")
+
+
+@pytest.fixture(scope="session")
+def message_parts(request: pytest.FixtureRequest) -> list[dict[str, Any]] | None:
+    """Load optional operator-supplied parts before any SUT operation runs."""
+    path = request.config.getoption("--message-parts-file")
+    if path is None:
+        return None
+    try:
+        return load_message_parts(path)
+    except MessagePartsError as exc:
+        raise pytest.UsageError(str(exc)) from exc
 
 
 @pytest.fixture(scope="session")

--- a/tests/compatibility/core_operations/test_requirements.py
+++ b/tests/compatibility/core_operations/test_requirements.py
@@ -162,6 +162,7 @@ def test_must_requirement(
     validators: dict[str, Any],
     compatibility_collector: Any,
     agent_card: dict[str, Any],
+    message_parts: list[dict[str, Any]] | None,
 ) -> None:
     """Verify a MUST-level requirement — hard failure on validation error."""
     _skip_if_capability_not_declared(requirement, transport, agent_card, compatibility_collector)
@@ -176,7 +177,11 @@ def test_must_requirement(
         )
         pytest.skip(f"Transport {transport!r} not configured (filtered by --transport)")
 
-    response = execute_operation(client, requirement)
+    response = execute_operation(
+        client,
+        requirement,
+        message_parts=message_parts,
+    )
     errors = _validate_response(response, transport, requirement, validators)
 
     compatibility_collector.record(
@@ -210,6 +215,7 @@ def test_should_requirement(
     validators: dict[str, Any],
     compatibility_collector: Any,
     agent_card: dict[str, Any],
+    message_parts: list[dict[str, Any]] | None,
 ) -> None:
     """Verify a SHOULD-level requirement — xfail on validation error."""
     _skip_if_capability_not_declared(requirement, transport, agent_card, compatibility_collector)
@@ -224,7 +230,11 @@ def test_should_requirement(
         )
         pytest.skip(f"Transport {transport!r} not configured (filtered by --transport)")
 
-    response = execute_operation(client, requirement)
+    response = execute_operation(
+        client,
+        requirement,
+        message_parts=message_parts,
+    )
     errors = _validate_response(response, transport, requirement, validators)
 
     compatibility_collector.record(
@@ -259,6 +269,7 @@ def test_may_requirement(
     validators: dict[str, Any],
     compatibility_collector: Any,
     agent_card: dict[str, Any],
+    message_parts: list[dict[str, Any]] | None,
 ) -> None:
     """Verify a MAY-level requirement — skip if capability not declared."""
     _skip_if_capability_not_declared(requirement, transport, agent_card, compatibility_collector)
@@ -273,7 +284,11 @@ def test_may_requirement(
         )
         pytest.skip(f"Transport {transport!r} not configured (filtered by --transport)")
 
-    response = execute_operation(client, requirement)
+    response = execute_operation(
+        client,
+        requirement,
+        message_parts=message_parts,
+    )
     errors = _validate_response(response, transport, requirement, validators)
 
     compatibility_collector.record(

--- a/tests/unit/test_message_parts.py
+++ b/tests/unit/test_message_parts.py
@@ -1,0 +1,50 @@
+"""Tests for operator-supplied A2A message parts."""
+
+from __future__ import annotations
+
+import json
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tck.message_parts import MessagePartsError, load_message_parts
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_load_message_parts_reads_non_empty_object_array(tmp_path: Path) -> None:
+    """A fixture file is the exact A2A Message.parts array to send."""
+    path = tmp_path / "parts.json"
+    expected = [{"data": {"decision": "approve"}, "mediaType": "application/json"}]
+    path.write_text(json.dumps(expected), encoding="utf-8")
+
+    assert load_message_parts(path) == expected
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        [],
+        ["not-an-object"],
+    ],
+)
+def test_load_message_parts_rejects_invalid_shapes(tmp_path: Path, payload: object) -> None:
+    """Invalid fixture shapes fail before any SUT request is made."""
+    path = tmp_path / "parts.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(MessagePartsError):
+        load_message_parts(path)
+
+
+def test_load_message_parts_rejects_invalid_json(tmp_path: Path) -> None:
+    """Malformed JSON produces a configuration error."""
+    path = tmp_path / "parts.json"
+    path.write_text("not-json", encoding="utf-8")
+
+    with pytest.raises(MessagePartsError):
+        load_message_parts(path)

--- a/tests/unit/test_run_tck.py
+++ b/tests/unit/test_run_tck.py
@@ -1,0 +1,24 @@
+"""Tests for the public TCK runner CLI."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+
+from run_tck import build_pytest_command
+
+
+def test_build_pytest_command_forwards_message_parts_file() -> None:
+    """The public runner forwards the custom fixture path to pytest."""
+    args = Namespace(
+        sut_host="http://localhost:9999",
+        transport="http_json",
+        level="must",
+        verbose=False,
+        verbose_log=False,
+        message_parts_file="fixtures/parts.json",
+        pytest_args=[],
+    )
+
+    command = build_pytest_command(args)
+
+    assert "--message-parts-file=fixtures/parts.json" in command

--- a/tests/unit/transport/test_dispatch.py
+++ b/tests/unit/transport/test_dispatch.py
@@ -1,0 +1,86 @@
+"""Tests for requirement operation dispatch."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tck.requirements.base import (
+    CONTENT_TYPE_NOT_SUPPORTED_ERROR,
+    OperationType,
+    RequirementLevel,
+    RequirementSpec,
+)
+from tck.transport.dispatch import execute_operation
+
+
+class _Client:
+    transport = "http_json"
+
+    def __init__(self) -> None:
+        self.message: dict[str, Any] | None = None
+
+    def send_message(self, message: dict[str, Any]) -> object:
+        self.message = message
+        return object()
+
+
+def _requirement() -> RequirementSpec:
+    return RequirementSpec(
+        id="TEST-SEND-001",
+        section="test",
+        title="test",
+        level=RequirementLevel.MUST,
+        description="test requirement",
+        operation=OperationType.SEND_MESSAGE,
+        sample_input={
+            "message": {
+                "role": "ROLE_USER",
+                "messageId": "original-id",
+                "contextId": "original-context",
+                "parts": [{"text": "generic fixture"}],
+            }
+        },
+    )
+
+
+def test_execute_operation_overrides_only_message_parts() -> None:
+    """Custom parts preserve scenario identity and all other request fields."""
+    client = _Client()
+    custom_parts = [{"data": {"invoiceId": "INV-1"}}]
+
+    execute_operation(client, _requirement(), message_parts=custom_parts)
+
+    assert client.message == {
+        "role": "ROLE_USER",
+        "messageId": "original-id-http_json",
+        "contextId": "original-context",
+        "parts": custom_parts,
+    }
+
+
+def test_execute_operation_does_not_mutate_custom_parts() -> None:
+    """Dispatch deep-copies operator input before passing it to a client."""
+    client = _Client()
+    custom_parts = [{"data": {"invoiceId": "INV-1"}}]
+
+    execute_operation(client, _requirement(), message_parts=custom_parts)
+    assert client.message is not None
+    client.message["parts"][0]["data"]["invoiceId"] = "changed"
+
+    assert custom_parts == [{"data": {"invoiceId": "INV-1"}}]
+
+
+def test_execute_operation_preserves_deliberate_error_parts() -> None:
+    """Operator input cannot erase the condition an error scenario exercises."""
+    client = _Client()
+    requirement = _requirement()
+    requirement.expected_error = CONTENT_TYPE_NOT_SUPPORTED_ERROR
+
+    execute_operation(
+        client,
+        requirement,
+        message_parts=[{"data": {"invoiceId": "INV-1"}}],
+    )
+
+    assert client.message is not None
+    assert client.message["parts"] == [{"text": "generic fixture"}]


### PR DESCRIPTION
## Summary
- add --message-parts-file to the public runner and pytest configuration
- load a non-empty JSON array of A2A Part objects for generic parametrized scenarios
- preserve scenario IDs, contexts, configuration, and metadata
- never override deliberate error scenarios that declare expected_error
- document the structured-data agent workflow

This provides a concrete input seam related to #229 without changing requirement applicability or weakening conformance checks.

## Verification
- make lint
- make unit-test (285 passed)
- localhost HTTP+JSON smoke: CORE-SEND-001 passed with a structured data-part fixture